### PR TITLE
Help command must use Stdout instead of Stderr

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -646,7 +646,7 @@ func TestSubcommandArgEvaluation(t *testing.T) {
 	second := &Command{
 		Use: "second",
 		Run: func(cmd *Command, args []string) {
-			fmt.Fprintf(cmd.Out(), "%v", args)
+			fmt.Fprintf(cmd.getOutOrStdout(), "%v", args)
 		},
 	}
 	first.AddCommand(second)


### PR DESCRIPTION
Help when called from `-h` or the `help` command must print to Stdout. Right now it only happens in the root cmd, any subcommand (e.g. `cmd subcmd -h`) prints to Stderr.

Other minor code reorg.