### PR TITLE
Must only add "[flags]" to the end of usage if not yet present

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -27,11 +27,12 @@ import (
 )
 
 var templateFuncs template.FuncMap = template.FuncMap{
-	"trim":           strings.TrimSpace,
-	"trimRightSpace": trimRightSpace,
-	"rpad":           rpad,
-	"gt":             Gt,
-	"eq":             Eq,
+	"trim":               strings.TrimSpace,
+	"trimRightSpace":     trimRightSpace,
+	"appendIfNotPresent": appendIfNotPresent,
+	"rpad":               rpad,
+	"gt":                 Gt,
+	"eq":                 Eq,
 }
 
 var initializers []func()
@@ -109,6 +110,14 @@ func Eq(a interface{}, b interface{}) bool {
 
 func trimRightSpace(s string) string {
 	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// appendIfNotPresent will append stringToAppend to the end of s, but only if it's not yet present in s
+func appendIfNotPresent(s, stringToAppend string) string {
+	if strings.Contains(s, stringToAppend) {
+		return s
+	}
+	return s + " " + stringToAppend
 }
 
 //rpad adds padding to the right of a string

--- a/command.go
+++ b/command.go
@@ -263,7 +263,7 @@ func (c *Command) UsageTemplate() string {
 		return c.parent.UsageTemplate()
 	} else {
 		return `Usage:{{if .Runnable}}
-  {{.UseLine}}{{if .HasFlags}} [flags]{{end}}{{end}}{{if .HasSubCommands}}
+  {{if .HasFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasSubCommands}}
   {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
 
 Aliases:


### PR DESCRIPTION
The commander must not infer that every command wants `[flags]` appended at the end of the usage string - some commands actually can't take flags there, for example something like:

```
rsh [flags] host -- REMOTE_COMMAND
```

This PR makes `[flags]` to only be added if it's not yet in the body of the usage string.