### PR TITLE
Add noun aliases

### DIFF
--- a/bash_completions.md
+++ b/bash_completions.md
@@ -80,7 +80,7 @@ The `BashCompletionFunction` option is really only valid/useful on the root comm
 In the above example "pod" was assumed to already be typed. But if you want `kubectl get [tab][tab]` to show a list of valid "nouns" you have to set them. Simplified code from `kubectl get` looks like:
 
 ```go
-validArgs []string = { "pods", "nodes", "services", "replicationControllers" }
+validArgs []string = { "pod", "node", "service", "replicationcontroller" }
 
 cmd := &cobra.Command{
 	Use:     "get [(-o|--output=)json|yaml|template|...] (RESOURCE [NAME] | RESOURCE/NAME ...)",
@@ -99,8 +99,33 @@ Notice we put the "ValidArgs" on the "get" subcommand. Doing so will give result
 
 ```bash
 # kubectl get [tab][tab]
-nodes                 pods                    replicationControllers  services
+node                 pod                    replicationcontroller  service
 ```
+
+## Plural form and shortcuts for nouns
+
+If your nouns have a number of aliases, you can define them alongside `ValidArgs` using `ArgAliases`:
+
+```go`
+argAliases []string = { "pods", "nodes", "services", "svc", "replicationcontrollers", "rc" }
+
+cmd := &cobra.Command{
+    ...
+	ValidArgs:  validArgs,
+	ArgAliases: argAliases
+}
+```
+
+The aliases are not shown to the user on tab completion, but they are accepted as valid nouns by
+the completion aglorithm if entered manually, e.g. in:
+
+```bash
+# kubectl get rc [tab][tab]
+backend        frontend       database 
+```
+
+Note that without declaring `rc` as an alias, the completion algorithm would show the list of nouns
+in this example again instead of the replication controllers.
 
 ## Mark flags as required
 

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -43,8 +43,12 @@ func TestBashCompletions(t *testing.T) {
 	c.MarkFlagRequired("introot")
 
 	// valid nouns
-	validArgs := []string{"pods", "nodes", "services", "replicationControllers"}
+	validArgs := []string{"pod", "node", "service", "replicationcontroller"}
 	c.ValidArgs = validArgs
+
+	// noun aliases
+	argAliases := []string{"pods", "nodes", "services", "replicationcontrollers", "po", "no", "svc", "rc"}
+	c.ArgAliases = argAliases
 
 	// filename
 	var flagval string
@@ -88,7 +92,11 @@ func TestBashCompletions(t *testing.T) {
 	// check for custom completion function
 	check(t, str, `COMPREPLY=( "hello" )`)
 	// check for required nouns
-	check(t, str, `must_have_one_noun+=("pods")`)
+	check(t, str, `must_have_one_noun+=("pod")`)
+	// check for noun aliases
+	check(t, str, `noun_aliases+=("pods")`)
+	check(t, str, `noun_aliases+=("rc")`)
+	checkOmit(t, str, `must_have_one_noun+=("pods")`)
 	// check for filename extension flags
 	check(t, str, `flags_completion+=("_filedir")`)
 	// check for filename extension flags

--- a/command.go
+++ b/command.go
@@ -45,8 +45,11 @@ type Command struct {
 	Long string
 	// Examples of how to use the command
 	Example string
-	// List of all valid non-flag arguments, used for bash completions *TODO* actually validate these
+	// List of all valid non-flag arguments that are accepted in bash completions
 	ValidArgs []string
+	// List of aliases for ValidArgs. These are not suggested to the user in the bash
+	// completion, but accepted if entered manually.
+	ArgAliases []string
 	// Custom functions used by the bash autocompletion generator
 	BashCompletionFunction string
 	// Is this command deprecated and should print this string when used?


### PR DESCRIPTION
Example:
- "rc" for replicationcontroller
- "pods" for "pod".