### PR TITLE
quiet down to go test for markdown generation

### DIFF
--- a/md_docs_test.go
+++ b/md_docs_test.go
@@ -59,6 +59,4 @@ func TestGenMdDoc(t *testing.T) {
 	if !strings.Contains(found, expected) {
 		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
 	}
-
-	fmt.Fprintf(os.Stdout, "%s\n", found)
 }


### PR DESCRIPTION
We were printing the markdown, don't ask me why.