### PR TITLE
Go tool path style

### DIFF
--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -141,42 +141,31 @@ func guessProjectPath() {
 	}
 
 	srcPath := getSrcPath()
-	// if provided, inspect for logical locations
-	if strings.ContainsRune(inputPath, os.PathSeparator) {
-		if filepath.IsAbs(inputPath) || filepath.HasPrefix(inputPath, string(os.PathSeparator)) {
-			// if Absolute, use it
-			projectPath = filepath.Clean(inputPath)
-			return
-		}
-		// If not absolute but contains slashes,
-		// assuming it means create it from $GOPATH
-		count := strings.Count(inputPath, string(os.PathSeparator))
 
-		switch count {
-		// If only one directory deep, assume "github.com"
-		case 1:
-			projectPath = filepath.Join(srcPath, "github.com", inputPath)
-			return
-		case 2:
-			projectPath = filepath.Join(srcPath, inputPath)
-			return
-		default:
-			er("Unknown directory")
+	var base string
+	// if provided, inspect for logical locations
+	if filepath.IsAbs(inputPath) || filepath.HasPrefix(inputPath, string(os.PathSeparator)) {
+		// if Absolute, use it.
+	} else if projectBase != "" {
+		// if projectBase specified any relative path starts with it
+		base = filepath.Join(srcPath, projectBase)
+	} else if inputPath == "." || strings.HasPrefix(inputPath, "./") || strings.HasPrefix(inputPath, "../") {
+		// relative to cwd like 'go test ./'
+		var err error
+		base, err = getWd()
+		if err != nil {
+			er(err)
 		}
 	} else {
-		// hardest case.. just a word.
-		if projectBase == "" {
-			x, err := getWd()
-			if err == nil {
-				projectPath = filepath.Join(x, inputPath)
-				return
-			}
-			er(err)
+		// relative, but not to cwd, so to $GOPATH/src
+		if dir, _ := filepath.Split(inputPath); dir == "" {
+			// If only one directory deep, assume "github.com"
+			base = filepath.Join(srcPath, "github.com")
 		} else {
-			projectPath = filepath.Join(srcPath, projectBase, inputPath)
-			return
+			base = srcPath
 		}
 	}
+	projectPath = filepath.Join(base, inputPath)
 }
 
 // isEmpty checks if a given path is empty.

--- a/cobra/cmd/helpers_test.go
+++ b/cobra/cmd/helpers_test.go
@@ -16,7 +16,7 @@ func checkGuess(t *testing.T, wd, input, expected string) {
 	guessProjectPath()
 
 	if projectPath != expected {
-		t.Errorf("Unexpected Project Path. \n Got: %q\nExpected: %q\n", projectPath, expected)
+		t.Errorf("Unexpected Project Path. \nGot: %q\nExpected: %q\nArg: %v\nDir: %v", projectPath, expected, input, wd)
 	}
 
 	reset()
@@ -30,9 +30,12 @@ func reset() {
 
 func TestProjectPath(t *testing.T) {
 	checkGuess(t, "", filepath.Join("github.com", "spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
-	checkGuess(t, "", filepath.Join("spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
+	checkGuess(t, "", filepath.Join("spf13", "hugo"), filepath.Join(getSrcPath(), "spf13", "hugo"))
 	checkGuess(t, "", filepath.Join("/", "bar", "foo"), filepath.Join("/", "bar", "foo"))
-	checkGuess(t, "/bar/foo", "baz", filepath.Join("/", "bar", "foo", "baz"))
+	checkGuess(t, "/bar/foo", "baz", filepath.Join(getSrcPath(), "github.com", "baz"))
+	checkGuess(t, "/bar/foo", "gopkg.in/baz", filepath.Join(getSrcPath(), "gopkg.in", "baz"))
+	checkGuess(t, "/bar/foo", "./baz", filepath.Join("/", "bar", "foo", "baz"))
+	checkGuess(t, "/bar/foo", "./gopkg.in/baz", filepath.Join("/", "bar", "foo", "gopkg.in", "baz"))
 	checkGuess(t, "/bar/foo/cmd", "", filepath.Join("/", "bar", "foo"))
 	checkGuess(t, "/bar/foo/command", "", filepath.Join("/", "bar", "foo"))
 	checkGuess(t, "/bar/foo/commands", "", filepath.Join("/", "bar", "foo"))

--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -72,7 +72,7 @@ func initializePath(path string) {
 			er(err)
 		}
 	} else { // If path exists and is not empty don't use it
-		empty, err := exists(path)
+		empty, err := isEmpty(path)
 		if err != nil {
 			er(err)
 		}


### PR DESCRIPTION
Command `cobra init ./` gets different result than `cobra init .`. that's a bit strange.
Also you can't place your command a bit deeper than project root using relative syntax. e.g. `cobra init github.com/user/project/many_cmds/prog1`

I propose to use syntax in go tool style:
- absolute path -> use as is
- relative path with prefix `./` -> `$PWD/given/path/of/any/depth`
- other relative path -> `$GOPATH/src/repo/name/path/to/command/dir`
- relative path without `./` prefix with only one depth level (`dirname` or either `dirname/`) -> `$GOPATH/src/github.com/dirname/`
