### PR TITLE
Always show help if requested, even if SilenceErrors is enabled

### DIFF
--- a/command.go
+++ b/command.go
@@ -661,13 +661,16 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	}
 	err = cmd.execute(flags)
 	if err != nil {
+		// Always show help if requested, even if SilenceErrors is in
+		// effect
+		if err == flag.ErrHelp {
+			cmd.HelpFunc()(cmd, args)
+			return cmd, nil
+		}
+
 		// If root command has SilentErrors flagged,
 		// all subcommands should respect it
 		if !cmd.SilenceErrors && !c.SilenceErrors {
-			if err == flag.ErrHelp {
-				cmd.HelpFunc()(cmd, args)
-				return cmd, nil
-			}
 			c.Println("Error:", err.Error())
 		}
 


### PR DESCRIPTION
Enabling SilenceErrors also stops --help from working. One could add SilenceHelp to the command struct if this should be configurable but i think the help system should always work.

I'm aware that "help <command>" still works but users will almost certainly try -h, --help first.
