### PR TITLE
Fixed Persistent-Run function propagation

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -869,3 +869,20 @@ func TestPreRun(t *testing.T) {
 		t.Error("Wrong *Pre functions called!")
 	}
 }
+
+// Check if cmdEchoSub gets PersistentPreRun from rootCmd even if is added last
+func TestPeristentPreRunPropagation(t *testing.T) {
+	rootCmd := initialize()
+
+	// First add the cmdEchoSub to cmdPrint
+	cmdPrint.AddCommand(cmdEchoSub)
+	// Now add cmdPrint to rootCmd
+	rootCmd.AddCommand(cmdPrint)
+
+	rootCmd.SetArgs(strings.Split("print echosub lala", " "))
+	rootCmd.Execute()
+
+	if rootPersPre == nil || len(rootPersPre) == 0 || rootPersPre[0] != "lala" {
+		t.Error("RootCmd PersistentPreRun not called but should have been")
+	}
+}

--- a/command.go
+++ b/command.go
@@ -463,8 +463,11 @@ func (c *Command) execute(a []string) (err error) {
 	c.preRun()
 	argWoFlags := c.Flags().Args()
 
-	if c.PersistentPreRun != nil {
-		c.PersistentPreRun(c, argWoFlags)
+	for p := c; p != nil; p = p.Parent() {
+		if p.PersistentPreRun != nil {
+			p.PersistentPreRun(c, argWoFlags)
+			break
+		}
 	}
 	if c.PreRun != nil {
 		c.PreRun(c, argWoFlags)
@@ -475,8 +478,11 @@ func (c *Command) execute(a []string) (err error) {
 	if c.PostRun != nil {
 		c.PostRun(c, argWoFlags)
 	}
-	if c.PersistentPostRun != nil {
-		c.PersistentPostRun(c, argWoFlags)
+	for p := c; p != nil; p = p.Parent() {
+		if p.PersistentPostRun != nil {
+			p.PersistentPostRun(c, argWoFlags)
+			break
+		}
 	}
 
 	return nil
@@ -601,14 +607,6 @@ func (c *Command) AddCommand(cmds ...*Command) {
 			c.commandsMaxNameLen = nameLen
 		}
 		c.commands = append(c.commands, x)
-
-		// Pass on peristent pre/post functions to children
-		if x.PersistentPreRun == nil {
-			x.PersistentPreRun = c.PersistentPreRun
-		}
-		if x.PersistentPostRun == nil {
-			x.PersistentPostRun = c.PersistentPostRun
-		}
 	}
 }
 


### PR DESCRIPTION
This is a fix for the following use case:

If I create a command A that is going to be a subcommand on B and then I add B as a subcommand to C (with this particular order on AddCommand), then A is not going to inherit PersistentPostRun and PersistenPreRun functions.