### PR TITLE
Add new BashCompSubdirsInDir annotation

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -13,6 +13,7 @@ import (
 const (
 	BashCompFilenameExt     = "cobra_annotation_bash_completion_filename_extentions"
 	BashCompOneRequiredFlag = "cobra_annotation_bash_completion_one_required_flag"
+	BashCompSubdirsInDir    = "cobra_annotation_bash_completion_subdirs_in_dir"
 )
 
 func preamble(out *bytes.Buffer) {
@@ -98,6 +99,12 @@ __handle_filename_extension_flag()
 {
     local ext="$1"
     _filedir "@(${ext})"
+}
+
+__handle_subdirs_in_dir_flag()
+{
+    local dir="$1"
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1
 }
 
 __handle_flag()
@@ -224,6 +231,16 @@ func writeFlagHandler(name string, annotations map[string][]string, out *bytes.B
 				fmt.Fprintf(out, "    flags_completion+=(%q)\n", ext)
 			} else {
 				ext := "_filedir"
+				fmt.Fprintf(out, "    flags_completion+=(%q)\n", ext)
+			}
+		case BashCompSubdirsInDir:
+			fmt.Fprintf(out, "    flags_with_completion+=(%q)\n", name)
+
+			if len(value) == 1 {
+				ext := "__handle_subdirs_in_dir_flag " + value[0]
+				fmt.Fprintf(out, "    flags_completion+=(%q)\n", ext)
+			} else {
+				ext := "_filedir -d"
 				fmt.Fprintf(out, "    flags_completion+=(%q)\n", ext)
 			}
 		}

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -56,6 +56,11 @@ func TestBashCompletions(t *testing.T) {
 	c.Flags().StringVar(&flagvalExt, "filename-ext", "", "Enter a filename (extension limited)")
 	c.MarkFlagFilename("filename-ext")
 
+	// subdirectories in a given directory
+	var flagvalTheme string
+	c.Flags().StringVar(&flagvalTheme, "theme", "", "theme to use (located in /themes/THEMENAME/)")
+	c.Flags().SetAnnotation("theme", BashCompSubdirsInDir, []string{"themes"})
+
 	out := new(bytes.Buffer)
 	c.GenBashCompletion(out)
 	str := out.String()
@@ -75,6 +80,8 @@ func TestBashCompletions(t *testing.T) {
 	check(t, str, `flags_completion+=("_filedir")`)
 	// check for filename extension flags
 	check(t, str, `flags_completion+=("__handle_filename_extension_flag json|yaml|yml")`)
+	// check for subdirs_in_dir flags
+	check(t, str, `flags_completion+=("__handle_subdirs_in_dir_flag themes")`)
 
 	checkOmit(t, str, cmdDeprecated.Name())
 }


### PR DESCRIPTION
This first `cd` to a specified directory, then
lists the subdirectories therein with `_filedir -d`.

This can be used by e.g. `hugo --theme=[Tab][Tab]`, which would
give a list of subdirectories under the `themes` directory.
See Pull Request spf13/hugo#1343 for more information.