### PR TITLE
Issue #195: Compile mousetrap only on Windows

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -40,14 +40,6 @@ var initializers []func()
 // Set this to true to enable it
 var EnablePrefixMatching bool = false
 
-// enables an information splash screen on Windows if the CLI is started from explorer.exe.
-var EnableWindowsMouseTrap bool = true
-
-var MousetrapHelpText string = `This is a command line tool
-
-You need to open cmd.exe and run it from there.
-`
-
 //AddTemplateFunc adds a template function that's available to Usage and Help
 //template generation.
 func AddTemplateFunc(name string, tmplFunc interface{}) {

--- a/command.go
+++ b/command.go
@@ -21,11 +21,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"time"
 
-	"github.com/inconshreveable/mousetrap"
 	flag "github.com/spf13/pflag"
 )
 
@@ -626,12 +623,9 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		return c.Root().ExecuteC()
 	}
 
-	if EnableWindowsMouseTrap && runtime.GOOS == "windows" {
-		if mousetrap.StartedByExplorer() {
-			c.Print(MousetrapHelpText)
-			time.Sleep(5 * time.Second)
-			os.Exit(1)
-		}
+	// windows hook
+	if preExecHookFn != nil {
+		preExecHookFn(c)
 	}
 
 	// initialize help as the last point possible to allow for user

--- a/command_notwin.go
+++ b/command_notwin.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package cobra
+
+var preExecHookFn func(*Command) = nil

--- a/command_win.go
+++ b/command_win.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package cobra
+
+import (
+	"os"
+	"time"
+
+	"github.com/inconshreveable/mousetrap"
+)
+
+var preExecHookFn = preExecHook
+
+// enables an information splash screen on Windows if the CLI is started from explorer.exe.
+var MousetrapHelpText string = `This is a command line tool
+
+You need to open cmd.exe and run it from there.
+`
+
+func preExecHook(c *Command) {
+	if mousetrap.StartedByExplorer() {
+		c.Print(MousetrapHelpText)
+		time.Sleep(5 * time.Second)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
* Create command_win.go and command_notwin.go for windows only code
* Move call to mousetrap hook into separate preExecHook() function