### PR TITLE
use root command if no other command matches and root is runnable

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -934,6 +934,11 @@ func TestRootSuggestions(t *testing.T) {
 
 	cmd := initializeWithRootCmd()
 	cmd.AddCommand(cmdTimes)
+	origCmdRun := cmd.Run
+	defer func() {
+		cmd.Run = origCmdRun
+	}()
+	cmd.Run = nil
 
 	tests := map[string]string{
 		"time":     "times",
@@ -1024,6 +1029,12 @@ func TestFlagsBeforeCommand(t *testing.T) {
 func TestRemoveCommand(t *testing.T) {
 	versionUsed = 0
 	c := initializeWithRootCmd()
+	origCmdRun := c.Run
+	defer func() {
+		c.Run = origCmdRun
+	}()
+	c.Run = nil
+
 	c.AddCommand(cmdVersion1)
 	c.RemoveCommand(cmdVersion1)
 	x := fullTester(c, "version")

--- a/command.go
+++ b/command.go
@@ -436,7 +436,7 @@ func (c *Command) Find(args []string) (*Command, []string, error) {
 	}
 
 	// root command with subcommands, do subcommand checking
-	if commandFound == c && len(argsWOflags) > 0 {
+	if commandFound == c && !c.Runnable() && len(argsWOflags) > 0 {
 		suggestionsString := ""
 		if !c.DisableSuggestions {
 			if c.SuggestionsMinimumDistance <= 0 {
@@ -734,7 +734,7 @@ func (c commandSorterByName) Less(i, j int) bool { return c[i].Name() < c[j].Nam
 // Commands returns a sorted slice of child commands.
 func (c *Command) Commands() []*Command {
 	// do not sort commands if it already sorted or sorting was disabled
-	if EnableCommandSorting && !c.commandsAreSorted{
+	if EnableCommandSorting && !c.commandsAreSorted {
 		sort.Sort(commandSorterByName(c.commands))
 		c.commandsAreSorted = true
 	}


### PR DESCRIPTION
A very simple solution for https://github.com/spf13/cobra/issues/15 and https://github.com/spf13/cobra/issues/42

TL;DR; pick the root command if it's runnable and no other command matched.
