### PR TITLE
Help uses Short message if Long is not available

### DIFF
--- a/command.go
+++ b/command.go
@@ -248,7 +248,7 @@ func (c *Command) HelpTemplate() string {
 	if c.HasParent() {
 		return c.parent.HelpTemplate()
 	} else {
-		return `{{.Long | trim}}
+		return `{{with or .Long .Short }}{{. | trim}}{{end}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
 `
 	}


### PR DESCRIPTION
I'm a little green on templates but I think that should do it.