### PR TITLE
Make flags declared outside spf13.pflag persistent flags on the parent

### DIFF
--- a/command.go
+++ b/command.go
@@ -942,6 +942,13 @@ func (c *Command) mergePersistentFlags() {
 		c.PersistentFlags().VisitAll(addtolocal)
 	}
 	rmerge = func(x *Command) {
+		if ! x.HasParent() {
+			flag.CommandLine.VisitAll(func(f *flag.Flag) {
+				if x.PersistentFlags().Lookup(f.Name) == nil {
+					x.PersistentFlags().AddFlag(f)
+				}
+			})
+		}
 		if x.HasPersistentFlags() {
 			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
 				if c.Flags().Lookup(f.Name) == nil {


### PR DESCRIPTION
Some projects pick up flags from other projects they include.  A great
example would be projects that use glog and thus get all of those flags.
Kubernetes, for example, merges those flags manually into its commands.
    
This was reported in https://github.com/spf13/cobra/issues/44
    
What this patch does is merge those flags into the PersistentFlags on
the highest parent.  This allows kubernetes to stop having to merge
things themselves...
