### PR TITLE
help displays command names instead of usage in Available Commands

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -467,7 +467,15 @@ func TestRootHelp(t *testing.T) {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
 	}
 
+	if strings.Contains(x.Output, cmdEcho.Use) {
+		t.Errorf("--help shouldn't display subcommand's usage, Got: \n %s", x.Output)
+	}
+
 	x = fullSetupTest("echo --help")
+
+	if strings.Contains(x.Output, cmdTimes.Use) {
+		t.Errorf("--help shouldn't display subsubcommand's usage, Got: \n %s", x.Output)
+	}
 
 	checkResultContains(t, x, "Available Commands:")
 	checkResultContains(t, x, "for more information about that command")

--- a/command.go
+++ b/command.go
@@ -54,6 +54,7 @@ type Command struct {
 	// max lengths of commands' string lengths for use in padding
 	commandsMaxUseLen         int
 	commandsMaxCommandPathLen int
+	commandsMaxNameLen        int
 
 	flagErrorBuf *bytes.Buffer
 	cmdErrorBuf  *bytes.Buffer
@@ -181,6 +182,16 @@ func (c *Command) CommandPathPadding() int {
 	}
 }
 
+var minNamePadding int = 11
+
+func (c *Command) NamePadding() int {
+	if c.parent == nil || minNamePadding > c.parent.commandsMaxNameLen {
+		return minNamePadding
+	} else {
+		return c.parent.commandsMaxNameLen
+	}
+}
+
 func (c *Command) UsageTemplate() string {
 	if c.usageTemplate != "" {
 		return c.usageTemplate
@@ -198,7 +209,7 @@ Aliases:
   {{.NameAndAliases}}{{end}}
 {{ if .HasSubCommands}}
 Available Commands: {{range .Commands}}{{if .Runnable}}
-  {{rpad .Use .UsagePadding }} {{.Short}}{{end}}{{end}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 {{end}}
 {{ if .HasFlags}} Available Flags:
 {{.Flags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
@@ -526,6 +537,10 @@ func (c *Command) AddCommand(cmds ...*Command) {
 		commandPathLen := len(x.CommandPath())
 		if commandPathLen > c.commandsMaxCommandPathLen {
 			c.commandsMaxCommandPathLen = commandPathLen
+		}
+		nameLen := len(x.Name())
+		if nameLen > c.commandsMaxNameLen {
+			c.commandsMaxNameLen = nameLen
 		}
 		c.commands = append(c.commands, x)
 	}


### PR DESCRIPTION
When a command has a subcommand whose usage is very log, it's difficult to look the help. After this change, the help displays just command names instead of usage.

For example, there are 2 subcommands bar and baz, and bar has a very long usage. The command's help displays like following:
```
Usage of foo:

Usage: 
  foo --very-very-long-use [flags]
  foo [command]

Available Commands: 
  bar [--foo-blah-blah-blah] [--bar-blah-blah-blah]  [--baz-blah-blah-blah] [--qux-blah-blah-blah] [--quux-blah-blah-blah] [--foobarbaz-blah-blah-blah] Description of bar
  baz --baz                                                                                                                                             Description of baz
  help [command]                                                                                                                                        Help about any command

 Available Flags:
  -h, --help=false: help for foo

Use "foo help [command]" for more information about that command.
```
After this change, the help displays like following:
```
Usage of foo:

Usage: 
  foo --very-very-long-use [flags]
  foo [command]

Available Commands: 
  bar         Description of bar
  baz         Description of baz
  help        Help about any command

 Available Flags:
  -h, --help=false: help for foo

Use "foo help [command]" for more information about that command.
```

`help bar` still displays detailed usage as before. 

Or as an alternative option, `ShortUse` variable to display Available Commands.