### PR TITLE
make filename extension handling a bash function

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -93,6 +93,13 @@ __handle_reply()
     fi
 }
 
+# The arguments should be in the form "ext1|ext2|extn"
+__handle_filename_extension_flag()
+{
+    local ext="$1"
+    _filedir "@(${ext})"
+}
+
 __handle_flag()
 {
     __debug "${FUNCNAME}: c is $c words[c] is ${words[c]}"
@@ -213,7 +220,7 @@ func writeFlagHandler(name string, annotations map[string][]string, out *bytes.B
 			fmt.Fprintf(out, "    flags_with_completion+=(%q)\n", name)
 
 			ext := strings.Join(value, "|")
-			ext = "_filedir '@(" + ext + ")'"
+			ext = "__handle_filename_extension_flag " + ext
 			fmt.Fprintf(out, "    flags_completion+=(%q)\n", ext)
 		}
 	}

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -76,7 +76,7 @@ func TestBashCompletions(t *testing.T) {
 	// check for required nouns
 	check(t, str, `must_have_one_noun+=("pods")`)
 	// check for filename extention flags
-	check(t, str, `flags_completion+=("_filedir '@(json|yaml|yml)'")`)
+	check(t, str, `flags_completion+=("__handle_filename_extension_flag json|yaml|yml")`)
 
 	checkOmit(t, str, cmdDeprecated.Name())
 }


### PR DESCRIPTION
We were trying to call a bash function with bash stuff like @ () from a
variable.  Stop that.  Just call a function with an arg from a variable
instead of trying to pass around the bash.

Should fix https://github.com/spf13/cobra/pull/103