### PR TITLE
Fix #269

### DIFF
--- a/cobra/cmd/add.go
+++ b/cobra/cmd/add.go
@@ -78,8 +78,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// {{.cmdName}}Cmd represents the {{.cmdName}} command
-var {{ .cmdName }}Cmd = &cobra.Command{
+// {{.cmdName|camelcase}}Cmd represents the {{.cmdName}} command
+var {{ .cmdName|camelcase }}Cmd = &cobra.Command{
 	Use:   "{{ .cmdName }}",
 	Short: "A brief description of your command",
 	Long: ` + "`" + `A longer description that spans multiple lines and likely contains examples
@@ -95,7 +95,7 @@ to quickly create a Cobra application.` + "`" + `,
 }
 
 func init() {
-	{{ .parentName }}.AddCommand({{ .cmdName }}Cmd)
+	{{ .parentName }}.AddCommand({{ .cmdName|camelcase }}Cmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"regexp"
 
 	"github.com/spf13/viper"
 )
@@ -43,6 +44,7 @@ var cmdDirs = []string{"cmd", "cmds", "command", "commands"}
 func init() {
 	funcMap = template.FuncMap{
 		"comment": commentifyString,
+		"camelcase": camelCaseString,
 	}
 }
 
@@ -353,4 +355,15 @@ func commentifyString(in string) string {
 		}
 	}
 	return strings.Join(newlines, "\n")
+}
+
+func camelCaseString(in string) string {
+	r := regexp.MustCompile("[A-Za-z0-9_]+")
+	parts := r.FindAll([]byte(in), -1)
+	for i, v := range parts {
+		if i > 0 {
+			parts[i] = bytes.Title(v)
+		}
+	}
+	return string(bytes.Join(parts, nil))
 }

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -19,10 +19,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
-	"regexp"
 
 	"github.com/spf13/viper"
 )
@@ -43,7 +43,7 @@ var cmdDirs = []string{"cmd", "cmds", "command", "commands"}
 
 func init() {
 	funcMap = template.FuncMap{
-		"comment": commentifyString,
+		"comment":   commentifyString,
 		"camelcase": camelCaseString,
 	}
 }

--- a/command_test.go
+++ b/command_test.go
@@ -146,8 +146,8 @@ func TestInitHelpFlagMergesFlags(t *testing.T) {
 	cmd.initHelpFlag()
 	actual := cmd.Flags().Lookup("help").Usage
 	if actual != usage {
-		t.Fatalf("Expected the help flag from the base command with usage '%s', " +
-		         "but got the default with usage '%s'", usage, actual)
+		t.Fatalf("Expected the help flag from the base command with usage '%s', "+
+			"but got the default with usage '%s'", usage, actual)
 	}
 }
 


### PR DESCRIPTION
This PR fixes #269.

Cobra generator will automatically use a camelCase version of the command name if it is needed.

By example:
`$ cobra add camel-case`
will generate:
```
...
// camelCaseCmd represents the camel-case command
var camelCaseCmd = &cobra.Command{
        Use:   "camel-case",
        Short: "A brief description of your command",
...
```