### PR TITLE
Fixed import path issue on Windows

### DIFF
--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -104,7 +104,7 @@ func guessImportPath() string {
 		er("Cobra only supports project within $GOPATH")
 	}
 
-	return filepath.Clean(strings.TrimPrefix(projectPath, getSrcPath()))
+	return filepath.ToSlash(filepath.Clean(strings.TrimPrefix(projectPath, getSrcPath())))
 }
 
 func getSrcPath() string {

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -143,7 +143,7 @@ func guessProjectPath() {
 	srcPath := getSrcPath()
 	// if provided, inspect for logical locations
 	if strings.ContainsRune(inputPath, os.PathSeparator) {
-		if filepath.IsAbs(inputPath) {
+		if filepath.IsAbs(inputPath) || filepath.HasPrefix(inputPath, string(os.PathSeparator)) {
 			// if Absolute, use it
 			projectPath = filepath.Clean(inputPath)
 			return

--- a/cobra/cmd/helpers_test.go
+++ b/cobra/cmd/helpers_test.go
@@ -29,11 +29,9 @@ func reset() {
 }
 
 func TestProjectPath(t *testing.T) {
-	wd, _ := os.Getwd()
-
-	checkGuess(t, "", "github.com/spf13/hugo", filepath.Join(wd, "github.com", "spf13", "hugo"))
-	checkGuess(t, "", "spf13/hugo", filepath.Join(wd, "spf13", "hugo"))
-	checkGuess(t, "", "/bar/foo", filepath.Join(wd, "bar", "foo"))
+	checkGuess(t, "", filepath.Join("github.com", "spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
+	checkGuess(t, "", filepath.Join("spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
+	checkGuess(t, "", filepath.Join("/", "bar", "foo"), filepath.Join(getSrcPath(), "bar", "foo"))
 	checkGuess(t, "/bar/foo", "baz", filepath.Join("/", "bar", "foo", "baz"))
 	checkGuess(t, "/bar/foo/cmd", "", filepath.Join("/", "bar", "foo"))
 	checkGuess(t, "/bar/foo/command", "", filepath.Join("/", "bar", "foo"))

--- a/cobra/cmd/helpers_test.go
+++ b/cobra/cmd/helpers_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -28,12 +29,14 @@ func reset() {
 }
 
 func TestProjectPath(t *testing.T) {
-	checkGuess(t, "", "github.com/spf13/hugo", getSrcPath()+"github.com/spf13/hugo")
-	checkGuess(t, "", "spf13/hugo", getSrcPath()+"github.com/spf13/hugo")
-	checkGuess(t, "", "/bar/foo", "/bar/foo")
-	checkGuess(t, "/bar/foo", "baz", "/bar/foo/baz")
-	checkGuess(t, "/bar/foo/cmd", "", "/bar/foo")
-	checkGuess(t, "/bar/foo/command", "", "/bar/foo")
-	checkGuess(t, "/bar/foo/commands", "", "/bar/foo")
-	checkGuess(t, "github.com/spf13/hugo/../hugo", "", "github.com/spf13/hugo")
+	wd, _ := os.Getwd()
+
+	checkGuess(t, "", "github.com/spf13/hugo", filepath.Join(wd, "github.com", "spf13", "hugo"))
+	checkGuess(t, "", "spf13/hugo", filepath.Join(wd, "spf13", "hugo"))
+	checkGuess(t, "", "/bar/foo", filepath.Join(wd, "bar", "foo"))
+	checkGuess(t, "/bar/foo", "baz", filepath.Join("/", "bar", "foo", "baz"))
+	checkGuess(t, "/bar/foo/cmd", "", filepath.Join("/", "bar", "foo"))
+	checkGuess(t, "/bar/foo/command", "", filepath.Join("/", "bar", "foo"))
+	checkGuess(t, "/bar/foo/commands", "", filepath.Join("/", "bar", "foo"))
+	checkGuess(t, "github.com/spf13/hugo/../hugo", "", filepath.Join("github.com", "spf13", "hugo"))
 }

--- a/cobra/cmd/helpers_test.go
+++ b/cobra/cmd/helpers_test.go
@@ -31,7 +31,7 @@ func reset() {
 func TestProjectPath(t *testing.T) {
 	checkGuess(t, "", filepath.Join("github.com", "spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
 	checkGuess(t, "", filepath.Join("spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
-	checkGuess(t, "", filepath.Join("/", "bar", "foo"), filepath.Join(getSrcPath(), "bar", "foo"))
+	checkGuess(t, "", filepath.Join("/", "bar", "foo"), filepath.Join("/", "bar", "foo"))
 	checkGuess(t, "/bar/foo", "baz", filepath.Join("/", "bar", "foo", "baz"))
 	checkGuess(t, "/bar/foo/cmd", "", filepath.Join("/", "bar", "foo"))
 	checkGuess(t, "/bar/foo/command", "", filepath.Join("/", "bar", "foo"))


### PR DESCRIPTION
I sort of feel crazy here but trying out Cobra, I'm finding that it isn't working on Windows. It's fairly easy to reproduce. 

Test Case 1 (This one works)

```
C:\go\src\cobra.exe init test
C:\go\src\test\cat .\main.go
```

Which shows an import path of `import test/cmd`

Test Case 2 (This one is broken and fixed with this PR)

```
C:\go\src\directory\cobra.exe init test
C:\go\src\directory\cat .\main.go
```

Which shows an import path of `import directory\test/cmd`

Along with running into this issue, I ran the tests inside cobra/cmd and found that they weren't working. 

It's entirely possible I'm crazy and this is working for everyone else. I'm just not sure I see how it could be though based on the windows slashes being different from import slashes. 