### PR TITLE
Add a tags field for user defined tags on a Command

### DIFF
--- a/command.go
+++ b/command.go
@@ -57,6 +57,9 @@ type Command struct {
 	Deprecated string
 	// Is this command hidden and should NOT show up in the list of available commands?
 	Hidden bool
+	// Annotations are key/value pairs that can be used by applications to identify or
+	// group commands
+	Annotations map[string]string
 	// Full set of flags
 	flags *flag.FlagSet
 	// Set of flags childrens of this command will inherit
@@ -455,7 +458,7 @@ func argsMinusFirstX(args []string, x string) []string {
 	return args
 }
 
-// Find finds the target command given the args and command tree
+// Find the target command given the args and command tree
 // Meant to be run on the highest node. Only searches down.
 func (c *Command) Find(args []string) (*Command, []string, error) {
 	if c == nil {


### PR DESCRIPTION
This `Tags` field would be used by an application to identify commands with specific properties. For example:
* experimental
* added-in version x

They could be used in custom help/usage text to group commands in different ways, or to filter the commands to hide based on tags.

See https://github.com/docker/docker/pull/28010 for a concrete use case.

cc @bep 