### PR TITLE
Compatibility for multiple GOPATH workspaces

### DIFF
--- a/cobra/cmd/helpers_test.go
+++ b/cobra/cmd/helpers_test.go
@@ -29,8 +29,8 @@ func reset() {
 }
 
 func TestProjectPath(t *testing.T) {
-	checkGuess(t, "", filepath.Join("github.com", "spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
-	checkGuess(t, "", filepath.Join("spf13", "hugo"), filepath.Join(getSrcPath(), "github.com", "spf13", "hugo"))
+	checkGuess(t, "", filepath.Join("github.com", "spf13", "hugo"), filepath.Join(getSrcPaths()[0], "github.com", "spf13", "hugo"))
+	checkGuess(t, "", filepath.Join("spf13", "hugo"), filepath.Join(getSrcPaths()[0], "github.com", "spf13", "hugo"))
 	checkGuess(t, "", filepath.Join("/", "bar", "foo"), filepath.Join("/", "bar", "foo"))
 	checkGuess(t, "/bar/foo", "baz", filepath.Join("/", "bar", "foo", "baz"))
 	checkGuess(t, "/bar/foo/cmd", "", filepath.Join("/", "bar", "foo"))

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -33,7 +33,7 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 }
 
-//Execute adds all child commands to the root command sets flags appropriately.
+// Execute adds all child commands to the root command sets flags appropriately.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
This commit adds the necessary changes to support users with multiple
`GOPATH` workspaces. Previously the `getSrcPath()` function in
`cobra/cmd/helpers.go` would not take into account the fact the the
system `GOPATH` returns a colon-separated list if system was configured
with multiple GOPATH workspaces. If the GOPATH was set to be
`/foo/a:/bar/b`, it would simply append `src/` to the end of the string
literal giving `/foo/a:/bar/b/src` which resulted in undesired behavior.

Following the specs the changeset here adds support for multiple GOPATH
workspaces and if a given package directory is not to be found in any of
the workspaces the first one is chosen, i.e. for `cobra init` it will
first check all workspaces for the specified project and settling on the
first (`/foo/a`) if nothing found.
This preserves backwards compatibility as single workspace environments
are provably unaffected by these changes.

This fixes #276, cc @eparis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spf13/cobra/351)
<!-- Reviewable:end -->
