### PR TITLE
Add rclone to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Many of the most widely used Go projects are built using Cobra including:
 * [Parse (CLI)](https://parse.com/)
 * [GiantSwarm's swarm](https://github.com/giantswarm/cli)
 * [Nanobox](https://github.com/nanobox-io/nanobox)/[Nanopack](https://github.com/nanopack)
+* [rclone](http://rclone.org/)
 
 
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)


### PR DESCRIPTION
I've converted rclone over to use cobra - what a great package - thank you very much.
- http://rclone.org
- https://github.com/ncw/rclone

Here is a PR to add rclone to the list of users.  I don't know whether 2,000 github stars is popular enough for the list - if not please disregard this PR!

Thanks

Nick
