### PR TITLE
No leading newline if Short and Long both unset

### DIFF
--- a/command.go
+++ b/command.go
@@ -284,8 +284,9 @@ func (c *Command) HelpTemplate() string {
 	if c.HasParent() {
 		return c.parent.HelpTemplate()
 	} else {
-		return `{{with or .Long .Short }}{{. | trim}}{{end}}
-{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+		return `{{with or .Long .Short }}{{. | trim}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 	}
 }
 


### PR DESCRIPTION
Before --help would start
```

Usage:
  command [flags]
  [...]
```

After --help will show
```
Usage:
  command [flags]
  [...]
```