### PR TITLE
Persistent flags completions

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -396,6 +396,11 @@ func (cmd *Command) MarkFlagRequired(name string) error {
 	return MarkFlagRequired(cmd.Flags(), name)
 }
 
+// MarkPersistentFlagRequired adds the BashCompOneRequiredFlag annotation to the named persistent flag, if it exists.
+func (cmd *Command) MarkPersistentFlagRequired(name string) error {
+	return MarkFlagRequired(cmd.PersistentFlags(), name)
+}
+
 // MarkFlagRequired adds the BashCompOneRequiredFlag annotation to the named flag in the flag set, if it exists.
 func MarkFlagRequired(flags *pflag.FlagSet, name string) error {
 	return flags.SetAnnotation(name, BashCompOneRequiredFlag, []string{"true"})
@@ -405,6 +410,12 @@ func MarkFlagRequired(flags *pflag.FlagSet, name string) error {
 // Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
 func (cmd *Command) MarkFlagFilename(name string, extensions ...string) error {
 	return MarkFlagFilename(cmd.Flags(), name, extensions...)
+}
+
+// MarkPersistentFlagFilename adds the BashCompFilenameExt annotation to the named persistent flag, if it exists.
+// Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
+func (cmd *Command) MarkPersistentFlagFilename(name string, extensions ...string) error {
+	return MarkFlagFilename(cmd.PersistentFlags(), name, extensions...)
 }
 
 // MarkFlagFilename adds the BashCompFilenameExt annotation to the named flag in the flag set, if it exists.

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -305,6 +305,12 @@ func writeFlags(cmd *Command, out *bytes.Buffer) {
 			writeShortFlag(flag, out)
 		}
 	})
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		writeFlag(flag, out)
+		if len(flag.Shorthand) > 0 {
+			writeShortFlag(flag, out)
+		}
+	})
 
 	fmt.Fprintf(out, "\n")
 }

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -51,6 +51,12 @@ func TestBashCompletions(t *testing.T) {
 	c.Flags().StringVar(&flagval, "filename", "", "Enter a filename")
 	c.MarkFlagFilename("filename", "json", "yaml", "yml")
 
+	// persistent filename
+	var flagvalPersistent string
+	c.PersistentFlags().StringVar(&flagvalPersistent, "persistent-filename", "", "Enter a filename")
+	c.MarkPersistentFlagFilename("persistent-filename")
+	c.MarkPersistentFlagRequired("persistent-filename")
+
 	// filename extensions
 	var flagvalExt string
 	c.Flags().StringVar(&flagvalExt, "filename-ext", "", "Enter a filename (extension limited)")
@@ -72,6 +78,7 @@ func TestBashCompletions(t *testing.T) {
 
 	// check for required flags
 	check(t, str, `must_have_one_flag+=("--introot=")`)
+	check(t, str, `must_have_one_flag+=("--persistent-filename=")`)
 	// check for custom completion function
 	check(t, str, `COMPREPLY=( "hello" )`)
 	// check for required nouns


### PR DESCRIPTION
Inherited flags should also be part of completions for every command that inherits it. Also allows marking persistent flags as required or filename for completions.