### PR TITLE
Bugfix/consistent error reporting when called with unknown subcommand

### DIFF
--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -53,7 +53,7 @@ COMPREPLY=( "hello" )
 )
 
 func TestBashCompletions(t *testing.T) {
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 	cmdEcho.AddCommand(cmdTimes)
 	c.AddCommand(cmdEcho, cmdPrint, cmdDeprecated, cmdColon)
 

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -27,6 +27,7 @@ var versionUsed int
 
 const strtwoParentHelp = "help message for parent flag strtwo"
 const strtwoChildHelp = "help message for child flag strtwo"
+const nonExistentCommand = "non_existent_command"
 
 var cmdHidden = &Command{
 	Use:   "hide [secret string to print]",
@@ -212,7 +213,7 @@ func initializeWithSameName() *Command {
 	return c
 }
 
-func initializeWithRootCmd() *Command {
+func initializeWithRootCmdWithRun() *Command {
 	cmdRootWithRun.ResetCommands()
 	tt, tp, te, tr, rootcalled = nil, nil, nil, nil, false
 	flagInit()
@@ -229,16 +230,28 @@ type resulter struct {
 }
 
 func fullSetupTest(input string) resulter {
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 
 	return fullTester(c, input)
 }
 
 func noRRSetupTestSilenced(input string) resulter {
 	c := initialize()
+
+	silenceErrors := c.SilenceErrors
+	silenceUsage := c.SilenceUsage
+
 	c.SilenceErrors = true
 	c.SilenceUsage = true
-	return fullTester(c, input)
+
+	res := fullTester(c, input)
+
+	// Restore previous values of silencing errors and usage.
+	// This is a workaround for these values not being reset properly between tests.
+	c.SilenceErrors = silenceErrors
+	c.SilenceUsage = silenceUsage
+
+	return res
 }
 
 func noRRSetupTest(input string) resulter {
@@ -248,7 +261,7 @@ func noRRSetupTest(input string) resulter {
 }
 
 func rootOnlySetupTest(input string) resulter {
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 
 	return simpleTester(c, input)
 }
@@ -585,7 +598,7 @@ func TestTrailingCommandFlags(t *testing.T) {
 }
 
 func TestInvalidSubcommandFlags(t *testing.T) {
-	cmd := initializeWithRootCmd()
+	cmd := initializeWithRootCmdWithRun()
 	cmd.AddCommand(cmdTimes)
 
 	result := simpleTester(cmd, "times --inttwo=2 --badflag=bar")
@@ -599,7 +612,7 @@ func TestInvalidSubcommandFlags(t *testing.T) {
 }
 
 func TestSubcommandExecuteC(t *testing.T) {
-	cmd := initializeWithRootCmd()
+	cmd := initializeWithRootCmdWithRun()
 	double := &Command{
 		Use: "double message",
 		Run: func(c *Command, args []string) {
@@ -634,7 +647,7 @@ func TestSubcommandExecuteC(t *testing.T) {
 }
 
 func TestSubcommandArgEvaluation(t *testing.T) {
-	cmd := initializeWithRootCmd()
+	cmd := initializeWithRootCmdWithRun()
 
 	first := &Command{
 		Use: "first",
@@ -753,7 +766,7 @@ func TestVisitParents(t *testing.T) {
 
 func TestRunnableRootCommandNilInput(t *testing.T) {
 	var emptyArg []string
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 
 	buf := new(bytes.Buffer)
 	// Testing flag with invalid input
@@ -777,7 +790,7 @@ func TestRunnableRootCommandEmptyInput(t *testing.T) {
 	args[0] = ""
 	args[1] = "--introot=12"
 	args[2] = ""
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 
 	buf := new(bytes.Buffer)
 	// Testing flag with invalid input
@@ -916,23 +929,70 @@ func TestRootUnknownCommand(t *testing.T) {
 
 func TestRootUnknownCommandSilenced(t *testing.T) {
 	r := noRRSetupTestSilenced("bogus")
-	s := "Run 'cobra-test --help' for usage.\n"
 
 	if r.Output != "" {
-		t.Errorf("Unexpected response.\nExpecting to be: \n\"\"\n Got:\n %q\n", s, r.Output)
+		t.Errorf("Unexpected response.\nExpecting to be: \n\"\"\n Got:\n %q\n", r.Output)
 	}
 
 	r = noRRSetupTestSilenced("--strtwo=a bogus")
 	if r.Output != "" {
-		t.Errorf("Unexpected response.\nExpecting to be:\n\"\"\nGot:\n %q\n", s, r.Output)
+		t.Errorf("Unexpected response.\nExpecting to be:\n\"\"\nGot:\n %q\n", r.Output)
 	}
 }
 
-func TestRootSuggestions(t *testing.T) {
-	outputWithSuggestions := "Error: unknown command \"%s\" for \"cobra-test\"\n\nDid you mean this?\n\t%s\n\nRun 'cobra-test --help' for usage.\n"
-	outputWithoutSuggestions := "Error: unknown command \"%s\" for \"cobra-test\"\nRun 'cobra-test --help' for usage.\n"
+func TestSubcommandChecksErrorsWhenSubcommandNotFound(t *testing.T) {
+	rootCmd := initialize()
+	rootCmd.AddCommand(cmdSubNoRun)
+	// Current semantics is that commands with no subcommands and no run print out the description.
+	cmdSubNoRun.AddCommand(cmdEcho)
 
-	cmd := initializeWithRootCmd()
+	result := simpleTester(rootCmd, nonExistentCommand)
+	if result.Error == nil {
+		t.Errorf("Unexpected response.\nExpected error, got success with output:\n %q\n", result.Output)
+	}
+	cmdName := rootCmd.Name()
+	expectedOutput := fmt.Sprintf("Error: unknown command %q for %q\nRun '%s --help' for usage.\n", nonExistentCommand, rootCmd.Name(), rootCmd.Name())
+	if result.Output != expectedOutput {
+		t.Errorf("Unexpected response.\nExpected:\n %q\nGot:\n %q\n", expectedOutput, result.Output)
+	}
+
+	result = simpleTester(rootCmd, cmdSubNoRun.Name() + " " + nonExistentCommand)
+	if result.Error == nil {
+		t.Errorf("Unexpected response.\nExpected error, got success with output:\n %q\n", result.Output)
+	}
+	cmdName = rootCmd.Name() + " " + cmdSubNoRun.Name()
+	expectedOutput = fmt.Sprintf("Error: unknown command %q for %q\nRun '%s --help' for usage.\n", nonExistentCommand, cmdName, cmdName)
+	if result.Output != expectedOutput {
+		t.Errorf("Unexpected response.\nExpected:\n %q\nGot:\n %q\n", expectedOutput, result.Output)
+	}
+}
+
+func TestSubcommandChecksNoErrorsWhenRunDefined(t *testing.T) {
+	rootCmd := initializeWithRootCmdWithRun()
+	rootCmd.AddCommand(cmdEcho)
+
+	result := simpleTester(rootCmd, nonExistentCommand)
+	if result.Error != nil {
+		t.Errorf("Unexpected response.\nExpected error, got success with output:\n %q\n", result.Output)
+	}
+	if !reflect.DeepEqual([]string{nonExistentCommand}, tr) {
+		t.Errorf("Unexpected response.\nExpected output:\n %q\nGot:\n %q\n", []string{nonExistentCommand}, tr)
+	}
+
+	result = simpleTester(rootCmd, cmdEcho.Name() + " " + nonExistentCommand)
+	if result.Error != nil {
+		t.Errorf("Unexpected response.\nExpected error, got success with output:\n %q\n", result.Output)
+	}
+	if !reflect.DeepEqual([]string{nonExistentCommand}, te) {
+		t.Errorf("Unexpected response.\nExpected output:\n %q\nGot:\n %q\n", []string{nonExistentCommand}, te)
+	}
+}
+
+func TestSubcommandSuggestions(t *testing.T) {
+	outputWithSuggestions := "Error: unknown command %q for \"cobra-test\"\n\nDid you mean this?\n\t%s\n\nRun 'cobra-test --help' for usage.\n"
+	outputWithoutSuggestions := "Error: unknown command %q for \"cobra-test\"\nRun 'cobra-test --help' for usage.\n"
+
+	cmd := initialize()
 	cmd.AddCommand(cmdTimes)
 
 	tests := map[string]string{
@@ -1023,7 +1083,7 @@ func TestFlagsBeforeCommand(t *testing.T) {
 
 func TestRemoveCommand(t *testing.T) {
 	versionUsed = 0
-	c := initializeWithRootCmd()
+	c := initialize()
 	c.AddCommand(cmdVersion1)
 	c.RemoveCommand(cmdVersion1)
 	x := fullTester(c, "version")
@@ -1034,7 +1094,7 @@ func TestRemoveCommand(t *testing.T) {
 }
 
 func TestCommandWithoutSubcommands(t *testing.T) {
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 
 	x := simpleTester(c, "")
 	if x.Error != nil {
@@ -1044,7 +1104,7 @@ func TestCommandWithoutSubcommands(t *testing.T) {
 }
 
 func TestCommandWithoutSubcommandsWithArg(t *testing.T) {
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 	expectedArgs := []string{"arg"}
 
 	x := simpleTester(c, "arg")
@@ -1060,7 +1120,7 @@ func TestCommandWithoutSubcommandsWithArg(t *testing.T) {
 
 func TestReplaceCommandWithRemove(t *testing.T) {
 	versionUsed = 0
-	c := initializeWithRootCmd()
+	c := initializeWithRootCmdWithRun()
 	c.AddCommand(cmdVersion1)
 	c.RemoveCommand(cmdVersion1)
 	c.AddCommand(cmdVersion2)

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -956,7 +956,7 @@ func TestSubcommandChecksErrorsWhenSubcommandNotFound(t *testing.T) {
 		t.Errorf("Unexpected response.\nExpected:\n %q\nGot:\n %q\n", expectedOutput, result.Output)
 	}
 
-	result = simpleTester(rootCmd, cmdSubNoRun.Name() + " " + nonExistentCommand)
+	result = simpleTester(rootCmd, cmdSubNoRun.Name()+" "+nonExistentCommand)
 	if result.Error == nil {
 		t.Errorf("Unexpected response.\nExpected error, got success with output:\n %q\n", result.Output)
 	}
@@ -979,7 +979,7 @@ func TestSubcommandChecksNoErrorsWhenRunDefined(t *testing.T) {
 		t.Errorf("Unexpected response.\nExpected output:\n %q\nGot:\n %q\n", []string{nonExistentCommand}, tr)
 	}
 
-	result = simpleTester(rootCmd, cmdEcho.Name() + " " + nonExistentCommand)
+	result = simpleTester(rootCmd, cmdEcho.Name()+" "+nonExistentCommand)
 	if result.Error != nil {
 		t.Errorf("Unexpected response.\nExpected error, got success with output:\n %q\n", result.Output)
 	}

--- a/command.go
+++ b/command.go
@@ -462,14 +462,14 @@ func (c *Command) Find(args []string) (*Command, []string, error) {
 		return commandFound, a, nil
 	}
 
-	// root command with subcommands, do subcommand checking
-	if commandFound == c && len(argsWOflags) > 0 {
+	// command with no run method, do subcommand checking
+	if commandFound.Run == nil && commandFound.RunE == nil && len(argsWOflags) > 0 {
 		suggestionsString := ""
-		if !c.DisableSuggestions {
-			if c.SuggestionsMinimumDistance <= 0 {
-				c.SuggestionsMinimumDistance = 2
+		if !commandFound.DisableSuggestions {
+			if commandFound.SuggestionsMinimumDistance <= 0 {
+				commandFound.SuggestionsMinimumDistance = 2
 			}
-			if suggestions := c.SuggestionsFor(argsWOflags[0]); len(suggestions) > 0 {
+			if suggestions := commandFound.SuggestionsFor(argsWOflags[0]); len(suggestions) > 0 {
 				suggestionsString += "\n\nDid you mean this?\n"
 				for _, s := range suggestions {
 					suggestionsString += fmt.Sprintf("\t%v\n", s)


### PR DESCRIPTION
We recently noticed that error reporting and auto-suggestion when a non-existent sub-command name is specified via command line only happens for the root command, not when specifying a sub-command of a sub-command. This behaviour was very unexpected, and I don't think there is any fundamental reason for it. Moreover, when looking into this issue, I found that the root command cannot take positional arguments if it has any sub-commands whereas sub-commands can do so, even if they have sub-commands.

In general, the problem of whether something is specifying a sub-command or a positional argument is unsolvable, but if a command has no `Run` or `RunE` specified, it's safe to assume we are referencing a sub-command.

This PR changes the behaviour such that if a command has sub-commands, an argument is provided, and it does not match any of the sub-command names:
- an error is printed if the command doesn't specify `Run` or `RunE`.
- `Run` or `RunE` is called with the remaining args, if specified.

Furthermore, this PR unifies this behaviour across commands, such that it's the same for the root and sub-commands or lower.

Tests have been added but due to them not being completely hermetic, I had to change some details elsewhere. I think the tests should be rewritten to always get fresh instances to prevent this in the future; however, I didn't want to make this PR too large and contentious.

I think running command with no `Run`, `RunE`, and no sub-commands with an argument should also be an error. However, I can see how that's arguable so didn't want to add it to this PR - please do let me know if you think the behaviour should change there so it's unified.

I hope you find this contribution useful,
Jan
