### PR TITLE
Add Bash support for command-substitute flags

### DIFF
--- a/bash_completions.md
+++ b/bash_completions.md
@@ -143,6 +143,21 @@ and you'll get something like
 -c            --container=  -p            --pod=  
 ```
 
+## Mark flags as substitutes for subcommands
+
+A flag may be sufficient input to a command that would normally require subcommands. Most commonly, this is the case when the flag specifies a file containing operations to run. In this case, we mark the flag as a command substitute:
+
+```go
+cmd.MarkFlagCommandSubstitute("filename")
+```
+
+This will result in something like:
+
+```bash
+# kubectl create [tab][tab]
+--filename=   -f            secret        user
+```
+
 # Specify valid filename extensions for flags that take a filename
 
 In this example we use --filename= and expect to get a json or yaml file as the argument. To make this easier we annotate the --filename flag with valid filename extensions.

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -97,6 +97,16 @@ func TestBashCompletions(t *testing.T) {
 	c.Flags().StringVar(&flagvalTheme, "theme", "", "theme to use (located in /themes/THEMENAME/)")
 	c.Flags().SetAnnotation("theme", BashCompSubdirsInDir, []string{"themes"})
 
+	// command-substitute flag
+	var flagvalCommand string
+	c.Flags().StringVar(&flagvalCommand, "commandflag", "", "This is a command")
+	c.MarkFlagCommandSubstitute("commandflag")
+
+	// persistent command-substitute flag
+	var flagvalPersistentCommand string
+	c.PersistentFlags().StringVar(&flagvalPersistentCommand, "persistent-commandflag", "", "This is a command")
+	c.MarkPersistentFlagCommandSubstitute("persistent-commandflag")
+
 	out := new(bytes.Buffer)
 	c.GenBashCompletion(out)
 	str := out.String()
@@ -110,6 +120,9 @@ func TestBashCompletions(t *testing.T) {
 	// check for required flags
 	check(t, str, `must_have_one_flag+=("--introot=")`)
 	check(t, str, `must_have_one_flag+=("--persistent-filename=")`)
+	// check for command-substitute flags
+	check(t, str, `flag_command_substitutes+=("--commandflag=")`)
+	check(t, str, `flag_command_substitutes+=("--persistent-commandflag=")`)
 	// check for custom completion function
 	check(t, str, `COMPREPLY=( "hello" )`)
 	// check for required nouns


### PR DESCRIPTION
These are useful to mark a flag as taking the place of a command. For example, `kubectl create` can be called using either [a subcommand](http://kubernetes.io/docs/user-guide/kubectl/kubectl_create/#see-also) or by [providing a file as input](http://kubernetes.io/docs/user-guide/kubectl/kubectl_create/):

    kubectl create --filename=file-input.yml

    kubectl create secret generic [...]

This allows the generated Bash completions to reflect this and suggest both commands and command-substitute flags.