### PR TITLE
Improve suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,18 @@ or
 
     command.SuggestionsMinimumDistance = 1
 
+You can also explicitly set names for which a given command will be suggested using the `SuggestFor` attribute. This allows suggestions for strings that are not close in terms of string distance, but makes sense in your set of commands and for some which you don't want aliases. Example:
+
+```
+$ hugo delete
+unknown command "delete" for "hugo"
+
+Did you mean this?
+  remove
+
+Run 'hugo --help' for usage.
+```
+
 ## Generating markdown formatted documentation for your command
 
 Cobra can generate a markdown formatted document based on the subcommands, flags, etc. A simple example of how to do this for your command can be found in [Markdown Docs](md_docs.md)

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -816,22 +816,32 @@ func TestRootSuggestions(t *testing.T) {
 	cmd.AddCommand(cmdTimes)
 
 	tests := map[string]string{
-		"time":  "times",
-		"tiems": "times",
-		"timeS": "times",
-		"rimes": "times",
+		"time":     "times",
+		"tiems":    "times",
+		"tims":     "times",
+		"timeS":    "times",
+		"rimes":    "times",
+		"ti":       "times",
+		"t":        "times",
+		"timely":   "times",
+		"ri":       "",
+		"timezone": "",
+		"foo":      "",
 	}
 
 	for typo, suggestion := range tests {
-		cmd.DisableSuggestions = false
-		result := simpleTester(cmd, typo)
-		if expected := fmt.Sprintf(outputWithSuggestions, typo, suggestion); result.Output != expected {
-			t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", expected, result.Output)
-		}
-		cmd.DisableSuggestions = true
-		result = simpleTester(cmd, typo)
-		if expected := fmt.Sprintf(outputWithoutSuggestions, typo); result.Output != expected {
-			t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", expected, result.Output)
+		for _, suggestionsDisabled := range []bool{false, true} {
+			cmd.DisableSuggestions = suggestionsDisabled
+			result := simpleTester(cmd, typo)
+			expected := ""
+			if len(suggestion) == 0 || suggestionsDisabled {
+				expected = fmt.Sprintf(outputWithoutSuggestions, typo)
+			} else {
+				expected = fmt.Sprintf(outputWithSuggestions, typo, suggestion)
+			}
+			if result.Output != expected {
+				t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", expected, result.Output)
+			}
 		}
 	}
 }

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -82,9 +82,10 @@ var cmdDeprecated = &Command{
 }
 
 var cmdTimes = &Command{
-	Use:   "times [# times] [string to echo]",
-	Short: "Echo anything to the screen more times",
-	Long:  `a slightly useless command for testing.`,
+	Use:        "times [# times] [string to echo]",
+	SuggestFor: []string{"counts"},
+	Short:      "Echo anything to the screen more times",
+	Long:       `a slightly useless command for testing.`,
 	PersistentPreRun: func(cmd *Command, args []string) {
 		timesPersPre = args
 	},
@@ -827,6 +828,7 @@ func TestRootSuggestions(t *testing.T) {
 		"ri":       "",
 		"timezone": "",
 		"foo":      "",
+		"counts":   "times",
 	}
 
 	for typo, suggestion := range tests {


### PR DESCRIPTION
Multiple improvements to suggestions when "unknown command" errors happen. Basically a `HasPrefix` will now also match, and adds the `SuggestFor` attribute to allow explicit suggestions. By setting that attribute you can for example suggest the valid command `remove` when users try `delete`, if for some reason you don't want actual aliases.