### PR TITLE
Include instruction for building the cobra tool in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ func main() {
 Cobra provides its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
+In order to use the cobra command, compile it using the following command:
+
+    > go install github.com/spf13/cobra/cobra
+
+This will create the cobra executable under your go path bin directory!
+
 ### cobra init
 
 The `cobra init [yourApp]` command will create your initial application code


### PR DESCRIPTION
This change added a few lines to the README.md documentation for building the cobra tool.

I spent a whole hour just to figure this thing out. I thought this is only available on Linux, so I get myself a Linux VM, and still, it does not work. Finally, I figured out the tool source code come with the library as a whole and I need to compile it in order to get it.

Writing this so that other don't have to follow the same path I did.

By the way, the document about how the commands are arranged in a tree is awesome.