### PR TITLE
changed help flag setup to use PersistentFlags so -h will be supported

### DIFF
--- a/command.go
+++ b/command.go
@@ -637,7 +637,7 @@ func (c *Command) Flags() *flag.FlagSet {
 			c.flagErrorBuf = new(bytes.Buffer)
 		}
 		c.flags.SetOutput(c.flagErrorBuf)
-		c.flags.BoolVar(&c.helpFlagVal, "help", false, "help for "+c.Name())
+		c.PersistentFlags().BoolVarP(&c.helpFlagVal, "help", "h", false, "help for "+c.Name())
 	}
 	return c.flags
 }


### PR DESCRIPTION
This addresses #22.

The short flag for `help` wasn't being displayed in the 'Available Flags' list. This was dues to setting the `help` flag using `BoolVar()` instead of `PersistentFlags().BoolVarP()`. This changes that so the `-h` flag will be recognized and displayed in the 'Available Flags' list for `help`.

Example  output after changes:

```
$ ./spf13template asdkjflakjdf

Usage: 
  spf13template [flags]
  spf13template [command]

Available Commands: 
  hello [phrase to use]     Returns 'Hello ' with what you entered after the command
  version                   Print spf13template version
  help [command]            Help about any command

 Available Flags:
  -h, --help=false: help for spf13template
  -l, --log=false: Enable/disable logging
  -f, --logfile="application.log": Logfile location. Enables logging when this flag is passed with a value
  -t, --loglevel="info": Max logging level to ouput. Enables logging when this flag is passed with a value
      --lower=false: lowercase output
  -s, --stdoutlevel="warn": Max logging level for stdout output

Use "spf13template help [command]" for more information about that command.
Error: unknown command "asdkjflakjdf"
Run 'help' for usage.

spf13template: invalid command [`asdkjflakjdf`]
Run 'spf13template help' for usage
CRITICAL: 2014/09/12 unknown command "asdkjflakjdf"
Run 'help' for usage.

```
