### PR TITLE
Advanced custom bash completion of flags

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	BashCompFilenameExt     = "cobra_annotation_bash_completion_filename_extentions"
+	BashCompCustom          = "cobra_annotation_bash_completion_custom"
 	BashCompOneRequiredFlag = "cobra_annotation_bash_completion_one_required_flag"
 	BashCompSubdirsInDir    = "cobra_annotation_bash_completion_subdirs_in_dir"
 )
@@ -318,6 +319,20 @@ func writeFlagHandler(name string, annotations map[string][]string, w io.Writer)
 			if err != nil {
 				return err
 			}
+		case BashCompCustom:
+			_, err := fmt.Fprintf(w, "    flags_with_completion+=(%q)\n", name)
+			if err != nil {
+				return err
+			}
+			if len(value) > 0 {
+				handlers := strings.Join(value, "; ")
+				_, err = fmt.Fprintf(w, "    flags_completion+=(%q)\n", handlers)
+			} else {
+				_, err = fmt.Fprintf(w, "    flags_completion+=(:)\n")
+			}
+			if err != nil {
+				return err
+			}
 		case BashCompSubdirsInDir:
 			_, err := fmt.Fprintf(w, "    flags_with_completion+=(%q)\n", name)
 
@@ -538,6 +553,12 @@ func (cmd *Command) MarkFlagFilename(name string, extensions ...string) error {
 	return MarkFlagFilename(cmd.Flags(), name, extensions...)
 }
 
+// MarkFlagCustom adds the BashCompCustom annotation to the named flag, if it exists.
+// Generated bash autocompletion will call the bash function f for the flag.
+func (cmd *Command) MarkFlagCustom(name string, f string) error {
+	return MarkFlagCustom(cmd.Flags(), name, f)
+}
+
 // MarkPersistentFlagFilename adds the BashCompFilenameExt annotation to the named persistent flag, if it exists.
 // Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
 func (cmd *Command) MarkPersistentFlagFilename(name string, extensions ...string) error {
@@ -548,4 +569,10 @@ func (cmd *Command) MarkPersistentFlagFilename(name string, extensions ...string
 // Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
 func MarkFlagFilename(flags *pflag.FlagSet, name string, extensions ...string) error {
 	return flags.SetAnnotation(name, BashCompFilenameExt, extensions)
+}
+
+// MarkFlagCustom adds the BashCompCustom annotation to the named flag in the flag set, if it exists.
+// Generated bash autocompletion will call the bash function f for the flag.
+func MarkFlagCustom(flags *pflag.FlagSet, name string, f string) error {
+	return flags.SetAnnotation(name, BashCompCustom, []string{f})
 }

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -189,6 +189,8 @@ __handle_noun()
 
     if __contains_word "${words[c]}" "${must_have_one_noun[@]}"; then
         must_have_one_noun=()
+    elif __contains_word "${words[c]%s}" "${must_have_one_noun[@]}"; then
+        must_have_one_noun=()
     fi
 
     nouns+=("${words[c]}")

--- a/bash_completions.md
+++ b/bash_completions.md
@@ -147,3 +147,35 @@ hello.yml                     test.json
 ```
 
 So while there are many other files in the CWD it only shows me subdirs and those with valid extensions.
+
+# Specifiy custom flag completion
+
+Similar to the filename completion and filtering usingn cobra.BashCompFilenameExt, you can specifiy
+a custom flag completion function with cobra.BashCompCustom:
+
+```go
+	annotation := make(map[string][]string)
+	annotation[cobra.BashCompFilenameExt] = []string{"__kubectl_get_namespaces"}
+
+	flag := &pflag.Flag{
+		Name:        "namespace",
+		Usage:       usage,
+		Annotations: annotation,
+	}
+	cmd.Flags().AddFlag(flag)
+```
+
+In addition add the `__handle_namespace_flag` implementation in the `BashCompletionFunction`
+value, e.g.:
+
+```bash
+__kubectl_get_namespaces()
+{
+    local template
+    template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
+    local kubectl_out
+    if kubectl_out=$(kubectl get -o template --template="${template}" namespace 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubectl_out}[*]" -- "$cur" ) )
+    fi
+}
+```

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -62,6 +62,11 @@ func TestBashCompletions(t *testing.T) {
 	c.Flags().StringVar(&flagvalExt, "filename-ext", "", "Enter a filename (extension limited)")
 	c.MarkFlagFilename("filename-ext")
 
+	// filename extensions
+	var flagvalCustom string
+	c.Flags().StringVar(&flagvalCustom, "custom", "", "Enter a filename (extension limited)")
+	c.MarkFlagCustom("custom", "__complete_custom")
+
 	// subdirectories in a given directory
 	var flagvalTheme string
 	c.Flags().StringVar(&flagvalTheme, "theme", "", "theme to use (located in /themes/THEMENAME/)")
@@ -88,6 +93,8 @@ func TestBashCompletions(t *testing.T) {
 	check(t, str, `flags_completion+=("_filedir")`)
 	// check for filename extension flags
 	check(t, str, `flags_completion+=("__handle_filename_extension_flag json|yaml|yml")`)
+	// check for custom flags
+	check(t, str, `flags_completion+=("__complete_custom")`)
 	// check for subdirs_in_dir flags
 	check(t, str, `flags_completion+=("__handle_subdirs_in_dir_flag themes")`)
 


### PR DESCRIPTION
![kubectl-completion](https://cloud.githubusercontent.com/assets/730123/13912472/b002d1c6-ef3d-11e5-8907-b8f7a8876024.gif)

- add completion after `--flag=` or `--flag=abc`
- add flag annotation for custom flag completion, like e.g. for `--namespace=` in Kubernetes kubectl