### PR TITLE
Correctly print the unknown command name

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -755,6 +755,11 @@ func TestRootUnknownCommand(t *testing.T) {
 	if r.Output != s {
 		t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", s, r.Output)
 	}
+
+	r = noRRSetupTest("--strtwo=a bogus")
+	if r.Output != s {
+		t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", s, r.Output)
+	}
 }
 
 func TestFlagsBeforeCommand(t *testing.T) {

--- a/command.go
+++ b/command.go
@@ -424,7 +424,7 @@ func (c *Command) Find(args []string) (*Command, []string, error) {
 
 	// If we matched on the root, but we asked for a subcommand, return an error
 	if commandFound.Name() == c.Name() && len(stripFlags(args, c)) > 0 && commandFound.Name() != args[0] {
-		return nil, a, fmt.Errorf("unknown command %q", a[0])
+		return nil, a, fmt.Errorf("unknown command %q", stripFlags(args, c)[0])
 	}
 
 	return commandFound, a, nil


### PR DESCRIPTION
by now, if someone calls: `program --validflag unknowncommand` the
output will be:

```
Error: unknown command "--validflag"
Run 'program help' for usage.
```

This patch strips out flags so the unknown command is printed:

```
Error: unknown command "unknowncommand"
Run 'program help' for usage.
```