### PR TITLE
Right aligns "Use" and "Additional help topics"

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -17,6 +17,7 @@
 package cobra
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"strconv"
@@ -66,11 +67,17 @@ func Eq(a interface{}, b interface{}) bool {
 	return false
 }
 
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
 // tmpl executes the given template text on data, writing the result to w.
 func tmpl(w io.Writer, text string, data interface{}) error {
 	t := template.New("top")
 	t.Funcs(template.FuncMap{
 		"trim": strings.TrimSpace,
+		"rpad": rpad,
 		"gt":   Gt,
 		"eq":   Eq,
 	})


### PR DESCRIPTION
If a command was especially long (> 15 char), the right alignment wouldn't work properly. Example:

```
Available Commands:
  views [<db>...]           :: Print all views
  refreshviews [<db>...] [--verbose] :: Refresh all views
```

Same issue with the _Additional help topics_ (> 11 char)

```
Additional help topics:
  hugolong version :: Prints the version
  hugolong server :: Print basic server info
```

This commit attempts to properly align regardless of length:

```
Available Commands:
  views [<db>...]                    :: Print all views
  refreshviews [<db>...] [--verbose] :: Refresh all views

Additional help topics:
  hugolong version      :: Prints the version
  hugolong server       :: Print basic server info
```
