### PR TITLE
fixes verbose tests by checking if the first arg belongs to cobra

### DIFF
--- a/command.go
+++ b/command.go
@@ -618,7 +618,7 @@ func (c *Command) Execute() (err error) {
 
 	var args []string
 
-	if len(c.args) == 0 {
+	if len(c.args) == 0 && os.Args[0] == c.Name() {
 		args = os.Args[1:]
 	} else {
 		args = c.args


### PR DESCRIPTION
This should fix the tests by checking if first arg is the same as the name as the root command in cobra. Replaces PR #155 @eparis @spf13 @anthonyfok 