### PR TITLE
Make SEE ALSO references and generated file names agree with each other.

### DIFF
--- a/doc/man_docs.go
+++ b/doc/man_docs.go
@@ -37,7 +37,7 @@ func GenManTree(cmd *cobra.Command, header *GenManHeader, dir string) error {
 	return GenManTreeFromOpts(cmd, GenManTreeOptions{
 		Header:           header,
 		Path:             dir,
-		CommandSeparator: "_",
+		CommandSeparator: "-",
 	})
 }
 


### PR DESCRIPTION
Fixes  #342.
