### PR TITLE
Enable prefix matching for commands

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -47,6 +47,12 @@ var cmdRootNoRun = &Command{
 	Long:  "The root description for help",
 }
 
+var cmdRootSameName = &Command{
+	Use:   "print",
+	Short: "Root with the same name as a subcommand",
+	Long:  "The root description for help",
+}
+
 var cmdRootWithRun = &Command{
 	Use:   "cobra-test",
 	Short: "The root can run it's own function",
@@ -65,6 +71,7 @@ func flagInit() {
 	cmdPrint.ResetFlags()
 	cmdTimes.ResetFlags()
 	cmdRootNoRun.ResetFlags()
+	cmdRootSameName.ResetFlags()
 	cmdRootWithRun.ResetFlags()
 	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
 	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
@@ -82,12 +89,21 @@ func commandInit() {
 	cmdPrint.ResetCommands()
 	cmdTimes.ResetCommands()
 	cmdRootNoRun.ResetCommands()
+	cmdRootSameName.ResetCommands()
 	cmdRootWithRun.ResetCommands()
 }
 
 func initialize() *Command {
 	tt, tp, te = nil, nil, nil
 	var c = cmdRootNoRun
+	flagInit()
+	commandInit()
+	return c
+}
+
+func initializeWithSameName() *Command {
+	tt, tp, te = nil, nil, nil
+	var c = cmdRootSameName
 	flagInit()
 	commandInit()
 	return c
@@ -152,6 +168,40 @@ func TestChildCommandPrefix(t *testing.T) {
 		t.Error("Wrong command called")
 	}
 	if strings.Join(tt, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestChildSameName(t *testing.T) {
+	c := initializeWithSameName()
+	c.AddCommand(cmdPrint, cmdEcho)
+	c.SetArgs(strings.Split("print one two", " "))
+	c.Execute()
+
+	if te != nil || tt != nil {
+		t.Error("Wrong command called")
+	}
+	if tp == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tp, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestChildSameNamePrefix(t *testing.T) {
+	c := initializeWithSameName()
+	c.AddCommand(cmdPrint, cmdEcho)
+	c.SetArgs(strings.Split("pr one two", " "))
+	c.Execute()
+
+	if te != nil || tt != nil {
+		t.Error("Wrong command called")
+	}
+	if tp == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tp, " ") != "one two" {
 		t.Error("Command didn't parse correctly")
 	}
 }

--- a/command.go
+++ b/command.go
@@ -260,7 +260,7 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 	commandFound, a := innerfind(c, arrs)
 
 	// if commander returned and not appropriately matched return nil & error
-	if commandFound.Name() == c.Name() && commandFound.Name() != arrs[0] {
+	if commandFound.Name() == c.Name() && !strings.HasPrefix(commandFound.Name(), arrs[0]) {
 		return nil, a, fmt.Errorf("unknown command %q\nRun 'help' for usage.\n", a[0])
 	}
 


### PR DESCRIPTION
With these commits, it's possible to match a command based on a non-ambiguous prefix of its name, in addition to the full name. For example, in hugo, you could invoke the `server` command with just `hugo s`, since none of the other commands start with an `s`.

I added a basic test for this functionality as well (and of course I checked that it works with `go test`), but let me know if you'd like to see some other behaviors tested; I'll see what I can do.
