### PR TITLE
Bash completion for names with ':' character.

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -103,6 +103,8 @@ __handle_reply()
     if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
         declare -F __custom_func >/dev/null && __custom_func
     fi
+
+    __ltrim_colon_completions "$cur"
 }
 
 # The arguments should be in the form "ext1|ext2|extn"
@@ -166,9 +168,9 @@ __handle_command()
 
     local next_command
     if [[ -n ${last_command} ]]; then
-        next_command="_${last_command}_${words[c]}"
+        next_command="_${last_command}_${words[c]//:/__}"
     else
-        next_command="_${words[c]}"
+        next_command="_${words[c]//:/__}"
     fi
     c=$((c+1))
     __debug "${FUNCNAME}: looking for ${next_command}"
@@ -196,6 +198,7 @@ __handle_word()
 }
 
 func postscript(out *bytes.Buffer, name string) {
+	name = strings.Replace(name, ":", "__", -1)
 	fmt.Fprintf(out, "__start_%s()\n", name)
 	fmt.Fprintf(out, `{
     local cur prev words cword
@@ -355,6 +358,7 @@ func gen(cmd *Command, out *bytes.Buffer) {
 	}
 	commandName := cmd.CommandPath()
 	commandName = strings.Replace(commandName, " ", "_", -1)
+	commandName = strings.Replace(commandName, ":", "__", -1)
 	fmt.Fprintf(out, "_%s()\n{\n", commandName)
 	fmt.Fprintf(out, "    last_command=%q\n", commandName)
 	writeCommands(cmd, out)

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -34,7 +34,7 @@ COMPREPLY=( "hello" )
 func TestBashCompletions(t *testing.T) {
 	c := initializeWithRootCmd()
 	cmdEcho.AddCommand(cmdTimes)
-	c.AddCommand(cmdEcho, cmdPrint, cmdDeprecated)
+	c.AddCommand(cmdEcho, cmdPrint, cmdDeprecated, cmdColon)
 
 	// custom completion function
 	c.BashCompletionFunction = bash_completion_func
@@ -75,6 +75,7 @@ func TestBashCompletions(t *testing.T) {
 	check(t, str, "_cobra-test_echo")
 	check(t, str, "_cobra-test_echo_times")
 	check(t, str, "_cobra-test_print")
+	check(t, str, "_cobra-test_cmd__colon")
 
 	// check for required flags
 	check(t, str, `must_have_one_flag+=("--introot=")`)

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -143,6 +143,12 @@ var cmdVersion2 = &Command{
 	},
 }
 
+var cmdColon = &Command{
+	Use: "cmd:colon",
+	Run: func(cmd *Command, args []string) {
+	},
+}
+
 func flagInit() {
 	cmdEcho.ResetFlags()
 	cmdPrint.ResetFlags()


### PR DESCRIPTION
This makes completions work with commands that have a colon in the name.  The issue came up when using [cmdns](https://github.com/gosuri/cmdns), but probably isn't limited to cases where this is used.