### PR TITLE
Set the defaults BEFORE considering a --config CLI argument

### DIFF
--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -64,7 +64,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
-	viper.AutomaticEnv()          // read in environment variables that match
+	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -57,12 +57,13 @@ func init() {
 
 // Read in config file and ENV variables if set.
 func initConfig() {
+	viper.SetConfigName(".cobra") // name of config file (without extension)
+	viper.AddConfigPath("$HOME")  // adding home directory as first search path
+
 	if cfgFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(cfgFile)
 	}
 
-	viper.SetConfigName(".cobra") // name of config file (without extension)
-	viper.AddConfigPath("$HOME")  // adding home directory as first search path
 	viper.AutomaticEnv()          // read in environment variables that match
 
 	// If a config file is found, read it in.


### PR DESCRIPTION
viper.setConfigName will also set configFile == "" therefor we must set all defaults prior to considering command line arguments.