### PR TITLE
  Add flags_completion as without @ format to _filedir

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -214,7 +214,7 @@ func writeFlagHandler(name string, annotations map[string][]string, out *bytes.B
 			fmt.Fprintf(out, "    flags_with_completion+=(%q)\n", name)
 
 			ext := strings.Join(value, "|")
-			ext = "_filedir '@(" + ext + ")'"
+			ext = "_filedir " + ext
 			fmt.Fprintf(out, "    flags_completion+=(%q)\n", ext)
 		}
 	}


### PR DESCRIPTION
In my environment, [filename extentionsf for flags](https://github.com/spf13/cobra/blob/master/bash_completions.md#specify-valid-filename-extentions-for-flags-that-take-a-filename) doesn't work.

It seems that the format `_filedir @(json|yaml|yml)` doesn't work, but `_filedir 'json|yaml|yml'` works. I tested [1] with replacing as below.

~~~
#${flags_completion[${index}]}
_filedir "json|yaml|yml"
~~~

It may be my environment issue, but I hope if you could check it.

[1] https://github.com/GoogleCloudPlatform/kubernetes/blob/72f9e940a863878569571623669ef4a4add18cc2/contrib/completions/bash/kubectl#L54