### PR TITLE
fix usage template conditional

### DIFF
--- a/command.go
+++ b/command.go
@@ -232,8 +232,8 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasInheritedFlags}}Global Flags:
 {{.InheritedFlags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
-Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
+Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}
 {{end}}{{ if .HasSubCommands }}
 Use "{{.Root.Name}} help [command]" for more information about a command.
 {{end}}`


### PR DESCRIPTION
I wrote https://github.com/eparis/readable-golang-template which
converts golang templates into something structured around the
conditionals.  Obviously you can't just USE the output, but you can SEE
the problems.  In this case the output shows something like:
```
{{if .HasParent}}
        {{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
                Additional help topics:
                {{if gt .Commands 0 }}
                        {{range .Commands}}
                                {{if not .Runnable}}
                                        {{rpad .CommandPath .CommandPathPadding}} {{.Short}}
                                {{end}}
                        {{end}}
                {{end}}
                {{if gt .Parent.Commands 1 }}
                        {{range .Parent.Commands}}
                                {{if .Runnable}}
                                        {{if not (eq .Name $cmd.Name) }}
                                        {{end}}
                                        {{rpad .CommandPath .CommandPathPadding}} {{.Short}}
                                {{end}}
                        {{end}}
                {{end}}
        {{end}}
{{end}}
```
We have a completely unused "{{if not (eq .Name $cmd.Name) }}"

Move the {{end}} after the {{rpad...}}