### PR TITLE
Prevent incorrect flag message on bad subcommand parse

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -417,6 +417,33 @@ func TestTrailingCommandFlags(t *testing.T) {
 	}
 }
 
+func TestInvalidSubCommandFlags(t *testing.T) {
+	sub := &Command{
+		Use:   "sub",
+		Short: "Invalid sub command test sub",
+		Run: func(cmd *Command, args []string) {
+		},
+	}
+	sub.Flags().String("images", "", "images flag")
+
+	root := &Command{
+		Use:   "root",
+		Short: "Invalid sub command test root",
+		Run: func(cmd *Command, args []string) {
+		},
+	}
+	root.AddCommand(sub)
+
+	result := simpleTester(root, "sub --images=foo --master=bar")
+
+	checkResultContains(t, result, "unknown flag: --master")
+
+	if strings.Contains(result.Output, "unknown flag: --images") {
+		t.Errorf("invalid --master flag shouldn't fail on images, Got: \n %s", result.Output)
+	}
+
+}
+
 func TestPersistentFlags(t *testing.T) {
 	fullSetupTest("echo -s something -p more here")
 


### PR DESCRIPTION
If an invalid argument is passed to a subcommand, but the root command is runnable, the flags are reparsed and the wrong error message appears to a user.

For instance 
```
openshift start node --images=foo --master=bar
```
If `openshift start node` has a `--images` flag, but does not have a `--master` flag, the parse will fail (good).  But after that failure, if openshift is runnable and doesn't have any flags, then the message displayed to the user `unknown flag: --images` which is incorrect.


I've added a test to demonstrate.