### PR TITLE
Display neither hidden nor deprecated flags in bash completion

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -421,6 +421,9 @@ func writeFlags(cmd *Command, w io.Writer) error {
 	localNonPersistentFlags := cmd.LocalNonPersistentFlags()
 	var visitErr error
 	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
 		if err := writeFlag(flag, w); err != nil {
 			visitErr = err
 			return
@@ -442,6 +445,9 @@ func writeFlags(cmd *Command, w io.Writer) error {
 		return visitErr
 	}
 	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
 		if err := writeFlag(flag, w); err != nil {
 			visitErr = err
 			return
@@ -468,6 +474,9 @@ func writeRequiredFlag(cmd *Command, w io.Writer) error {
 	flags := cmd.NonInheritedFlags()
 	var visitErr error
 	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
 		for key := range flag.Annotations {
 			switch key {
 			case BashCompOneRequiredFlag:

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -421,7 +421,7 @@ func writeFlags(cmd *Command, w io.Writer) error {
 	localNonPersistentFlags := cmd.LocalNonPersistentFlags()
 	var visitErr error
 	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
-		if flag.Hidden {
+		if nonCompletableFlag(flag) {
 			return
 		}
 		if err := writeFlag(flag, w); err != nil {
@@ -445,7 +445,7 @@ func writeFlags(cmd *Command, w io.Writer) error {
 		return visitErr
 	}
 	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
-		if flag.Hidden {
+		if nonCompletableFlag(flag) {
 			return
 		}
 		if err := writeFlag(flag, w); err != nil {
@@ -474,7 +474,7 @@ func writeRequiredFlag(cmd *Command, w io.Writer) error {
 	flags := cmd.NonInheritedFlags()
 	var visitErr error
 	flags.VisitAll(func(flag *pflag.Flag) {
-		if flag.Hidden {
+		if nonCompletableFlag(flag) {
 			return
 		}
 		for key := range flag.Annotations {
@@ -581,6 +581,10 @@ func (cmd *Command) GenBashCompletion(w io.Writer) error {
 		return err
 	}
 	return postscript(w, cmd.Name())
+}
+
+func nonCompletableFlag(flag *pflag.Flag) bool {
+	return flag.Hidden || len(flag.Deprecated) > 0
 }
 
 func (cmd *Command) GenBashCompletionFile(filename string) error {

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -158,3 +158,23 @@ func TestBashCompletionHiddenFlag(t *testing.T) {
 		t.Error("expected completion to not include %q flag: Got %v", flagName, bashCompletion)
 	}
 }
+
+func TestBashCompletionDeprecatedFlag(t *testing.T) {
+	var cmdTrue = &Command{
+		Use: "does nothing",
+		Run: func(cmd *Command, args []string) {},
+	}
+
+	const flagName = "deprecated-foo-bar-baz"
+
+	var flagValue bool
+	cmdTrue.Flags().BoolVar(&flagValue, flagName, false, "hidden flag")
+	cmdTrue.Flags().MarkDeprecated(flagName, "use --does-not-exist instead")
+
+	out := new(bytes.Buffer)
+	cmdTrue.GenBashCompletion(out)
+	bashCompletion := out.String()
+	if strings.Contains(bashCompletion, flagName) {
+		t.Errorf("expected completion to not include %q flag: Got %v", flagName, bashCompletion)
+	}
+}

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -138,3 +138,23 @@ func TestBashCompletions(t *testing.T) {
 		t.Fatalf("shellcheck failed: %v", err)
 	}
 }
+
+func TestBashCompletionHiddenFlag(t *testing.T) {
+	var cmdTrue = &Command{
+		Use: "does nothing",
+		Run: func(cmd *Command, args []string) {},
+	}
+
+	const flagName = "hidden-foo-bar-baz"
+
+	var flagValue bool
+	cmdTrue.Flags().BoolVar(&flagValue, flagName, false, "hidden flag")
+	cmdTrue.Flags().MarkHidden(flagName)
+
+	out := new(bytes.Buffer)
+	cmdTrue.GenBashCompletion(out)
+	bashCompletion := out.String()
+	if strings.Contains(bashCompletion, flagName) {
+		t.Error("expected completion to not include %q flag: Got %v", flagName, bashCompletion)
+	}
+}


### PR DESCRIPTION
As per the title.

I'm not certain if there's a reason not to hide both of these, but I'm open to opinions or discussion otherwise. Subcommands that are deprecated/hidden are already hidden it looks like.