### PR TITLE
Additional help topics

### DIFF
--- a/command.go
+++ b/command.go
@@ -232,8 +232,8 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasInheritedFlags}}Global Flags:
 {{.InheritedFlags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
-Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
+Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}
 {{end}}{{ if .HasSubCommands }}
 Use "{{.Root.Name}} help [command]" for more information about a command.
 {{end}}`

--- a/command.go
+++ b/command.go
@@ -223,7 +223,7 @@ Aliases:
 
 Examples:
 {{ .Example }}
-{{end}}{{ if .HasSubCommands}}
+{{end}}{{ if .HasRunnableSubCommands}}
 
 Available Commands: {{range .Commands}}{{if .Runnable}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
@@ -231,9 +231,9 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{ if .HasLocalFlags}}Flags:
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasInheritedFlags}}Global Flags:
-{{.InheritedFlags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
-Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}
+{{.InheritedFlags.FlagUsages}}{{end}}{{if or (.HasHelpSubCommands) (.HasRunnableSiblings)}}
+Additional help topics: {{if .HasHelpSubCommands}}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasRunnableSiblings }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
 {{end}}{{ if .HasSubCommands }}
 Use "{{.Root.Name}} help [command]" for more information about a command.
 {{end}}`
@@ -785,6 +785,37 @@ func (c *Command) Runnable() bool {
 // Determine if the command has children commands
 func (c *Command) HasSubCommands() bool {
 	return len(c.commands) > 0
+}
+
+func (c *Command) HasRunnableSiblings() bool {
+	if !c.HasParent() {
+		return false
+	}
+	for _, sub := range c.parent.commands {
+		if sub.Runnable() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Command) HasHelpSubCommands() bool {
+	for _, sub := range c.commands {
+		if !sub.Runnable() {
+			return true
+		}
+	}
+	return false
+}
+
+// Determine if the command has runnable children commands
+func (c *Command) HasRunnableSubCommands() bool {
+	for _, sub := range c.commands {
+		if sub.Runnable() {
+			return true
+		}
+	}
+	return false
 }
 
 // Determine if the command is a child command


### PR DESCRIPTION
This gets us to https://github.com/spf13/cobra/pull/41

There are some minor differences.....

#41 used  {{rpad .Use .UsagePadding }} {{.Short}}
We use:   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}

#41 did not print sibling runnable command information
we do print sibling runnable command information

I'm happy to alter either...