### PR TITLE
hidden flags

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -18,8 +18,8 @@ var _ = os.Stderr
 
 var tp, te, tt, t1, tr []string
 var rootPersPre, echoPre, echoPersPre, timesPersPre []string
-var flagb1, flagb2, flagb3, flagbr, flagbp bool
-var flags1, flags2a, flags2b, flags3 string
+var flagb1, flagb2, flagb3, flagbr, flagbp, flagbh, flagbph bool
+var flags1, flags2a, flags2b, flags3, outs string
 var flagi1, flagi2, flagi3, flagir int
 var globalFlag1 bool
 var flagEcho, rootcalled bool
@@ -27,6 +27,18 @@ var versionUsed int
 
 const strtwoParentHelp = "help message for parent flag strtwo"
 const strtwoChildHelp = "help message for child flag strtwo"
+
+var cmdHiddenFlags = &Command{
+	Use:   "hidden [string to set]",
+	Short: "set a string value to string var",
+	Long:  `an utterly useless command for testing.`,
+	Run: func(cmd *Command, args []string) {
+		outs = "visible"
+		if flagbh {
+			outs = "hidden"
+		}
+	},
+}
 
 var cmdPrint = &Command{
 	Use:   "print [string to print]",
@@ -976,15 +988,15 @@ func TestFlagOnPflagCommandLine(t *testing.T) {
 func TestAddTemplateFunctions(t *testing.T) {
 	AddTemplateFunc("t", func() bool { return true })
 	AddTemplateFuncs(template.FuncMap{
-		"f": func() bool { return false }, 
-		"h": func() string { return "Hello," }, 
+		"f": func() bool { return false },
+		"h": func() string { return "Hello," },
 		"w": func() string { return "world." }})
 
 	const usage = "Hello, world."
-	
+
 	c := &Command{}
 	c.SetUsageTemplate(`{{if t}}{{h}}{{end}}{{if f}}{{h}}{{end}} {{w}}`)
-	
+
 	if us := c.UsageString(); us != usage {
 		t.Errorf("c.UsageString() != \"%s\", is \"%s\"", usage, us)
 	}

--- a/command.go
+++ b/command.go
@@ -917,14 +917,14 @@ func (c *Command) LocalFlags() *flag.FlagSet {
 
 	local := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	c.lflags.VisitAll(func(f *flag.Flag) {
-		if !f.Private {
+		if !f.Hidden {
 			local.AddFlag(f)
 		}
 	})
 	if !c.HasParent() {
 		flag.CommandLine.VisitAll(func(f *flag.Flag) {
 			if local.Lookup(f.Name) == nil {
-				if !f.Private {
+				if !f.Hidden {
 					local.AddFlag(f)
 				}
 			}
@@ -946,7 +946,7 @@ func (c *Command) InheritedFlags() *flag.FlagSet {
 		if x.HasPersistentFlags() {
 			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
 				if inherited.Lookup(f.Name) == nil && local.Lookup(f.Name) == nil {
-					if !f.Private {
+					if !f.Hidden {
 						inherited.AddFlag(f)
 					}
 				}

--- a/command.go
+++ b/command.go
@@ -917,12 +917,16 @@ func (c *Command) LocalFlags() *flag.FlagSet {
 
 	local := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	c.lflags.VisitAll(func(f *flag.Flag) {
-		local.AddFlag(f)
+		if !f.Private {
+			local.AddFlag(f)
+		}
 	})
 	if !c.HasParent() {
 		flag.CommandLine.VisitAll(func(f *flag.Flag) {
 			if local.Lookup(f.Name) == nil {
-				local.AddFlag(f)
+				if !f.Private {
+					local.AddFlag(f)
+				}
 			}
 		})
 	}
@@ -942,7 +946,9 @@ func (c *Command) InheritedFlags() *flag.FlagSet {
 		if x.HasPersistentFlags() {
 			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
 				if inherited.Lookup(f.Name) == nil && local.Lookup(f.Name) == nil {
-					inherited.AddFlag(f)
+					if !f.Private {
+						inherited.AddFlag(f)
+					}
 				}
 			})
 		}

--- a/command_test.go
+++ b/command_test.go
@@ -24,7 +24,7 @@ func TestHiddenFlagExecutes(t *testing.T) {
 	}
 
 	//
-	boringCmd.Flags().BoolVarP(&secretFlag, "secret", "s", false, "makes commands run in super secret mode")
+	boringCmd.Flags().BoolVarP(&secretFlag, "secret", "s", false, "makes this command run in super secret mode")
 	boringCmd.Flags().MarkHidden("secret")
 
 	//
@@ -76,7 +76,7 @@ func TestHiddenFlagsAreHidden(t *testing.T) {
 
 	//
 	boringCmd.PersistentFlags().BoolVarP(&persistentSecretFlag, "Secret", "S", false, "run any sub command in super secret mode")
-	boringCmd.Flags().MarkHidden("Secret")
+	boringCmd.PersistentFlags().MarkHidden("Secret")
 
 	// if a command has inherited flags, they will appear in usage/help text
 	if boringCmd.HasInheritedFlags() {

--- a/command_test.go
+++ b/command_test.go
@@ -5,82 +5,33 @@ import (
 	"testing"
 )
 
-// test to ensure hidden flags run as intended
+func init() {
+	cmdHiddenFlags.Flags().BoolVarP(&flagbh, "boolh", "", false, "")
+	cmdHiddenFlags.Flags().MarkHidden("boolh")
+
+	cmdHiddenFlags.PersistentFlags().BoolVarP(&flagbph, "boolph", "", false, "")
+	cmdHiddenFlags.PersistentFlags().MarkHidden("boolph")
+}
+
+// test to ensure hidden flags run as intended; if the the hidden flag fails to
+// run, the output will be incorrect
 func TestHiddenFlagExecutes(t *testing.T) {
-	var out string
-	var secretFlag bool
-
-	boringCmd := &Command{
-		Use:   "boring",
-		Short: "Do something boring...",
-		Long:  `Not a flashy command, just does boring stuff`,
-		Run: func(cmd *Command, args []string) {
-			out = "boring output"
-
-			if secretFlag {
-				out = "super secret NOT boring output!"
-			}
-		},
-	}
-
-	//
-	boringCmd.Flags().BoolVarP(&secretFlag, "secret", "s", false, "makes this command run in super secret mode")
-	boringCmd.Flags().MarkHidden("secret")
-
-	//
-	boringCmd.Execute()
-
-	if out != "boring output" {
-		t.Errorf("Command with hidden flag failed to run!")
-	}
-
-	//
-	boringCmd.execute([]string{"-s"})
-
-	if out != "super secret NOT boring output!" {
+	cmdHiddenFlags.execute([]string{"--boolh"})
+	if outs != "hidden" {
 		t.Errorf("Hidden flag failed to run!")
 	}
 }
 
-// test to ensure hidden flags do not show up in usage/help text
+// test to ensure hidden flags do not show up in usage/help text; if a flag is
+// found by Lookup() it will be visible in usage/help text
 func TestHiddenFlagsAreHidden(t *testing.T) {
-	var out string
-	var secretFlag bool
-	var persistentSecretFlag bool
 
-	boringCmd := &Command{
-		Use:   "boring",
-		Short: "Do something boring...",
-		Long:  `Not a flashy command, just does boring stuff`,
-		Run: func(cmd *Command, args []string) {
-			out = "boring output"
-
-			if secretFlag {
-				out = "super secret NOT boring output!"
-			}
-
-			if persistentSecretFlag {
-				out = "you have no idea what you're getting yourself into!"
-			}
-		},
+	if cmdHiddenFlags.LocalFlags().Lookup("boolh") != nil {
+		t.Errorf("unexpected flag 'boolh'")
 	}
 
-	//
-	boringCmd.Flags().BoolVarP(&secretFlag, "secret", "s", false, "run this command in super secret mode")
-	boringCmd.Flags().MarkHidden("secret")
-
-	// if a command has local flags, they will appear in usage/help text
-	if boringCmd.HasLocalFlags() {
-		t.Errorf("Hidden flag found!")
-	}
-
-	//
-	boringCmd.PersistentFlags().BoolVarP(&persistentSecretFlag, "Secret", "S", false, "run any sub command in super secret mode")
-	boringCmd.PersistentFlags().MarkHidden("Secret")
-
-	// if a command has inherited flags, they will appear in usage/help text
-	if boringCmd.HasInheritedFlags() {
-		t.Errorf("Hidden flag found!")
+	if cmdHiddenFlags.InheritedFlags().Lookup("boolph") != nil {
+		t.Errorf("unexpected flag 'boolph'")
 	}
 }
 


### PR DESCRIPTION
It would be nice if there was a quick way to designate a flag as "for internal use only" (hidden/private) so that consumers would never see the flag but cobra could make it available to commands.

Initially I thought that simply having a blank usage could be a way of indicating a private command, but decided that this was more of just a 'quick-fix' rather than a true solution
if f.Usage != "" {
  local.AddFlag(f)
}

Then I considered just using the already built-in Flag.Deprecated, however it seemed it was designed for something slightly different, and while it would do the job, it didn't feel like the right solution.
if f.Deprecated == "" {
  local.AddFlag(f)
}

Ultimately I feel that this, coupled with a pull request from spf13/pflag (https://github.com/spf13/pflag/pull/53), is the best approach; adding a Flag.Private field with the corresponding method to set a flag as private is the cleanest and most responsible solution to the problem.