### PR TITLE
Fix redundant error for unknown root commands

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -554,6 +554,15 @@ func TestRootNoCommandHelp(t *testing.T) {
 	}
 }
 
+func TestRootUnknownCommand(t *testing.T) {
+	r := noRRSetupTest("bogus")
+	s := "Error: unknown command \"bogus\"\nRun 'cobra-test help' for usage.\n"
+
+	if r.Output != s {
+		t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", s, r.Output)
+	}
+}
+
 func TestFlagsBeforeCommand(t *testing.T) {
 	// short without space
 	x := fullSetupTest("-i10 echo")

--- a/command.go
+++ b/command.go
@@ -378,7 +378,7 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 	// if commander returned and the first argument (if it exists) doesn't
 	// match the command name, return nil & error
 	if commandFound.Name() == c.Name() && len(arrs[0]) > 0 && commandFound.Name() != arrs[0] {
-		return nil, a, fmt.Errorf("unknown command %q\nRun 'help' for usage.\n", a[0])
+		return nil, a, fmt.Errorf("unknown command %q", a[0])
 	}
 
 	return commandFound, a, nil
@@ -539,10 +539,10 @@ func (c *Command) Execute() (err error) {
 	if err != nil {
 		if err == flag.ErrHelp {
 			c.Help()
+
 		} else {
 			c.Println("Error:", err.Error())
-			c.Printf("%v: invalid command %#q\n", c.Root().Name(), os.Args[1:])
-			c.Printf("Run '%v help' for usage\n", c.Root().Name())
+			c.Printf("Run '%v help' for usage.\n", c.Root().Name())
 		}
 	}
 


### PR DESCRIPTION
When an unknown command is called on a non-runnable root, the error message stated twice, in slightly different ways:

```
~/code/src/github.com/adammck/cobra-test$ ./cobra-test whatever
Error: unknown command "whatever"
Run 'help' for usage.

cobra-test: invalid command [`whatever`]
Run 'cobra-test help' for usage
```

Neither of these are especially clear, so I merged them. The result is:

```
~/code/src/github.com/adammck/cobra-test$ ./cobra-test whatever
Error: unknown command "whatever"                        
Run 'cobra-test help' for usage
```

I believe this solves #29, and obsoletes #34.