### PR TITLE
adds check to see if command name and os.Args[0] is the same before...

### DIFF
--- a/command.go
+++ b/command.go
@@ -566,7 +566,7 @@ func (c *Command) Execute() (err error) {
 
 	var args []string
 
-	if len(c.args) == 0 {
+	if len(c.args) == 0 && os.Args[0] == c.Name() {
 		args = os.Args[1:]
 	} else {
 		args = c.args


### PR DESCRIPTION
applying os.Args as it was leading appending false arguments from the test suite. This was causing the test suite to fail. All tests should be passing now.