### PR TITLE
Don't prepend filename in default GenMarkdownTree

### DIFF
--- a/md_docs.go
+++ b/md_docs.go
@@ -104,8 +104,9 @@ func GenMarkdownCustom(cmd *Command, out *bytes.Buffer, linkHandler func(string)
 }
 
 func GenMarkdownTree(cmd *Command, dir string) {
-	noOp := func(s string) string { return s }
-	GenMarkdownTreeCustom(cmd, dir, noOp, noOp)
+	identity := func(s string) string { return s }
+	emptyStr := func(s string) string { return "" }
+	GenMarkdownTreeCustom(cmd, dir, emptyStr, identity)
 }
 
 func GenMarkdownTreeCustom(cmd *Command, dir string, filePrepender func(string) string, linkHandler func(string) string) {


### PR DESCRIPTION
Fix default behavior added by #109. It's not typical to prepend the full filepath in a generated file, especially as that path will differ between e.g. a dev's laptop and a ci environment.