### PR TITLE
fix missing newline in help output 

### DIFF
--- a/command.go
+++ b/command.go
@@ -212,9 +212,11 @@ Usage: {{if .Runnable}}
 Aliases:
   {{.NameAndAliases}}
 {{end}}{{if .HasExample}}
+
 Examples:
 {{ .Example }}
 {{end}}{{ if .HasSubCommands}}
+
 Available Commands: {{range .Commands}}{{if .Runnable}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 {{end}}


### PR DESCRIPTION
The current help output for a simple program with commands looks like this:

```bash
Usage:
  iq [command]
Available Commands:
  command1
  command2
  ...
```

In the README and past versions there is a newline between the `Usage` and `Available Commands` section;  this behavior was changed (I suspect accidentally) in bf480fe628.  It also seems like there would be a missing newline for `Examples` sections, which this also adds back.