### PR TITLE
Go vet

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -22,7 +22,7 @@ func preamble(out io.Writer, name string) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprint(out, `
+	preamStr := `
 __debug()
 {
     if [[ -n ${BASH_COMP_DEBUG_FILE} ]]; then
@@ -241,7 +241,8 @@ __handle_word()
     __handle_word
 }
 
-`)
+`
+	_, err = fmt.Fprint(out, preamStr)
 	return err
 }
 

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -916,15 +916,14 @@ func TestRootUnknownCommand(t *testing.T) {
 
 func TestRootUnknownCommandSilenced(t *testing.T) {
 	r := noRRSetupTestSilenced("bogus")
-	s := "Run 'cobra-test --help' for usage.\n"
 
 	if r.Output != "" {
-		t.Errorf("Unexpected response.\nExpecting to be: \n\"\"\n Got:\n %q\n", s, r.Output)
+		t.Errorf("Unexpected response.\nExpecting to be: \n\"\"\n Got:\n %q\n", r.Output)
 	}
 
 	r = noRRSetupTestSilenced("--strtwo=a bogus")
 	if r.Output != "" {
-		t.Errorf("Unexpected response.\nExpecting to be:\n\"\"\nGot:\n %q\n", s, r.Output)
+		t.Errorf("Unexpected response.\nExpecting to be:\n\"\"\nGot:\n %q\n", r.Output)
 	}
 }
 


### PR DESCRIPTION
A couple of cleanups needed for `go vet ./...` to pass.

Discovered after vendoring cobra.
