### PR TITLE
When no subcommands are registered, omit command help output

### DIFF
--- a/command.go
+++ b/command.go
@@ -203,9 +203,9 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{.Flags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
 Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
-{{end}}
+{{end}}{{ if .HasSubCommands }}
 Use "{{.Root.Name}} help [command]" for more information about that command.
-`
+{{end}}`
 	}
 }
 
@@ -465,6 +465,10 @@ func (c *Command) Execute() (err error) {
 
 func (c *Command) initHelp() {
 	if c.helpCommand == nil {
+		if !c.HasSubCommands() {
+			return
+		}
+
 		c.helpCommand = &Command{
 			Use:   "help [command]",
 			Short: "Help about any command",
@@ -479,6 +483,7 @@ func (c *Command) initHelp() {
 // Used for testing
 func (c *Command) ResetCommands() {
 	c.commands = nil
+	c.helpCommand = nil
 }
 
 func (c *Command) Commands() []*Command {


### PR DESCRIPTION
For a single root command with a Run method, the help output still
contains 'help [command]' as a subcommand (because Help is always
added). Since the only subcommand would be 'help', the help is better
off omitted.

This change allows a command to be used both as a subcommand
or a root command without having to define a custom help that elides
the help command when no subcommands are added.  Instead, the default
help command is only added when subcommands are present.

Example:

```
$ mycommand --help
longdescription

Usage:
  mycommand

Available Flags:
  --help=false
  ....

# no help message displayed at end
```

If you specify a custom help command, your help command will be used
regardless of subcommand presence.
