### PR TITLE
Sort commands by their names

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -41,6 +41,10 @@ var initializers []func()
 // Set this to true to enable it
 var EnablePrefixMatching = false
 
+//EnableCommandSorting controls sorting of the slice of commands, which is turned on by default.
+//To disable sorting, set it to false.
+var EnableCommandSorting = true
+
 //AddTemplateFunc adds a template function that's available to Usage and Help
 //template generation.
 func AddTemplateFunc(name string, tmplFunc interface{}) {

--- a/command_test.go
+++ b/command_test.go
@@ -133,3 +133,44 @@ func Test_DisableFlagParsing(t *testing.T) {
 		t.Errorf("expected: %v, got: %v", as, targs)
 	}
 }
+
+func TestCommandsAreSorted(t *testing.T) {
+	EnableCommandSorting = true
+
+	originalNames := []string{"middle", "zlast", "afirst"}
+	expectedNames := []string{"afirst", "middle", "zlast"}
+
+	var tmpCommand = &Command{Use: "tmp"}
+
+	for _, name := range(originalNames) {
+		tmpCommand.AddCommand(&Command{Use: name})
+	}
+
+	for i, c := range(tmpCommand.Commands()) {
+		if expectedNames[i] != c.Name() {
+			t.Errorf("expected: %s, got: %s", expectedNames[i], c.Name())
+		}
+	}
+
+	EnableCommandSorting = true
+}
+
+func TestEnableCommandSortingIsDisabled(t *testing.T) {
+	EnableCommandSorting = false
+
+	originalNames := []string{"middle", "zlast", "afirst"}
+
+	var tmpCommand = &Command{Use: "tmp"}
+
+	for _, name := range(originalNames) {
+		tmpCommand.AddCommand(&Command{Use: name})
+	}
+
+	for i, c := range(tmpCommand.Commands()) {
+		if originalNames[i] != c.Name() {
+			t.Errorf("expected: %s, got: %s", originalNames[i], c.Name())
+		}
+	}
+
+	EnableCommandSorting = true
+}


### PR DESCRIPTION
When the number of commands is big, help message become unreadable (It is hard to read "Available Commands" section and find proper command).
Example of output from Kubernetes project(`kubectl --help`):

```
Available Commands:
  get            Display one or many resources
  set            Set specific features on objects
  describe       Show details of a specific resource or group of resources
  create         Create a resource by filename or stdin
  replace        Replace a resource by filename or stdin.
  patch          Update field(s) of a resource using strategic merge patch.
  delete         Delete resources by filenames, stdin, resources and names, or by resources and label selector.
  edit           Edit a resource on the server
  apply          Apply a configuration to a resource by filename or stdin
  namespace      SUPERSEDED: Set and view the current Kubernetes namespace
  logs           Print the logs for a container in a pod.
  rolling-update Perform a rolling update of the given ReplicationController.
  scale          Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job.
  cordon         Mark node as unschedulable
  drain          Drain node in preparation for maintenance
  uncordon       Mark node as schedulable
  attach         Attach to a running container.
  exec           Execute a command in a container.
  port-forward   Forward one or more local ports to a pod.
  proxy          Run a proxy to the Kubernetes API server
  run            Run a particular image on the cluster.
  expose         Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
  autoscale      Auto-scale a Deployment, ReplicaSet, or ReplicationController
  rollout        rollout manages a deployment
  label          Update the labels on a resource
  annotate       Update the annotations on a resource
  taint          Update the taints on one or more nodes
  config         config modifies kubeconfig files
  cluster-info   Display cluster info
  api-versions   Print the supported API versions on the server, in the form of "group/version".
  version        Print the client and server version information.
  explain        Documentation of resources.
  convert        Convert config files between different API versions
  completion     Output shell completion code for the given shell (bash or zsh)
```

After this pr, it will look like:
```
Available Commands:
  annotate       Update the annotations on a resource
  api-versions   Print the supported API versions on the server, in the form of "group/version".
  apply          Apply a configuration to a resource by filename or stdin
  attach         Attach to a running container.
  autoscale      Auto-scale a Deployment, ReplicaSet, or ReplicationController
  cluster-info   Display cluster info
  completion     Output shell completion code for the given shell (bash or zsh)
  config         config modifies kubeconfig files
  convert        Convert config files between different API versions
  cordon         Mark node as unschedulable
  create         Create a resource by filename or stdin
  delete         Delete resources by filenames, stdin, resources and names, or by resources and label selector.
  describe       Show details of a specific resource or group of resources
  drain          Drain node in preparation for maintenance
  edit           Edit a resource on the server
  exec           Execute a command in a container.
  explain        Documentation of resources.
  expose         Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
  get            Display one or many resources
  label          Update the labels on a resource
  logs           Print the logs for a container in a pod.
  namespace      SUPERSEDED: Set and view the current Kubernetes namespace
  patch          Update field(s) of a resource using strategic merge patch.
  port-forward   Forward one or more local ports to a pod.
  proxy          Run a proxy to the Kubernetes API server
  replace        Replace a resource by filename or stdin.
  rolling-update Perform a rolling update of the given ReplicationController.
  rollout        rollout manages a deployment
  run            Run a particular image on the cluster.
  scale          Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job.
  set            Set specific features on objects
  taint          Update the taints on one or more nodes
  uncordon       Mark node as schedulable
  version        Print the client and server version information.
```