### PR TITLE
Add "docker" to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Many of the most widely used Go projects are built using Cobra including:
 * [Hugo](http://gohugo.io)
 * [rkt](https://github.com/coreos/rkt)
 * [etcd](https://github.com/coreos/etcd)
+* [Docker](https://github.com/docker/docker)
 * [Docker (distribution)](https://github.com/docker/distribution)
 * [OpenShift](https://www.openshift.com/)
 * [Delve](https://github.com/derekparker/delve)


### PR DESCRIPTION
Docker (https://github.com/docker/docker) now also uses Cobra for the CLI. A majority of the
commands have been migrated (still some left), but adding it already :)
