### PR TITLE
Support validation of positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,38 @@ A flag can also be assigned locally which will only apply to that specific comma
 RootCmd.Flags().StringVarP(&Source, "source", "s", "", "Source directory to read from")
 ```
 
+### Specify if you command takes arguments
+
+There are multiple options for how a command can handle unknown arguments which can be set in `TakesArgs`
+- `Legacy`
+- `None`
+- `Arbitrary`
+- `ValidOnly`
+
+`Legacy` (or default) the rules are as follows:
+- root commands with no subcommands can take arbitrary arguments
+- root commands with subcommands will do subcommand validity checking
+- subcommands will always accept arbitrary arguments and do no subsubcommand validity checking
+
+`None` the command will be rejected if there are any left over arguments after parsing flags.
+
+`Arbitrary` any additional values left after parsing flags will be passed in to your `Run` function.
+
+`ValidOnly` you must define all valid (non-subcommand) arguments to your command. These are defined in a slice name ValidArgs. For example a command which only takes the argument "one" or "two" would be defined as:
+
+```go
+var HugoCmd = &cobra.Command{
+        Use:   "hugo",
+        Short: "Hugo is a very fast static site generator",
+	ValidArgs: []string{"one", "two", "three", "four"}
+	TakesArgs: cobra.ValidOnly
+        Run: func(cmd *cobra.Command, args []string) {
+            // args will only have the values one, two, three, four
+	    // or the cmd.Execute() will fail.
+        },
+    }
+```
+
 ### Bind Flags with Config
 
 You can also bind your flags with [viper](https://github.com/spf13/viper):

--- a/README.md
+++ b/README.md
@@ -462,36 +462,34 @@ A flag can also be assigned locally which will only apply to that specific comma
 RootCmd.Flags().StringVarP(&Source, "source", "s", "", "Source directory to read from")
 ```
 
-### Specify if you command takes arguments
+## Positional and Custom Arguments
 
-There are multiple options for how a command can handle unknown arguments which can be set in `TakesArgs`
-- `Legacy`
-- `None`
-- `Arbitrary`
-- `ValidOnly`
+Validation of positional arguments can be specified using the `Args` field.
 
-`Legacy` (or default) the rules are as follows:
-- root commands with no subcommands can take arbitrary arguments
-- root commands with subcommands will do subcommand validity checking
-- subcommands will always accept arbitrary arguments and do no subsubcommand validity checking
+The follow validators are built in:
 
-`None` the command will be rejected if there are any left over arguments after parsing flags.
+- `NoArgs` - the command will report an error if there are any positional args.
+- `ArbitraryArgs` - the command will accept any args.
+- `OnlyValidArgs` - the command will report an error if there are any positional args that are not in the ValidArgs list.
+- `MinimumNArgs(int)` - the command will report an error if there are not at least N positional args.
+- `MaximumNArgs(int)` - the command will report an error if there are more than N positional args.
+- `ExactArgs(int)` - the command will report an error if there are not exactly N positional args.
+- `RangeArgs(min, max)` - the command will report an error if the number of args is not between the minimum and maximum number of expected args.
 
-`Arbitrary` any additional values left after parsing flags will be passed in to your `Run` function.
-
-`ValidOnly` you must define all valid (non-subcommand) arguments to your command. These are defined in a slice name ValidArgs. For example a command which only takes the argument "one" or "two" would be defined as:
+A custom validator can be provided like this:
 
 ```go
-var HugoCmd = &cobra.Command{
-        Use:   "hugo",
-        Short: "Hugo is a very fast static site generator",
-	ValidArgs: []string{"one", "two", "three", "four"}
-	TakesArgs: cobra.ValidOnly
-        Run: func(cmd *cobra.Command, args []string) {
-            // args will only have the values one, two, three, four
-	    // or the cmd.Execute() will fail.
-        },
-    }
+
+Args: func validColorArgs(cmd *cobra.Command, args []string) error {
+  if err := cli.RequiresMinArgs(1)(cmd, args); err != nil {
+    return err
+  }
+  if myapp.IsValidColor(args[0]) {
+     return nil
+  }
+  return fmt.Errorf("Invalid color specified: %s", args[0])
+}
+
 ```
 
 ### Bind Flags with Config
@@ -511,6 +509,7 @@ In this example the persistent flag `author` is bound with `viper`.
 when the `--author` flag is not provided by user.
 
 More in [viper documentation](https://github.com/spf13/viper#working-with-flags).
+
 
 ## Example
 

--- a/args.go
+++ b/args.go
@@ -1,0 +1,98 @@
+package cobra
+
+import (
+	"fmt"
+)
+
+type PositionalArgs func(cmd *Command, args []string) error
+
+// Legacy arg validation has the following behaviour:
+// - root commands with no subcommands can take arbitrary arguments
+// - root commands with subcommands will do subcommand validity checking
+// - subcommands will always accept arbitrary arguments
+func legacyArgs(cmd *Command, args []string) error {
+	// no subcommand, always take args
+	if !cmd.HasSubCommands() {
+		return nil
+	}
+
+	// root command with subcommands, do subcommand checking
+	if !cmd.HasParent() && len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
+	}
+	return nil
+}
+
+// NoArgs returns an error if any args are included
+func NoArgs(cmd *Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+	}
+	return nil
+}
+
+// OnlyValidArgs returns an error if any args are not in the list of ValidArgs
+func OnlyValidArgs(cmd *Command, args []string) error {
+	if len(cmd.ValidArgs) > 0 {
+		for _, v := range args {
+			if !stringInSlice(v, cmd.ValidArgs) {
+				return fmt.Errorf("invalid argument %q for %q%s", v, cmd.CommandPath(), cmd.findSuggestions(args[0]))
+			}
+		}
+	}
+	return nil
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ArbitraryArgs never returns an error
+func ArbitraryArgs(cmd *Command, args []string) error {
+	return nil
+}
+
+// MinimumNArgs returns an error if there is not at least N args
+func MinimumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < n {
+			return fmt.Errorf("requires at least %d arg(s), only received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// MaximumNArgs returns an error if there are more than N args
+func MaximumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) > n {
+			return fmt.Errorf("accepts at most %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// ExactArgs returns an error if there are not exactly n args
+func ExactArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("accepts %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// RangeArgs returns an error if the number of args is not within the expected range
+func RangeArgs(min int, max int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < min || len(args) > max {
+			return fmt.Errorf("accepts between %d and %d arg(s), received %d", min, max, len(args))
+		}
+		return nil
+	}
+}

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -117,6 +117,8 @@ func TestBashCompletions(t *testing.T) {
 	// check for filename extension flags
 	check(t, str, `flags_completion+=("_filedir")`)
 	// check for filename extension flags
+	check(t, str, `must_have_one_noun+=("three")`)
+	// check for filename extention flags
 	check(t, str, `flags_completion+=("__handle_filename_extension_flag json|yaml|yml")`)
 	// check for custom flags
 	check(t, str, `flags_completion+=("__complete_custom")`)

--- a/command.go
+++ b/command.go
@@ -27,6 +27,15 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+type Args int
+
+const (
+	Legacy Args = iota
+	Arbitrary
+	ValidOnly
+	None
+)
+
 // Command is just that, a command for your application.
 // E.g.  'go run ...' - 'run' is the command. Cobra requires
 // you to define the usage and description as part of your command
@@ -59,6 +68,8 @@ type Command struct {
 	// but accepted if entered manually.
 	ArgAliases []string
 
+	// Does this command take arbitrary arguments
+	TakesArgs Args
 	// BashCompletionFunction is custom functions used by the bash autocompletion generator.
 	BashCompletionFunction string
 
@@ -472,6 +483,15 @@ func argsMinusFirstX(args []string, x string) []string {
 	return args
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 // Find the target command given the args and command tree
 // Meant to be run on the highest node. Only searches down.
 func (c *Command) Find(args []string) (*Command, []string, error) {
@@ -515,29 +535,51 @@ func (c *Command) Find(args []string) (*Command, []string, error) {
 	commandFound, a := innerfind(c, args)
 	argsWOflags := stripFlags(a, commandFound)
 
-	// no subcommand, always take args
-	if !commandFound.HasSubCommands() {
+	// "Legacy" has some 'odd' characteristics.
+	// - root commands with no subcommands can take arbitrary arguments
+	// - root commands with subcommands will do subcommand validity checking
+	// - subcommands will always accept arbitrary arguments
+	if commandFound.TakesArgs == Legacy {
+		// no subcommand, always take args
+		if !commandFound.HasSubCommands() {
+			return commandFound, a, nil
+		}
+		// root command with subcommands, do subcommand checking
+		if commandFound == c && len(argsWOflags) > 0 {
+			return commandFound, a, fmt.Errorf("unknown command %q for %q%s", argsWOflags[0], commandFound.CommandPath(), c.findSuggestions(argsWOflags))
+		}
 		return commandFound, a, nil
 	}
 
-	// root command with subcommands, do subcommand checking
-	if commandFound == c && len(argsWOflags) > 0 {
-		suggestionsString := ""
-		if !c.DisableSuggestions {
-			if c.SuggestionsMinimumDistance <= 0 {
-				c.SuggestionsMinimumDistance = 2
-			}
-			if suggestions := c.SuggestionsFor(argsWOflags[0]); len(suggestions) > 0 {
-				suggestionsString += "\n\nDid you mean this?\n"
-				for _, s := range suggestions {
-					suggestionsString += fmt.Sprintf("\t%v\n", s)
-				}
-			}
-		}
-		return commandFound, a, fmt.Errorf("unknown command %q for %q%s", argsWOflags[0], commandFound.CommandPath(), suggestionsString)
+	if commandFound.TakesArgs == None && len(argsWOflags) > 0 {
+		return commandFound, a, fmt.Errorf("unknown command %q for %q", argsWOflags[0], commandFound.CommandPath())
 	}
 
+	if commandFound.TakesArgs == ValidOnly && len(commandFound.ValidArgs) > 0 {
+		for _, v := range argsWOflags {
+			if !stringInSlice(v, commandFound.ValidArgs) {
+				return commandFound, a, fmt.Errorf("invalid argument %q for %q%s", v, commandFound.CommandPath(), c.findSuggestions(argsWOflags))
+			}
+		}
+	}
 	return commandFound, a, nil
+}
+
+func (c *Command) findSuggestions(argsWOflags []string) string {
+	if c.DisableSuggestions {
+		return ""
+	}
+	if c.SuggestionsMinimumDistance <= 0 {
+		c.SuggestionsMinimumDistance = 2
+	}
+	suggestionsString := ""
+	if suggestions := c.SuggestionsFor(argsWOflags[0]); len(suggestions) > 0 {
+		suggestionsString += "\n\nDid you mean this?\n"
+		for _, s := range suggestions {
+			suggestionsString += fmt.Sprintf("\t%v\n", s)
+		}
+	}
+	return suggestionsString
 }
 
 // SuggestionsFor provides suggestions for the typedName.


### PR DESCRIPTION
Fixes #42
Branched from #120

Adds a new field `Args` that allows a user to define the expected positional arguments that a command should receive. If a command doesn't receive the expected args it returns an error.

By accepting a validation function users can create their own custom validation for positional args. This PR includes validators for the most common cases.
