### PR TITLE
Explicitly support local flags overwriting persistent/inherited flags

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -11,10 +11,13 @@ var _ = fmt.Println
 
 var tp, te, tt, t1 []string
 var flagb1, flagb2, flagb3, flagbr bool
-var flags1, flags2, flags3 string
+var flags1, flags2a, flags2b, flags3 string
 var flagi1, flagi2, flagi3, flagir int
 var globalFlag1 bool
 var flagEcho, rootcalled bool
+
+const strtwoParentHelp = "help message for parent flag strtwo"
+const strtwoChildHelp = "help message for child flag strtwo"
 
 var cmdPrint = &Command{
 	Use:   "print [string to print]",
@@ -72,11 +75,12 @@ func flagInit() {
 	cmdRootNoRun.ResetFlags()
 	cmdRootSameName.ResetFlags()
 	cmdRootWithRun.ResetFlags()
+	cmdRootNoRun.PersistentFlags().StringVarP(&flags2a, "strtwo", "t", "two", strtwoParentHelp)
 	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
 	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
 	cmdPrint.Flags().IntVarP(&flagi3, "intthree", "i", 345, "help message for flag intthree")
 	cmdEcho.PersistentFlags().StringVarP(&flags1, "strone", "s", "one", "help message for flag strone")
-	cmdTimes.PersistentFlags().StringVarP(&flags2, "strtwo", "t", "two", "help message for flag strtwo")
+	cmdTimes.PersistentFlags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
 	cmdPrint.PersistentFlags().StringVarP(&flags3, "strthree", "s", "three", "help message for flag strthree")
 	cmdEcho.Flags().BoolVarP(&flagb1, "boolone", "b", true, "help message for flag boolone")
 	cmdTimes.Flags().BoolVarP(&flagb2, "booltwo", "c", false, "help message for flag booltwo")
@@ -381,6 +385,17 @@ func TestChildCommandFlags(t *testing.T) {
 		t.Errorf("Wrong error message displayed, \n %s", r.Output)
 	}
 
+	// Testing with persistent flag overwritten by child
+	noRRSetupTest("echo times --strtwo=child one two")
+
+	if flags2b != "child" {
+		t.Errorf("flag value should be child, %s given", flags2b)
+	}
+
+	if flags2a != "two" {
+		t.Errorf("unset flag should have default value, expecting two, given %s", flags2a)
+	}
+
 	// Testing flag with invalid input
 	r = noRRSetupTest("echo -i10E")
 
@@ -437,6 +452,13 @@ func TestHelpCommand(t *testing.T) {
 	checkResultContains(t, r, cmdTimes.Long)
 }
 
+func TestChildCommandHelp(t *testing.T) {
+	c := noRRSetupTest("print --help")
+	checkResultContains(t, c, strtwoParentHelp)
+	r := noRRSetupTest("echo times --help")
+	checkResultContains(t, r, strtwoChildHelp)
+}
+
 func TestRunnableRootCommand(t *testing.T) {
 	fullSetupTest("")
 
@@ -484,6 +506,26 @@ func TestRootHelp(t *testing.T) {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
 	}
 
+}
+
+func TestFlagAccess(t *testing.T) {
+	initialize()
+
+	local := cmdTimes.LocalFlags()
+	inherited := cmdTimes.InheritedFlags()
+
+	for _, f := range []string{"inttwo", "strtwo", "booltwo"} {
+		if local.Lookup(f) == nil {
+			t.Errorf("LocalFlags expected to contain %s, Got: nil", f)
+		}
+	}
+	if inherited.Lookup("strone") == nil {
+		t.Errorf("InheritedFlags expected to contain strone, Got: nil")
+	}
+	if inherited.Lookup("strtwo") != nil {
+		t.Errorf("InheritedFlags shouldn not contain overwritten flag strtwo")
+
+	}
 }
 
 func TestRootNoCommandHelp(t *testing.T) {


### PR DESCRIPTION
The current (and arguably, desired) behavior when a Command specifies a flag that has the same name as a persistent/inherited flag, is that the local definition takes precedence. This change makes that behavior explicitly supported and updates the various `*Flags` functions accordingly:

* `LocalFlags`: now returns only the set of flags and persistent flags attached to the Command itself.
* `InheritedFlags`: now returns only the set of persistent flags inherited from the Command's parent(s), excluding any that are overwritten by a local flag.
* `NonInheritedFlags`: changed to an alias of `LocalFlags`.
* `AllPersistentFlags`: removed; it returned the set of all persistent flags attached to either the Command or its parent(s), which isn't very useful.

Default `UsageTemplate` updated to use `LocalFlags` and `InheritedFlags` for `Flags: ...`, `Global Flags: ...` output respectively.