### PR TITLE
Merge persistent flags before checking for a help flag

### DIFF
--- a/command.go
+++ b/command.go
@@ -684,6 +684,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 }
 
 func (c *Command) initHelpFlag() {
+	c.mergePersistentFlags()
 	if c.Flags().Lookup("help") == nil {
 		c.Flags().BoolP("help", "h", false, "help for "+c.Name())
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -134,6 +134,21 @@ func Test_DisableFlagParsing(t *testing.T) {
 	}
 }
 
+func TestInitHelpFlagMergesFlags(t *testing.T) {
+	usage := "custom flag"
+	baseCmd := Command{Use: "testcmd"}
+	baseCmd.PersistentFlags().Bool("help", false, usage)
+	cmd := Command{Use: "do"}
+	baseCmd.AddCommand(&cmd)
+
+	cmd.initHelpFlag()
+	actual := cmd.Flags().Lookup("help").Usage
+	if actual != usage {
+		t.Fatalf("Expected the help flag from the base command with usage '%s', " +
+		         "but got the default with usage '%s'", usage, actual)
+	}
+}
+
 func TestCommandsAreSorted(t *testing.T) {
 	EnableCommandSorting = true
 


### PR DESCRIPTION
Small bug fix. Without this change calling `UsageFlags()` in the `Run()` of a command that doesn't have any other flags would use the wrong `help` flag, if  a custom help flag was set as a PersistentFlag() on a parent command.