### PR TITLE
No newline after Flags in usage

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -23,13 +23,15 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"unicode"
 )
 
 var templateFuncs template.FuncMap = template.FuncMap{
-	"trim": strings.TrimSpace,
-	"rpad": rpad,
-	"gt":   Gt,
-	"eq":   Eq,
+	"trim":           strings.TrimSpace,
+	"trimRightSpace": trimRightSpace,
+	"rpad":           rpad,
+	"gt":             Gt,
+	"eq":             Eq,
 }
 
 var initializers []func()
@@ -111,6 +113,10 @@ func Eq(a interface{}, b interface{}) bool {
 		return av.String() == bv.String()
 	}
 	return false
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
 }
 
 //rpad adds padding to the right of a string

--- a/command.go
+++ b/command.go
@@ -186,6 +186,9 @@ func (c *Command) UsageFunc() (f func(*Command) error) {
 	} else {
 		return func(c *Command) error {
 			err := tmpl(c.Out(), c.UsageTemplate(), c)
+			if err != nil {
+				fmt.Print(err)
+			}
 			return err
 		}
 	}
@@ -263,10 +266,10 @@ Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasLocalFlags}}
 
 Flags:
-{{.LocalFlags.FlagUsages}}{{end}}{{ if .HasInheritedFlags}}
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasInheritedFlags}}
 
 Global Flags:
-{{.InheritedFlags.FlagUsages}}{{end}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasSubCommands }}


### PR DESCRIPTION
The flags usage template from pflags has a trailing \n. We need to
include a newline in case there are no flags in our template. This will
trim the newline from the end of the flags from pflag and we can do it
right outselves.