### PR TITLE
Fixing golint warnings

### DIFF
--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -25,7 +25,7 @@ func check(t *testing.T, found, expected string) {
 
 // World worst custom function, just keep telling you to enter hello!
 const (
-	bash_completion_func = `__custom_func() {
+	bashCompletionFunc = `__custom_func() {
 COMPREPLY=( "hello" )
 }
 `
@@ -37,7 +37,7 @@ func TestBashCompletions(t *testing.T) {
 	c.AddCommand(cmdEcho, cmdPrint, cmdDeprecated, cmdColon)
 
 	// custom completion function
-	c.BashCompletionFunction = bash_completion_func
+	c.BashCompletionFunction = bashCompletionFunc
 
 	// required flag
 	c.MarkFlagRequired("introot")

--- a/cobra.go
+++ b/cobra.go
@@ -26,7 +26,7 @@ import (
 	"unicode"
 )
 
-var templateFuncs template.FuncMap = template.FuncMap{
+var templateFuncs = template.FuncMap{
 	"trim":               strings.TrimSpace,
 	"trimRightSpace":     trimRightSpace,
 	"appendIfNotPresent": appendIfNotPresent,
@@ -39,7 +39,7 @@ var initializers []func()
 
 // automatic prefix matching can be a dangerous thing to automatically enable in CLI tools.
 // Set this to true to enable it
-var EnablePrefixMatching bool = false
+var EnablePrefixMatching = false
 
 //AddTemplateFunc adds a template function that's available to Usage and Help
 //template generation.

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -196,7 +196,7 @@ func isEmpty(path string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		list, err := f.Readdir(-1)
+		list, _ := f.Readdir(-1)
 		// f.Close() - see bug fix above
 		return len(list) == 0, nil
 	}

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -24,7 +24,7 @@ import (
 var cfgFile string
 var userLicense string
 
-// This represents the base command when called without any subcommands
+// RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "cobra",
 	Short: "A generator for Cobra based Applications",

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -454,10 +454,10 @@ func TestGrandChildSameName(t *testing.T) {
 
 func TestUsage(t *testing.T) {
 	x := fullSetupTest("help")
-	checkResultContains(t, x, cmdRootWithRun.Use + " [flags]")
+	checkResultContains(t, x, cmdRootWithRun.Use+" [flags]")
 	x = fullSetupTest("help customflags")
 	checkResultContains(t, x, cmdCustomFlags.Use)
-	checkResultOmits(t, x, cmdCustomFlags.Use + " [flags]")
+	checkResultOmits(t, x, cmdCustomFlags.Use+" [flags]")
 }
 
 func TestFlagLong(t *testing.T) {
@@ -752,7 +752,7 @@ func TestVisitParents(t *testing.T) {
 }
 
 func TestRunnableRootCommandNilInput(t *testing.T) {
-	empty_arg := make([]string, 0)
+	var emptyArg []string
 	c := initializeWithRootCmd()
 
 	buf := new(bytes.Buffer)
@@ -760,7 +760,7 @@ func TestRunnableRootCommandNilInput(t *testing.T) {
 	c.SetOutput(buf)
 	cmdEcho.AddCommand(cmdTimes)
 	c.AddCommand(cmdPrint, cmdEcho)
-	c.SetArgs(empty_arg)
+	c.SetArgs(emptyArg)
 
 	err := c.Execute()
 	if err != nil {
@@ -863,7 +863,7 @@ func TestFlagAccess(t *testing.T) {
 }
 
 func TestNoNRunnableRootCommandNilInput(t *testing.T) {
-	args := make([]string, 0)
+	var args []string
 	c := initialize()
 
 	buf := new(bytes.Buffer)

--- a/command.go
+++ b/command.go
@@ -132,9 +132,8 @@ func (c *Command) getOut(def io.Writer) io.Writer {
 
 	if c.HasParent() {
 		return c.parent.Out()
-	} else {
-		return def
 	}
+	return def
 }
 
 func (c *Command) Out() io.Writer {
@@ -194,14 +193,13 @@ func (c *Command) UsageFunc() (f func(*Command) error) {
 
 	if c.HasParent() {
 		return c.parent.UsageFunc()
-	} else {
-		return func(c *Command) error {
-			err := tmpl(c.Out(), c.UsageTemplate(), c)
-			if err != nil {
-				fmt.Print(err)
-			}
-			return err
+	}
+	return func(c *Command) error {
+		err := tmpl(c.Out(), c.UsageTemplate(), c)
+		if err != nil {
+			fmt.Print(err)
 		}
+		return err
 	}
 }
 
@@ -223,35 +221,32 @@ func (c *Command) HelpFunc() func(*Command, []string) {
 	}
 }
 
-var minUsagePadding int = 25
+var minUsagePadding = 25
 
 func (c *Command) UsagePadding() int {
 	if c.parent == nil || minUsagePadding > c.parent.commandsMaxUseLen {
 		return minUsagePadding
-	} else {
-		return c.parent.commandsMaxUseLen
 	}
+	return c.parent.commandsMaxUseLen
 }
 
-var minCommandPathPadding int = 11
+var minCommandPathPadding = 11
 
 //
 func (c *Command) CommandPathPadding() int {
 	if c.parent == nil || minCommandPathPadding > c.parent.commandsMaxCommandPathLen {
 		return minCommandPathPadding
-	} else {
-		return c.parent.commandsMaxCommandPathLen
 	}
+	return c.parent.commandsMaxCommandPathLen
 }
 
-var minNamePadding int = 11
+var minNamePadding = 11
 
 func (c *Command) NamePadding() int {
 	if c.parent == nil || minNamePadding > c.parent.commandsMaxNameLen {
 		return minNamePadding
-	} else {
-		return c.parent.commandsMaxNameLen
 	}
+	return c.parent.commandsMaxNameLen
 }
 
 func (c *Command) UsageTemplate() string {
@@ -261,8 +256,8 @@ func (c *Command) UsageTemplate() string {
 
 	if c.HasParent() {
 		return c.parent.UsageTemplate()
-	} else {
-		return `Usage:{{if .Runnable}}
+	}
+	return `Usage:{{if .Runnable}}
   {{if .HasFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasSubCommands}}
   {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
 
@@ -287,7 +282,6 @@ Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
-	}
 }
 
 func (c *Command) HelpTemplate() string {
@@ -297,11 +291,10 @@ func (c *Command) HelpTemplate() string {
 
 	if c.HasParent() {
 		return c.parent.HelpTemplate()
-	} else {
-		return `{{with or .Long .Short }}{{. | trim}}
+	}
+	return `{{with or .Long .Short }}{{. | trim}}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
-	}
 }
 
 // Really only used when casting a command to a commander
@@ -603,9 +596,8 @@ func (c *Command) errorMsgFromParse() string {
 
 	if len(x) > 0 {
 		return x[0]
-	} else {
-		return ""
 	}
+	return ""
 }
 
 // Call execute to use the args (os.Args[1:] by default)
@@ -786,18 +778,18 @@ main:
 	}
 }
 
-// Convenience method to Print to the defined output
+// Print is a convenience method to Print to the defined output
 func (c *Command) Print(i ...interface{}) {
 	fmt.Fprint(c.Out(), i...)
 }
 
-// Convenience method to Println to the defined output
+// Println is a convenience method to Println to the defined output
 func (c *Command) Println(i ...interface{}) {
 	str := fmt.Sprintln(i...)
 	c.Print(str)
 }
 
-// Convenience method to Printf to the defined output
+// Printf is a convenience method to Printf to the defined output
 func (c *Command) Printf(format string, i ...interface{}) {
 	str := fmt.Sprintf(format, i...)
 	c.Print(str)
@@ -908,7 +900,7 @@ func (c *Command) Name() string {
 	return name
 }
 
-// Determine if a given string is an alias of the command.
+// HasAlias determines if a given string is an alias of the command.
 func (c *Command) HasAlias(s string) bool {
 	for _, a := range c.Aliases {
 		if a == s {
@@ -926,12 +918,12 @@ func (c *Command) HasExample() bool {
 	return len(c.Example) > 0
 }
 
-// Determine if the command is itself runnable
+// Runnable determines if the command is itself runnable
 func (c *Command) Runnable() bool {
 	return c.Run != nil || c.RunE != nil
 }
 
-// Determine if the command has children commands
+// HasSubCommands determines if the command has children commands
 func (c *Command) HasSubCommands() bool {
 	return len(c.commands) > 0
 }
@@ -1123,7 +1115,7 @@ func (c *Command) HasInheritedFlags() bool {
 	return c.InheritedFlags().HasFlags()
 }
 
-// Climbs up the command tree looking for matching flag
+// Flag climbs up the command tree looking for matching flag
 func (c *Command) Flag(name string) (flag *flag.Flag) {
 	flag = c.Flags().Lookup(name)
 
@@ -1146,13 +1138,14 @@ func (c *Command) persistentFlag(name string) (flag *flag.Flag) {
 	return
 }
 
-// Parses persistent flag tree & local flags
+// ParseFlags parses persistent flag tree & local flags
 func (c *Command) ParseFlags(args []string) (err error) {
 	c.mergePersistentFlags()
 	err = c.Flags().Parse(args)
 	return
 }
 
+// Parent returns a commands parent command
 func (c *Command) Parent() *Command {
 	return c.parent
 }

--- a/command_notwin.go
+++ b/command_notwin.go
@@ -2,4 +2,4 @@
 
 package cobra
 
-var preExecHookFn func(*Command) = nil
+var preExecHookFn func(*Command)

--- a/doc/man_docs_test.go
+++ b/doc/man_docs_test.go
@@ -149,9 +149,8 @@ func AssertNextLineEquals(scanner *bufio.Scanner, expectedLine string) error {
 		line := scanner.Text()
 		if line == expectedLine {
 			return nil
-		} else {
-			return fmt.Errorf("AssertNextLineEquals: got %#v, not %#v", line, expectedLine)
 		}
+		return fmt.Errorf("AssertNextLineEquals: got %#v, not %#v", line, expectedLine)
 	}
 
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
* Moving final return outside of if-else
* Removing type declarations that Go can infer from values
* Cleaning up some existing comments
* Changing snake_case variables to camelCase
* Declaring slices using var instead of make
* Removing unused `err`
* Small gofmt change