### PR TITLE
Fixed Small Comment Typo

### DIFF
--- a/command.go
+++ b/command.go
@@ -747,7 +747,7 @@ func (c *Command) AddCommand(cmds ...*Command) {
 	}
 }
 
-// AddCommand removes one or more commands from a parent command.
+// RemoveCommand removes one or more commands from a parent command.
 func (c *Command) RemoveCommand(cmds ...*Command) {
 	commands := []*Command{}
 main:


### PR DESCRIPTION
small error in function description.
[ci skip]