### PR TITLE
Ensure the usage command is printed only once

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -1075,3 +1075,14 @@ func TestAddTemplateFunctions(t *testing.T) {
 		t.Errorf("c.UsageString() != \"%s\", is \"%s\"", usage, us)
 	}
 }
+
+func TestUsageIsNotPrintedTwice(t *testing.T) {
+	var cmd = &Command{Use: "root"}
+	var sub = &Command{Use: "sub"}
+	cmd.AddCommand(sub)
+
+	r := simpleTester(cmd, "")
+	if strings.Count(r.Output, "Usage:") != 1 {
+		t.Error("Usage output is not printed exactly once")
+	}
+}

--- a/command.go
+++ b/command.go
@@ -639,11 +639,6 @@ func (c *Command) Execute() (err error) {
 
 	err = cmd.execute(flags)
 	if err != nil {
-		// If root command has SilentUsage flagged,
-		// all subcommands should respect it
-		if !cmd.SilenceUsage && !c.SilenceUsage {
-			c.Println(cmd.UsageString())
-		}
 		// If root command has SilentErrors flagged,
 		// all subcommands should respect it
 		if !cmd.SilenceErrors && !c.SilenceErrors {
@@ -652,6 +647,12 @@ func (c *Command) Execute() (err error) {
 				return nil
 			}
 			c.Println("Error:", err.Error())
+		}
+
+		// If root command has SilentUsage flagged,
+		// all subcommands should respect it
+		if !cmd.SilenceUsage && !c.SilenceUsage {
+			c.Println(cmd.UsageString())
 		}
 		return err
 	}


### PR DESCRIPTION
Reverse a swap in logic introduced in #169 that would cause the usage
output to be printed twice.

Fixes #171