### PR TITLE
Allows command suggestions along with "unknown command" errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,30 @@ func main() {
 }
 ```
 
+## Suggestions when "unknown command" happens
+
+Cobra will print automatic suggestions when "unknown command" errors happen. This allows Cobra to behavior similarly to the `git` command when a typo happens. For example:
+
+```
+$ hugo srever
+unknown command "srever" for "hugo"
+
+Did you mean this?
+  server
+
+Run 'hugo --help' for usage.
+```
+
+Suggestions are automatic based on every subcommand registered and use an implementation of Levenshtein distance. Every registered command that matches a minimum distance of 2 (ignoring case) will be displayed as a suggestion.
+
+If you need to disable suggestions or tweak the string distance in your command, use:
+
+    command.DisableSuggestions = true
+
+or 
+
+    command.SuggestionsMinimumDistance = 1
+
 ## Generating markdown formatted documentation for your command
 
 Cobra can generate a markdown formatted document based on the subcommands, flags, etc. A simple example of how to do this for your command can be found in [Markdown Docs](md_docs.md)

--- a/cobra.go
+++ b/cobra.go
@@ -126,3 +126,39 @@ func tmpl(w io.Writer, text string, data interface{}) error {
 	template.Must(t.Parse(text))
 	return t.Execute(w, data)
 }
+
+// ld compares two strings and returns the levenshtein distance between them
+func ld(s, t string, ignoreCase bool) int {
+	if ignoreCase {
+		s = strings.ToLower(s)
+		t = strings.ToLower(t)
+	}
+	d := make([][]int, len(s)+1)
+	for i := range d {
+		d[i] = make([]int, len(t)+1)
+	}
+	for i := range d {
+		d[i][0] = i
+	}
+	for j := range d[0] {
+		d[0][j] = j
+	}
+	for j := 1; j <= len(t); j++ {
+		for i := 1; i <= len(s); i++ {
+			if s[i-1] == t[j-1] {
+				d[i][j] = d[i-1][j-1]
+			} else {
+				min := d[i-1][j]
+				if d[i][j-1] < min {
+					min = d[i][j-1]
+				}
+				if d[i-1][j-1] < min {
+					min = d[i-1][j-1]
+				}
+				d[i][j] = min + 1
+			}
+		}
+
+	}
+	return d[len(s)][len(t)]
+}

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -799,6 +799,34 @@ func TestRootUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestRootSuggestions(t *testing.T) {
+	outputWithSuggestions := "Error: unknown command \"%s\" for \"cobra-test\"\n\nDid you mean this?\n\t%s\n\nRun 'cobra-test --help' for usage.\n"
+	outputWithoutSuggestions := "Error: unknown command \"%s\" for \"cobra-test\"\nRun 'cobra-test --help' for usage.\n"
+
+	cmd := initializeWithRootCmd()
+	cmd.AddCommand(cmdTimes)
+
+	tests := map[string]string{
+		"time":  "times",
+		"tiems": "times",
+		"timeS": "times",
+		"rimes": "times",
+	}
+
+	for typo, suggestion := range tests {
+		cmd.DisableSuggestions = false
+		result := simpleTester(cmd, typo)
+		if expected := fmt.Sprintf(outputWithSuggestions, typo, suggestion); result.Output != expected {
+			t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", expected, result.Output)
+		}
+		cmd.DisableSuggestions = true
+		result = simpleTester(cmd, typo)
+		if expected := fmt.Sprintf(outputWithoutSuggestions, typo); result.Output != expected {
+			t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", expected, result.Output)
+		}
+	}
+}
+
 func TestFlagsBeforeCommand(t *testing.T) {
 	// short without space
 	x := fullSetupTest("-i10 echo")


### PR DESCRIPTION
Adds *optional* support to suggestions when "unknown command" errors happen. This allows Cobra to mimic the behaviour of `git`, like in:

```
$ git fethc
git: 'fethc' is not a git command. See 'git --help'.

Did you mean this?
	fetch
```