### PR TITLE
[silence-errors]: adds a way for errors to silenced down the stack

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -220,6 +220,7 @@ func fullSetupTest(input string) resulter {
 func noRRSetupTestSilenced(input string) resulter {
 	c := initialize()
 	c.SilenceErrors = true
+	c.SilenceUsage = true
 	return fullTester(c, input)
 }
 

--- a/command.go
+++ b/command.go
@@ -639,10 +639,13 @@ func (c *Command) Execute() (err error) {
 
 	err = cmd.execute(flags)
 	if err != nil {
-		// If root is silenced, all subcommands should have the same
+		// If root command has SilentUsage flagged,
+		// all subcommands should respect it
 		if !cmd.SilenceUsage && !c.SilenceUsage {
 			c.Println(cmd.UsageString())
 		}
+		// If root command has SilentErrors flagged,
+		// all subcommands should respect it
 		if !cmd.SilenceErrors && !c.SilenceErrors {
 			if err == flag.ErrHelp {
 				cmd.HelpFunc()(cmd, args)

--- a/command.go
+++ b/command.go
@@ -637,7 +637,8 @@ func (c *Command) Execute() (err error) {
 
 	err = cmd.execute(flags)
 	if err != nil {
-		if !cmd.SilenceErrors {
+		// If root is silenced, all subcommands should have the same
+		if !cmd.SilenceErrors && !c.SilenceErrors {
 			if err == flag.ErrHelp {
 				cmd.HelpFunc()(cmd, args)
 				return nil

--- a/command.go
+++ b/command.go
@@ -63,6 +63,8 @@ type Command struct {
 	lflags *flag.FlagSet
 	// SilenceErrors is an option to quiet errors down stream
 	SilenceErrors bool
+	// Silence Usage is an option to silence usage when an error occurs.
+	SilenceUsage bool
 	// The *Run functions are executed in the following order:
 	//   * PersistentPreRun()
 	//   * PreRun()
@@ -638,12 +640,14 @@ func (c *Command) Execute() (err error) {
 	err = cmd.execute(flags)
 	if err != nil {
 		// If root is silenced, all subcommands should have the same
+		if !cmd.SilenceUsage && !c.SilenceUsage {
+			c.Println(cmd.UsageString())
+		}
 		if !cmd.SilenceErrors && !c.SilenceErrors {
 			if err == flag.ErrHelp {
 				cmd.HelpFunc()(cmd, args)
 				return nil
 			}
-			c.Println(cmd.UsageString())
 			c.Println("Error:", err.Error())
 		}
 		return err


### PR DESCRIPTION
In waiting for #168, I kinda need this bug fixed so I took most of what @bep did but made it configurable as suggested by @spf13 and @eparis. This should fix #162.