### PR TITLE
In execute(), check if command is Runnable()

### DIFF
--- a/command.go
+++ b/command.go
@@ -357,8 +357,9 @@ func (c *Command) execute(a []string) (err error) {
 	if err != nil {
 		return err
 	} else {
-		// If help is called, regardless of other flags, we print that
-		if c.helpFlagVal {
+		// If help is called, regardless of other flags, we print that.
+		// Print help also if c.Run is nil.
+		if c.helpFlagVal || !c.Runnable() {
 			c.Help()
 			return nil
 		}


### PR DESCRIPTION
A corner case exists where c.Runnable() is not checked
before c.Run() is called, thus a nil c.Run is executed
leading to "panic: runtime error: invalid memory address
or nil pointer dereference".

This patch adds an extra c.Runnable() check in execute()
to catch that corner case.

Fixes #37.
