### PR TITLE
Add Global Normalization Function

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 var _ = fmt.Println
@@ -884,5 +887,30 @@ func TestPeristentPreRunPropagation(t *testing.T) {
 
 	if rootPersPre == nil || len(rootPersPre) == 0 || rootPersPre[0] != "lala" {
 		t.Error("RootCmd PersistentPreRun not called but should have been")
+	}
+}
+
+func TestGlobalNormFuncPropagation(t *testing.T) {
+	normFunc := func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName(name)
+	}
+
+	rootCmd := initialize()
+	rootCmd.SetGlobalNormalizationFunc(normFunc)
+	if reflect.ValueOf(normFunc) != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()) {
+		t.Error("rootCmd seems to have a wrong normalization function")
+	}
+
+	// First add the cmdEchoSub to cmdPrint
+	cmdPrint.AddCommand(cmdEchoSub)
+	if cmdPrint.GlobalNormalizationFunc() != nil && cmdEchoSub.GlobalNormalizationFunc() != nil {
+		t.Error("cmdPrint and cmdEchoSub should had no normalization functions")
+	}
+
+	// Now add cmdPrint to rootCmd
+	rootCmd.AddCommand(cmdPrint)
+	if reflect.ValueOf(cmdPrint.GlobalNormalizationFunc()).Pointer() != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()).Pointer() ||
+		reflect.ValueOf(cmdEchoSub.GlobalNormalizationFunc()).Pointer() != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()).Pointer() {
+		t.Error("cmdPrint and cmdEchoSub should had the normalization function of rootCmd")
 	}
 }

--- a/command.go
+++ b/command.go
@@ -93,6 +93,8 @@ type Command struct {
 	helpFunc      func(*Command, []string) // Help can be defined by application
 	helpCommand   *Command                 // The help command
 	helpFlagVal   bool
+	// The global normalization function that we can use on every pFlag set and children commands
+	globNormFunc func(f *flag.FlagSet, name string) flag.NormalizedName
 }
 
 // os.Args[1:] by default, if desired, can be overridden
@@ -149,6 +151,19 @@ func (c *Command) SetHelpCommand(cmd *Command) {
 // Can be defined by Application
 func (c *Command) SetHelpTemplate(s string) {
 	c.helpTemplate = s
+}
+
+// SetGlobalNormalizationFunc sets a normalization function to all flag sets and also to child commands.
+// The user should not have a cyclic dependency on commands.
+func (c *Command) SetGlobalNormalizationFunc(n func(f *flag.FlagSet, name string) flag.NormalizedName) {
+	c.Flags().SetNormalizeFunc(n)
+	c.PersistentFlags().SetNormalizeFunc(n)
+	c.LocalFlags().SetNormalizeFunc(n)
+	c.globNormFunc = n
+
+	for _, command := range c.commands {
+		command.SetGlobalNormalizationFunc(n)
+	}
 }
 
 func (c *Command) UsageFunc() (f func(*Command) error) {
@@ -606,6 +621,10 @@ func (c *Command) AddCommand(cmds ...*Command) {
 		if nameLen > c.commandsMaxNameLen {
 			c.commandsMaxNameLen = nameLen
 		}
+		// If glabal normalization function exists, update all children
+		if c.globNormFunc != nil {
+			x.SetGlobalNormalizationFunc(c.globNormFunc)
+		}
 		c.commands = append(c.commands, x)
 	}
 }
@@ -828,6 +847,11 @@ func (c *Command) HasRunnableSubCommands() bool {
 // Determine if the command is a child command
 func (c *Command) HasParent() bool {
 	return c.parent != nil
+}
+
+// GlobalNormalizationFunc returns the global normalization function or nil if doesn't exists
+func (c *Command) GlobalNormalizationFunc() func(f *flag.FlagSet, name string) flag.NormalizedName {
+	return c.globNormFunc
 }
 
 // Get the complete FlagSet that applies to this command (local and persistent declared here and by all parents)


### PR DESCRIPTION
Added a global function to add normalization functions to all pFlag sets. That helps in cases that someone has lots of subcommands and want to handle all flag names in a consistent and global way.