### PR TITLE
Correctly print the unknown command name

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -378,6 +378,24 @@ func TestChildSameName(t *testing.T) {
 	}
 }
 
+func TestGrandChildSameName(t *testing.T) {
+	c := initializeWithSameName()
+	cmdTimes.AddCommand(cmdPrint)
+	c.AddCommand(cmdTimes)
+	c.SetArgs(strings.Split("times print one two", " "))
+	c.Execute()
+
+	if te != nil || tt != nil {
+		t.Error("Wrong command called")
+	}
+	if tp == nil {
+		t.Error("Wrong command called")
+	}
+	if strings.Join(tp, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
 func TestFlagLong(t *testing.T) {
 	noRRSetupTest("echo --intone=13 something here")
 

--- a/command.go
+++ b/command.go
@@ -423,8 +423,9 @@ func (c *Command) Find(args []string) (*Command, []string, error) {
 	commandFound, a := innerfind(c, args)
 
 	// If we matched on the root, but we asked for a subcommand, return an error
-	if commandFound.Name() == c.Name() && len(stripFlags(args, c)) > 0 && commandFound.Name() != args[0] {
-		return nil, a, fmt.Errorf("unknown command %q", stripFlags(args, c)[0])
+	argsWOflags := stripFlags(a, commandFound)
+	if commandFound == c && len(argsWOflags) > 0 {
+		return nil, a, fmt.Errorf("unknown command %q", argsWOflags[0])
 	}
 
 	return commandFound, a, nil


### PR DESCRIPTION
by now, if someone calls: program --validflag unknowncommand the
output will be:

```
Error: unknown command "--validflag"
Run 'program help' for usage.
```
This patch strips out flags so the unknown command is printed:
```
Error: unknown command "unknowncommand"
Run 'program help' for usage.
```

Reported-by: Simone Gotti in https://github.com/spf13/cobra/pull/116

This also fixes a problem with the original code where if you had a
root command and a grand child with the same name, the parser would
break and would not run the grandchild. The code was special casing if
the immediate child had the same name, but didn't handle grand-children