### PR TITLE
Use nil instead of len for arg check.

### DIFF
--- a/command.go
+++ b/command.go
@@ -635,7 +635,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	var args []string
 
 	// Workaround FAIL with "go test -v" or "cobra.test -test.v", see #155
-	if len(c.args) == 0 && filepath.Base(os.Args[0]) != "cobra.test" {
+	if c.args == nil && filepath.Base(os.Args[0]) != "cobra.test" {
 		args = os.Args[1:]
 	} else {
 		args = c.args


### PR DESCRIPTION
The fix in #155 for go test -v breaks SetArgs().

```go
package main

import (
	"fmt"
	"strings"

	"github.com/spf13/cobra"
)

func main() {

	var cmdPrint = &cobra.Command{
		Use:   "print [string to print]",
		Short: "Print anything to the screen",
		Long: `print is for printing anything back to the screen.
        For many years people have printed back to the screen.
        `,
		Run: func(cmd *cobra.Command, args []string) {
			fmt.Println("Print: " + strings.Join(args, " "))
		},
	}

	cmdPrint.SetArgs([]string{})

	cmdPrint.Execute()
}
```

```bash
meddling_monk at BorgCube in /media/meddling_monk/Bear/dev/golang/src/github.com/JReyLBC/testCobra 
$ go run test_cobra1.go abc
Print: abc
```

Checking if args is nil, instead of having a zero length, honors the use of SetArgs(), and doesn't break go test -v.
