### PR TITLE
Fixes issue #276.

### DIFF
--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -100,15 +100,25 @@ func guessCmdDir() string {
 func guessImportPath() string {
 	guessProjectPath()
 
-	if !strings.HasPrefix(projectPath, getSrcPath()) {
-		er("Cobra only supports project within $GOPATH")
+	for _, path := range getSrcPaths() {
+		if strings.HasPrefix(projectPath, path) {
+			return filepath.ToSlash(filepath.Clean(strings.TrimPrefix(projectPath, path)))
+		}
 	}
 
-	return filepath.ToSlash(filepath.Clean(strings.TrimPrefix(projectPath, getSrcPath())))
+	er("Cobra only supports project within $GOPATH")
+
+	// not reached
+	return ""
 }
 
-func getSrcPath() string {
-	return filepath.Join(os.Getenv("GOPATH"), "src") + string(os.PathSeparator)
+func getSrcPaths() []string {
+	paths := strings.Split(os.Getenv("GOPATH"), ":")
+	for i, path := range paths {
+		paths[i] = filepath.Join(path, "src") + string(os.PathSeparator)
+	}
+
+	return paths
 }
 
 func projectName() string {
@@ -140,7 +150,7 @@ func guessProjectPath() {
 		}
 	}
 
-	srcPath := getSrcPath()
+	srcPaths := getSrcPaths()
 	// if provided, inspect for logical locations
 	if strings.ContainsRune(inputPath, os.PathSeparator) {
 		if filepath.IsAbs(inputPath) || filepath.HasPrefix(inputPath, string(os.PathSeparator)) {
@@ -148,6 +158,11 @@ func guessProjectPath() {
 			projectPath = filepath.Clean(inputPath)
 			return
 		}
+
+		if len(srcPaths) > 1 {
+			er("Cobra can't guess project path because $GOPATH contains multiple paths")
+		}
+
 		// If not absolute but contains slashes,
 		// assuming it means create it from $GOPATH
 		count := strings.Count(inputPath, string(os.PathSeparator))
@@ -155,10 +170,10 @@ func guessProjectPath() {
 		switch count {
 		// If only one directory deep, assume "github.com"
 		case 1:
-			projectPath = filepath.Join(srcPath, "github.com", inputPath)
+			projectPath = filepath.Join(srcPaths[0], "github.com", inputPath)
 			return
 		case 2:
-			projectPath = filepath.Join(srcPath, inputPath)
+			projectPath = filepath.Join(srcPaths[0], inputPath)
 			return
 		default:
 			er("Unknown directory")
@@ -173,7 +188,11 @@ func guessProjectPath() {
 			}
 			er(err)
 		} else {
-			projectPath = filepath.Join(srcPath, projectBase, inputPath)
+			if len(srcPaths) > 1 {
+				er("Cobra can't guess project path because $GOPATH contains multiple paths")
+			}
+
+			projectPath = filepath.Join(srcPaths[0], projectBase, inputPath)
 			return
 		}
 	}


### PR DESCRIPTION
This commit fixes issue #276. If $GOPATH includes multiple paths (as
allowed by the spec), Cobra cannot guess the project path, so now init
bails out if a relative path is given. The original behaviour is not
changed, if $GOPATH only contains a single path (as in most cases).