### PR TITLE
Adopt SPDX-License-Identifier header, etc.

### DIFF
--- a/cobra/cmd/add.go
+++ b/cobra/cmd/add.go
@@ -68,6 +68,7 @@ func createCmdFile(cmdName string) {
 	lic := getLicense()
 
 	template := `{{ comment .copyright }}
+// SPDX-License-Identifier: {{ .licensename }}
 {{ comment .license }}
 
 package cmd

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -301,11 +301,13 @@ func getLicense() License {
 	l := whichLicense()
 	if l != "" {
 		if x, ok := Licenses[l]; ok {
+			fmt.Printf("Info: License matched, using %q\n", x.Identifier)
 			return x
 		}
 	}
 
-	return Licenses["apache"]
+	fmt.Println("Info: License not specified or not found, using \"Apache-2.0\"")
+	return Licenses["Apache-2.0"]
 }
 
 func whichLicense() string {

--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -108,6 +108,7 @@ func createMainFile() {
 	lic := getLicense()
 
 	template := `{{ comment .copyright }}
+// SPDX-License-Identifier: {{ .licensename }}
 {{ comment .license }}
 
 package main
@@ -123,6 +124,7 @@ func main() {
 
 	data["copyright"] = copyrightLine()
 	data["license"] = lic.Header
+	data["licensename"] = lic.Identifier
 	data["importpath"] = guessImportPath() + "/" + guessCmdDir()
 
 	err := writeTemplateToFile(ProjectPath(), "main.go", template, data)
@@ -136,6 +138,7 @@ func createRootCmdFile() {
 	lic := getLicense()
 
 	template := `{{ comment .copyright }}
+// SPDX-License-Identifier: {{ .licensename }}
 {{ comment .license }}
 
 package cmd

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -1,4 +1,5 @@
 // Copyright © 2015 Steve Francia <spf@spf13.com>.
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +21,8 @@ import "strings"
 var Licenses map[string]License
 
 type License struct {
-	Name            string   // The type of license in use
+	Identifier      string   // SPDX License Identifier
+	Name            string   // The long name of the license in use
 	PossibleMatches []string // Similar names to guess
 	Text            string   // License text data
 	Header          string   // License header for source files
@@ -41,9 +43,10 @@ func matchLicense(in string) string {
 func init() {
 	Licenses = make(map[string]License)
 
-	Licenses["apache"] = License{
-		Name:            "Apache 2.0",
-		PossibleMatches: []string{"apache", "apache20", "apache 2.0", "apache2.0", "apache-2.0"},
+	Licenses["Apache-2.0"] = License{
+		Identifier:      "Apache-2.0",
+		Name:            "Apache License 2.0",
+		PossibleMatches: []string{"Apache-2.0", "Apache", "Apache-2", "apache20", "Apache 2.0", "Apache2.0"},
 		Header: `
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -261,9 +264,10 @@ func init() {
 `,
 	}
 
-	Licenses["mit"] = License{
-		Name:            "Mit",
-		PossibleMatches: []string{"mit"},
+	Licenses["MIT"] = License{
+		Identifier:      "MIT",
+		Name:            "MIT License",
+		PossibleMatches: []string{"MIT", "Expat"},
 		Header: `
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -306,9 +310,10 @@ THE SOFTWARE.
 `,
 	}
 
-	Licenses["bsd"] = License{
-		Name:            "NewBSD",
-		PossibleMatches: []string{"bsd", "newbsd", "3 clause bsd"},
+	Licenses["BSD-3-Clause"] = License{
+		Identifier:      "BSD-3-Clause",
+		Name:            `BSD 3-clause "New" or "Revised" License`,
+		PossibleMatches: []string{"BSD-3-Clause", "bsd", "newbsd", "3 clause bsd"},
 		Header: `
 All rights reserved.
 
@@ -367,9 +372,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 `,
 	}
 
-	Licenses["freebsd"] = License{
-		Name:            "Simplified BSD License",
-		PossibleMatches: []string{"freebsd", "simpbsd", "simple bsd", "2 clause bsd"},
+	Licenses["BSD-2-Clause"] = License{
+		Identifier:      "BSD-2-Clause",
+		Name:            `BSD 2-clause "Simplified" License`,
+		PossibleMatches: []string{"BSD-2-Clause", "freebsd", "simpbsd", "simple bsd", "2 clause bsd"},
 		Header: `
 All rights reserved.
 


### PR DESCRIPTION
Hello @spf13,

This is a work-in-progress, and I would like some valuable feedback from you as my current patch is problematic, e.g.:

 * My use of `lic.PossibleMatches[0]` seems problematic.
 * Ends up printing the selected license 3 times:

        Info: License matched, using "Apache-2.0"
        Info: License matched, using "Apache-2.0"
        Info: License matched, using "Apache-2.0"

No hurries though: I know you are busy preparing for Hugo v0.15, so this pull request can wait.

Cheers,
Anthony

----
## Commit message:

Improve Cobra Generator’s licensing helper

 - Adopt standardized short identifiers from the SPDX License List,
   see http://spdx.org/licenses/
 - Add SPDX-License-Identifier in the source header, see ESR’s
   endorsement in http://esr.ibiblio.org/?p=6867
 - Format license text and header to fit within 80-char width
 - Use the BSD-2-Clause license rather than the actual FreeBSD License
   with the FreeBSD’s disclaimer in it
 - Use template to output "Copyright © YEAR FULL NAME" to LICENSE
   where appropriate
 - Print a message telling the user which license is actually chosen

TODO: Work-in-progress, not ready for commit.  Comments welcome!