### PR TITLE
Display pflag.CommandLine flags as if they were declared on the parent

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -963,3 +963,11 @@ func TestGlobalNormFuncPropagation(t *testing.T) {
 		t.Error("cmdPrint and cmdEchoSub should had the normalization function of rootCmd")
 	}
 }
+
+func TestFlagOnPflagCommandLine(t *testing.T) {
+	flagName := "flagOnCommandLine"
+	pflag.CommandLine.String(flagName, "", "about my flag")
+	r := fullSetupTest("--help")
+
+	checkResultContains(t, r, flagName)
+}

--- a/command.go
+++ b/command.go
@@ -158,7 +158,6 @@ func (c *Command) SetHelpTemplate(s string) {
 func (c *Command) SetGlobalNormalizationFunc(n func(f *flag.FlagSet, name string) flag.NormalizedName) {
 	c.Flags().SetNormalizeFunc(n)
 	c.PersistentFlags().SetNormalizeFunc(n)
-	c.LocalFlags().SetNormalizeFunc(n)
 	c.globNormFunc = n
 
 	for _, command := range c.commands {
@@ -873,6 +872,13 @@ func (c *Command) LocalFlags() *flag.FlagSet {
 	c.lflags.VisitAll(func(f *flag.Flag) {
 		local.AddFlag(f)
 	})
+	if !c.HasParent() {
+		flag.CommandLine.VisitAll(func(f *flag.Flag) {
+			if local.Lookup(f.Name) == nil {
+				local.AddFlag(f)
+			}
+		})
+	}
 	return local
 }
 


### PR DESCRIPTION
```go
package main

import (
	"github.com/spf13/cobra"
	"github.com/spf13/pflag"
)

func main() {
	cmd := &cobra.Command{
		Use:   "min",
		Short: "minimal command",
		Run:   func(_ *cobra.Command, _ []string) {},
	}

	pflag.String("oncmdline", "oncmdline", "oncmdline")
	cmd.Execute()
}
```

Is a minimal cobra program.  When --help is displayed without this patch you get no indication the "oncmdline" is a valid flag. But it does work. With the patch --oncmdline is shows under flags.