### PR TITLE
Minor English correction

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -461,7 +461,7 @@ func TestRootHelp(t *testing.T) {
 	x := fullSetupTest("--help")
 
 	checkResultContains(t, x, "Available Commands:")
-	checkResultContains(t, x, "for more information about that command")
+	checkResultContains(t, x, "for more information about a command")
 
 	if strings.Contains(x.Output, "unknown flag: --help") {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
@@ -470,7 +470,7 @@ func TestRootHelp(t *testing.T) {
 	x = fullSetupTest("echo --help")
 
 	checkResultContains(t, x, "Available Commands:")
-	checkResultContains(t, x, "for more information about that command")
+	checkResultContains(t, x, "for more information about a command")
 
 	if strings.Contains(x.Output, "unknown flag: --help") {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
@@ -482,7 +482,7 @@ func TestRootNoCommandHelp(t *testing.T) {
 	x := rootOnlySetupTest("--help")
 
 	checkResultOmits(t, x, "Available Commands:")
-	checkResultOmits(t, x, "for more information about that command")
+	checkResultOmits(t, x, "for more information about a command")
 
 	if strings.Contains(x.Output, "unknown flag: --help") {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
@@ -491,7 +491,7 @@ func TestRootNoCommandHelp(t *testing.T) {
 	x = rootOnlySetupTest("echo --help")
 
 	checkResultOmits(t, x, "Available Commands:")
-	checkResultOmits(t, x, "for more information about that command")
+	checkResultOmits(t, x, "for more information about a command")
 
 	if strings.Contains(x.Output, "unknown flag: --help") {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)

--- a/command.go
+++ b/command.go
@@ -205,7 +205,7 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
 {{end}}{{ if .HasSubCommands }}
-Use "{{.Root.Name}} help [command]" for more information about that command.
+Use "{{.Root.Name}} help [command]" for more information about a command.
 {{end}}`
 	}
 }


### PR DESCRIPTION
"more information about that command" felt odd so verified the usage with `git help` and `go help`