### PR TITLE
Allow commands to be executed without parent

### DIFF
--- a/command.go
+++ b/command.go
@@ -645,17 +645,31 @@ func (c *Command) errorMsgFromParse() string {
 // and run through the command tree finding appropriate matches
 // for commands and then corresponding flags.
 func (c *Command) Execute() error {
+	if c.HasParent() {
+		_, err := c.Root().ExecuteC()
+		return err
+	}
 	_, err := c.ExecuteC()
 	return err
 }
 
-func (c *Command) ExecuteC() (cmd *Command, err error) {
+func (c *Command) ExecuteSolo() error {
+	_, err := c.executeC()
+	return err
+}
 
+func (c *Command) ExecuteC() (cmd *Command, err error) {
 	// Regardless of what command execute is called on, run on Root only
 	if c.HasParent() {
-		return c.Root().ExecuteC()
-	}
+                return c.Root().ExecuteC()
+        }
 
+	cmd, err = c.executeC()
+	return cmd, err
+}
+
+
+func (c *Command) executeC() (cmd *Command, err error) {
 	// windows hook
 	if preExecHookFn != nil {
 		preExecHookFn(c)


### PR DESCRIPTION
Hey,

This adds support for just executing subcommands without calling the root command.

My use case:
the tool im building looks like this:

./MyTool DoThing DoSubThing1/DoSubThing2... etc

What I would like, is for the DoThing command to execute DoSubThing1 as a default if it is called without any additional subcommands

```
Run: func(cmd *cobra.Command, args []string) {
                switch Cfg.DefaultSubThing {
                case "DoSubThing1":
                        DoSubThing1Cmd.SetArgs(Cfg.Args)
                        DoSubThing1Cmd.ExecuteC() // This ends up in an infiniteloop
                        // Id like to do DoSubThing1Cmd.ExecuteSolo() here
                default:
                        cmd.Usage()
                }
        },
```