### PR TITLE
Update root.go to fix golint bug with comment

### DIFF
--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -24,7 +24,7 @@ import (
 var cfgFile string
 var userLicense string
 
-// This represents the base command when called without any subcommands
+// RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "cobra",
 	Short: "A generator for Cobra based Applications",


### PR DESCRIPTION
Fix the name in the comment to fix a golint bug by not having the variable name begin the comment.