### PR TITLE
Use readline's default filename completion if completion fails

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -235,9 +235,9 @@ func postscript(out *bytes.Buffer, name string) {
 
 `, name)
 	fmt.Fprintf(out, `if [[ $(type -t compopt) = "builtin" ]]; then
-    complete -F __start_%s %s
+    complete -o default -F __start_%s %s
 else
-    complete -o nospace -F __start_%s %s
+    complete -o default -o nospace -F __start_%s %s
 fi
 
 `, name, name, name, name)


### PR DESCRIPTION
If the `compspec` generates no matches it should use bash file name completion instead.