### PR TITLE
Replace prefix matching with aliases

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -26,9 +26,10 @@ var cmdPrint = &Command{
 }
 
 var cmdEcho = &Command{
-	Use:   "echo [string to echo]",
-	Short: "Echo anything to the screen",
-	Long:  `an utterly useless command for testing.`,
+	Use:     "echo [string to echo]",
+	Aliases: []string{"say"},
+	Short:   "Echo anything to the screen",
+	Long:    `an utterly useless command for testing.`,
 	Run: func(cmd *Command, args []string) {
 		te = args
 	},
@@ -38,7 +39,9 @@ var cmdTimes = &Command{
 	Use:   "times [# times] [string to echo]",
 	Short: "Echo anything to the screen more times",
 	Long:  `an slightly useless command for testing.`,
-	Run:   timesRunner,
+	Run: func(cmd *Command, args []string) {
+		tt = args
+	},
 }
 
 var cmdRootNoRun = &Command{
@@ -60,10 +63,6 @@ var cmdRootWithRun = &Command{
 	Run: func(cmd *Command, args []string) {
 		rootcalled = true
 	},
-}
-
-func timesRunner(cmd *Command, args []string) {
-	tt = args
 }
 
 func flagInit() {
@@ -195,8 +194,8 @@ func TestChildCommand(t *testing.T) {
 	}
 }
 
-func TestChildCommandPrefix(t *testing.T) {
-	noRRSetupTest("ech tim one two")
+func TestCommandAlias(t *testing.T) {
+	noRRSetupTest("say times one two")
 
 	if te != nil || tp != nil {
 		t.Error("Wrong command called")
@@ -213,23 +212,6 @@ func TestChildSameName(t *testing.T) {
 	c := initializeWithSameName()
 	c.AddCommand(cmdPrint, cmdEcho)
 	c.SetArgs(strings.Split("print one two", " "))
-	c.Execute()
-
-	if te != nil || tt != nil {
-		t.Error("Wrong command called")
-	}
-	if tp == nil {
-		t.Error("Wrong command called")
-	}
-	if strings.Join(tp, " ") != "one two" {
-		t.Error("Command didn't parse correctly")
-	}
-}
-
-func TestChildSameNamePrefix(t *testing.T) {
-	c := initializeWithSameName()
-	c.AddCommand(cmdPrint, cmdEcho)
-	c.SetArgs(strings.Split("pr one two", " "))
 	c.Execute()
 
 	if te != nil || tt != nil {


### PR DESCRIPTION
Implicit, automatic prefix matching can be a dangerous thing to automatically enable in CLI tools. Since it is generally considered best practice to maintain backwards compatibility with CLI tools, prefix matching means that the CLI tool author needs to be aware that every time they introduce a command, they in fact are introducing len(cmd) commands into the CLI which they would then be expected to maintain compatibility for, which is difficult and surprising. A better solution is to allow explicit aliases. This PR implements command aliases and removes prefix matching.

Note that I am not at all against the _option_ of enabling prefix matching, but I could not find a way to expose that in a way that would be simple and consistent. IOW, the simplest way would be to add MatchPrefixes as a boolean on a command, but this creates a lot of questions: Does that apply to the command itself or its subcommands? Is it recursive? Does it apply to everything at that level or just to that one command? Or just its subcommands? Given how confusing this gets I thought it best to drop prefix matching altogether.

I understand that this breaks backwards compatibility but I think this is important enough in order to prevent authors from inadvertently breaking their tools in the future.
