### PR TITLE
Adding custom license functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ a custom license:
 license:
   header: This file is part of {{ .appName }}.
   text: |
-    {{ .Copyright }}
+    {{ .copyright }}
 
     This is my license. There are many like it, but this one is mine.
     My license is my best friend. It is my life. I must master it as I must

--- a/README.md
+++ b/README.md
@@ -226,11 +226,25 @@ The cobra generator will be easier to use if you provide a simple configuration
 file which will help you eliminate providing a bunch of repeated information in
 flags over and over.
 
-an example ~/.cobra.yaml file:
+An example ~/.cobra.yaml file:
 
 ```yaml
 author: Steve Francia <spf@spf13.com>
 license: MIT
+```
+
+You can specify no license by setting `license` to `none` or you can specify
+a custom license:
+
+```yaml
+license:
+  header: This file is part of {{ .appName }}.
+  text: |
+    {{ .Copyright }}
+
+    This is my license. There are many like it, but this one is mine.
+    My license is my best friend. It is my life. I must master it as I must
+    master my life.  
 ```
 
 ## Manually implementing Cobra

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -319,6 +319,15 @@ func whichLicense() string {
 
 	// default to viper's setting
 
+	if viper.IsSet("license.header") || viper.IsSet("license.text") {
+		if custom, ok := Licenses["custom"]; ok {
+			custom.Header = viper.GetString("license.header")
+			custom.Text = viper.GetString("license.text")
+			Licenses["custom"] = custom
+			return "custom"
+		}
+	}
+
 	return matchLicense(viper.GetString("license"))
 }
 

--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -88,20 +88,23 @@ func initializePath(path string) {
 }
 
 func createLicenseFile() {
-	data := make(map[string]interface{})
-
-	// Try to remove the email address, if any
-	data["copyright"] = strings.Split(copyrightLine(), " <")[0]
-
-	data["appName"] = projectName()
-
-	// Get license and generate the template from text and data.
 	lic := getLicense()
-	r, _ := templateToReader(lic.Text, data)
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(r)
-	if template := buf.String(); template != "" {
-		err := writeTemplateToFile(ProjectPath(), "LICENSE", template, data)
+
+	// Don't bother writing a LICENSE file if there is no text.
+	if lic.Text != "" {
+		data := make(map[string]interface{})
+
+		// Try to remove the email address, if any
+		data["copyright"] = strings.Split(copyrightLine(), " <")[0]
+
+		data["appName"] = projectName()
+
+		// Generate license template from text and data.
+		r, _ := templateToReader(lic.Text, data)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r)
+
+		err := writeTemplateToFile(ProjectPath(), "LICENSE", buf.String(), data)
 		_ = err
 		// if err != nil {
 		// 	er(err)

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -46,6 +46,12 @@ func matchLicense(in string) string {
 func init() {
 	Licenses = make(map[string]License)
 
+	// Allows a user to not use a license.
+	Licenses["none"] = License{"None", []string{"none", "false"}, "", ""}
+
+	// Allows a user to use config for a custom license.
+	Licenses["custom"] = License{"Custom", []string{}, "", ""}
+
 	Licenses["apache"] = License{
 		Name:            "Apache 2.0",
 		PossibleMatches: []string{"apache", "apache20", "apache 2.0", "apache2.0", "apache-2.0"},
@@ -428,22 +434,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Licenses["gpl3"] = License{
 		Name:            "GNU General Public License 3.0",
 		PossibleMatches: []string{"gpl3", "gpl", "gnu gpl3", "gnu gpl"},
-		Header: `{{ .copyright }}
+		Header: `
+This file is part of {{ .appName }}.
 
- This file is part of {{ .appName }}.
+{{ .appName }} is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
- {{ .appName }} is free software: you can redistribute it and/or modify
- it under the terms of the GNU Lesser General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+{{ .appName }} is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
 
- {{ .appName }} is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public License
- along with {{ .appName }}. If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with {{ .appName }}. If not, see <http://www.gnu.org/licenses/>.
 	   `,
 		Text: `                    GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -46,25 +46,13 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
 	RootCmd.PersistentFlags().StringVarP(&projectBase, "projectbase", "b", "", "base project directory, e.g. github.com/spf13/")
 	RootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "Author name for copyright attribution")
-	RootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "Name of license for the project (can provide `licensetext` in config)")
+	RootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "Name of license for the project (can provide `license` in config)")
 	RootCmd.PersistentFlags().Bool("viper", true, "Use Viper for configuration")
 	viper.BindPFlag("author", RootCmd.PersistentFlags().Lookup("author"))
 	viper.BindPFlag("projectbase", RootCmd.PersistentFlags().Lookup("projectbase"))
 	viper.BindPFlag("useViper", RootCmd.PersistentFlags().Lookup("viper"))
 	viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
 	viper.SetDefault("license", "apache")
-	viper.SetDefault("licenseText", `
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-`)
 }
 
 // Read in config file and ENV variables if set.


### PR DESCRIPTION
* Refactoring code that unnecessarily declares a map before making it.
* Cleaning up gpl3 formatting to match other licenses.
* Adding functionality that allows specifying custom license header
  and text in cobra config (#243).
* Using license header and text as templates so that they can use
  template variables (for custom and gpl3 licenses).
* Adding ability to specify no license (#249).
* Adding custom license example to README.