### PR TITLE
Several 'help' fixes

### DIFF
--- a/command.go
+++ b/command.go
@@ -371,9 +371,6 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 				// only accept a single prefix match - multiple matches would be ambiguous
 				if len(matches) == 1 {
 					return innerfind(matches[0], argsMinusX(args, argsWOflags[0]))
-				} else if len(matches) == 0 && len(args) > 0 && args[0] == "help" {
-					// special case help command
-					return innerfind(c, argsMinusX(append(args, "--help"), argsWOflags[0]))
 				}
 			}
 		}


### PR DESCRIPTION
Need to make sure `--help` is registered before calling `pflags` which tries to handle the help flag itself.

`Find()` must be aware of the special command `help` and consider the context it's being called in order to display the help for the proper command (instead of root). 
