### PR TITLE
Fix man page gen bugs

### DIFF
--- a/doc/man_docs.go
+++ b/doc/man_docs.go
@@ -107,18 +107,22 @@ func fillHeader(header *GenManHeader, name string) {
 	}
 }
 
-func manPreamble(out io.Writer, header *GenManHeader, name, short, long string) {
-	dashName := strings.Replace(name, " ", "-", -1)
+func manPreamble(out io.Writer, header *GenManHeader, cmd *cobra.Command, dashedName string) {
+	description := cmd.Long
+	if len(description) == 0 {
+		description = cmd.Short
+	}
+
 	fmt.Fprintf(out, `%% %s(%s)%s
 %% %s
 %% %s
 # NAME
 `, header.Title, header.Section, header.date, header.Source, header.Manual)
-	fmt.Fprintf(out, "%s \\- %s\n\n", dashName, short)
+	fmt.Fprintf(out, "%s \\- %s\n\n", dashedName, cmd.Short)
 	fmt.Fprintf(out, "# SYNOPSIS\n")
-	fmt.Fprintf(out, "**%s** [OPTIONS]\n\n", name)
+	fmt.Fprintf(out, "**%s**\n\n", cmd.UseLine())
 	fmt.Fprintf(out, "# DESCRIPTION\n")
-	fmt.Fprintf(out, "%s\n\n", long)
+	fmt.Fprintf(out, "%s\n\n", description)
 }
 
 func manPrintFlags(out io.Writer, flags *pflag.FlagSet) {
@@ -174,13 +178,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 
 	buf := new(bytes.Buffer)
 
-	short := cmd.Short
-	long := cmd.Long
-	if len(long) == 0 {
-		long = short
-	}
-
-	manPreamble(buf, header, commandName, short, long)
+	manPreamble(buf, header, cmd, dashCommandName)
 	manPrintOptions(buf, cmd)
 	if len(cmd.Example) > 0 {
 		fmt.Fprintf(buf, "# EXAMPLE\n")

--- a/doc/man_docs.go
+++ b/doc/man_docs.go
@@ -131,10 +131,10 @@ func manPrintFlags(out io.Writer, flags *pflag.FlagSet) {
 			return
 		}
 		format := ""
-		if len(flag.Shorthand) > 0 {
-			format = "**-%s**, **--%s**"
+		if len(flag.Shorthand) > 0 && len(flag.ShorthandDeprecated) == 0 {
+			format = fmt.Sprintf("**-%s**, **--%s**", flag.Shorthand, flag.Name)
 		} else {
-			format = "%s**--%s**"
+			format = fmt.Sprintf("**--%s**", flag.Name)
 		}
 		if len(flag.NoOptDefVal) > 0 {
 			format = format + "["
@@ -149,7 +149,7 @@ func manPrintFlags(out io.Writer, flags *pflag.FlagSet) {
 			format = format + "]"
 		}
 		format = format + "\n\t%s\n\n"
-		fmt.Fprintf(out, format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage)
+		fmt.Fprintf(out, format, flag.DefValue, flag.Usage)
 	})
 }
 

--- a/doc/man_docs_test.go
+++ b/doc/man_docs_test.go
@@ -129,6 +129,21 @@ func TestGenManSeeAlso(t *testing.T) {
 	}
 }
 
+func TestManPrintFlagsHidesShortDeperecated(t *testing.T) {
+	cmd := &cobra.Command{}
+	flags := cmd.Flags()
+	flags.StringP("foo", "f", "default", "Foo flag")
+	flags.MarkShorthandDeprecated("foo", "don't use it no more")
+
+	out := new(bytes.Buffer)
+	manPrintFlags(out, flags)
+
+	expected := "**--foo**=\"default\"\n\tFoo flag\n\n"
+	if out.String() != expected {
+		t.Fatalf("Expected %s, but got %s", expected, out.String())
+	}
+}
+
 func AssertLineFound(scanner *bufio.Scanner, expectedLine string) error {
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/doc/man_docs_test.go
+++ b/doc/man_docs_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -141,6 +143,30 @@ func TestManPrintFlagsHidesShortDeperecated(t *testing.T) {
 	expected := "**--foo**=\"default\"\n\tFoo flag\n\n"
 	if out.String() != expected {
 		t.Fatalf("Expected %s, but got %s", expected, out.String())
+	}
+}
+
+func TestGenManTree(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "do [OPTIONS] arg1 arg2",
+	}
+	header := &GenManHeader{Section: "2"}
+	tmpdir, err := ioutil.TempDir("", "test-gen-man-tree")
+	if err != nil {
+		t.Fatalf("Failed to create tempdir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	if err := GenManTree(cmd, header, tmpdir); err != nil {
+		t.Fatalf("GenManTree failed: %s", err.Error())
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpdir, "do.2")); err != nil {
+		t.Fatalf("Expected file 'do.2' to exist")
+	}
+
+	if header.Title != "" {
+		t.Fatalf("Expected header.Title to be unmodified")
 	}
 }
 


### PR DESCRIPTION
* use `Command.UseLine()` instead of `Command.Name()` to get the correct args and usages string in the `SYNOPSIS`
* fixes a bug where a flags shorthand was being displayed even when it was deprecated
* fixed a bug where the man page section from the header was not being used as part of the filename (section 1 was assumed)
* add a new `GenManTreeFromOpts()` which takes additional options while leaving `GenManTree()` backwards compatible. Currently only takes one additional option, but it can be expanded without breaking backwards compatibility.