### PR TITLE
Added support for yaml ouptut in docs gen

### DIFF
--- a/doc/util.go
+++ b/doc/util.go
@@ -13,7 +13,11 @@
 
 package doc
 
-import "github.com/spf13/cobra"
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 // Test to see if we have a reason to print See Also information in docs
 // Basically this is a test for a parent commend or a subcommand which is
@@ -29,6 +33,15 @@ func hasSeeAlso(cmd *cobra.Command) bool {
 		return true
 	}
 	return false
+}
+
+// Temporary workaround for yaml lib generating incorrect yaml with long strings
+// that do not contain \n.
+func forceMultiLine(s string) string {
+	if len(s) > 60 && !strings.Contains(s, "\n") {
+		s = s + "\n"
+	}
+	return s
 }
 
 type byName []*cobra.Command

--- a/doc/yaml_docs.go
+++ b/doc/yaml_docs.go
@@ -1,0 +1,165 @@
+// Copyright 2016 French Ben. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doc
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
+)
+
+type cmdOption struct {
+	Name         string
+	Shorthand    string `yaml:",omitempty"`
+	DefaultValue string `yaml:"default_value,omitempty"`
+	Usage        string `yaml:",omitempty"`
+}
+
+type cmdDoc struct {
+	Name             string
+	Synopsis         string      `yaml:",omitempty"`
+	Description      string      `yaml:",omitempty"`
+	Options          []cmdOption `yaml:",omitempty"`
+	InheritedOptions []cmdOption `yaml:"inherited_options,omitempty"`
+	Example          string      `yaml:",omitempty"`
+	SeeAlso          []string    `yaml:"see_also,omitempty"`
+}
+
+// GenYamlTree creates yaml structured ref files for this command and all descendants
+// in the directory given. This function may not work
+// correctly if your command names have - in them. If you have `cmd` with two
+// subcmds, `sub` and `sub-third`. And `sub` has a subcommand called `third`
+// it is undefined which help output will be in the file `cmd-sub-third.1`.
+func GenYamlTree(cmd *cobra.Command, dir string) error {
+	identity := func(s string) string { return s }
+	emptyStr := func(s string) string { return "" }
+	return GenYamlTreeCustom(cmd, dir, emptyStr, identity)
+}
+
+// GenYamlTreeCustom creates yaml structured ref files
+func GenYamlTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string) error {
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() || c.IsHelpCommand() {
+			continue
+		}
+		if err := GenYamlTreeCustom(c, dir, filePrepender, linkHandler); err != nil {
+			return err
+		}
+	}
+
+	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".yaml"
+	filename := filepath.Join(dir, basename)
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
+		return err
+	}
+	if err := GenYamlCustom(cmd, f, linkHandler); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GenYaml creates yaml output
+func GenYaml(cmd *cobra.Command, w io.Writer) error {
+	return GenYamlCustom(cmd, w, func(s string) string { return s })
+}
+
+// GenYamlCustom creates custom yaml output
+func GenYamlCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string) string) error {
+	yamlDoc := cmdDoc{}
+	yamlDoc.Name = cmd.CommandPath()
+
+	yamlDoc.Synopsis = forceMultiLine(cmd.Short)
+	yamlDoc.Description = forceMultiLine(cmd.Long)
+
+	if len(cmd.Example) > 0 {
+		yamlDoc.Example = cmd.Example
+	}
+
+	flags := cmd.NonInheritedFlags()
+	if flags.HasFlags() {
+		yamlDoc.Options = genFlagResult(flags)
+	}
+	flags = cmd.InheritedFlags()
+	if flags.HasFlags() {
+		yamlDoc.InheritedOptions = genFlagResult(flags)
+	}
+
+	if hasSeeAlso(cmd) {
+		result := []string{}
+		if cmd.HasParent() {
+			parent := cmd.Parent()
+			result = append(result, parent.CommandPath()+" - "+parent.Short)
+		}
+		children := cmd.Commands()
+		sort.Sort(byName(children))
+		for _, child := range children {
+			if !child.IsAvailableCommand() || child.IsHelpCommand() {
+				continue
+			}
+			result = append(result, child.Name()+" - "+child.Short)
+		}
+		yamlDoc.SeeAlso = result
+	}
+
+	final, err := yaml.Marshal(&yamlDoc)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if _, err := fmt.Fprintf(w, string(final)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func genFlagResult(flags *pflag.FlagSet) []cmdOption {
+	var result []cmdOption
+
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Todo, when we mark a shorthand is deprecated, but specify an empty message.
+		// The flag.ShorthandDeprecated is empty as the shorthand is deprecated.
+		// Using len(flag.ShorthandDeprecated) > 0 can't handle this, others are ok.
+		if !(len(flag.ShorthandDeprecated) > 0) && len(flag.Shorthand) > 0 {
+			opt := cmdOption{
+				flag.Name,
+				flag.Shorthand,
+				flag.DefValue,
+				forceMultiLine(flag.Usage),
+			}
+			result = append(result, opt)
+		} else {
+			opt := cmdOption{
+				Name:         flag.Name,
+				DefaultValue: forceMultiLine(flag.DefValue),
+				Usage:        forceMultiLine(flag.Usage),
+			}
+			result = append(result, opt)
+		}
+	})
+
+	return result
+}

--- a/doc/yaml_docs.md
+++ b/doc/yaml_docs.md
@@ -1,6 +1,6 @@
-# Generating Markdown Docs For Your Own cobra.Command
+# Generating Yaml Docs For Your Own cobra.Command
 
-Generating man pages from a cobra command is incredibly easy. An example is as follows:
+Generating yaml files from a cobra command is incredibly easy. An example is as follows:
 
 ```go
 package main
@@ -15,13 +15,13 @@ func main() {
 		Use:   "test",
 		Short: "my test program",
 	}
-	doc.GenMarkdownTree(cmd, "/tmp")
+	doc.GenYamlTree(cmd, "/tmp")
 }
 ```
 
-That will get you a Markdown document `/tmp/test.md`
+That will get you a Yaml document `/tmp/test.yaml`
 
-## Generate markdown docs for the entire command tree
+## Generate yaml docs for the entire command tree
 
 This program can actually generate docs for the kubectl command in the kubernetes project
 
@@ -40,40 +40,40 @@ import (
 
 func main() {
 	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
-	doc.GenMarkdownTree(kubectl, "./")
+	doc.GenYamlTree(kubectl, "./")
 }
 ```
 
 This will generate a whole series of files, one for each command in the tree, in the directory specified (in this case "./")
 
-## Generate markdown docs for a single command
+## Generate yaml docs for a single command
 
-You may wish to have more control over the output, or only generate for a single command, instead of the entire command tree. If this is the case you may prefer to `GenMarkdown` instead of `GenMarkdownTree`
+You may wish to have more control over the output, or only generate for a single command, instead of the entire command tree. If this is the case you may prefer to `GenYaml` instead of `GenYamlTree`
 
 ```go
 	out := new(bytes.Buffer)
-	doc.GenMarkdown(cmd, out)
+	doc.GenYaml(cmd, out)
 ```
 
-This will write the markdown doc for ONLY "cmd" into the out, buffer.
+This will write the yaml doc for ONLY "cmd" into the out, buffer.
 
 ## Customize the output
 
-Both `GenMarkdown` and `GenMarkdownTree` have alternate versions with callbacks to get some control of the output:
+Both `GenYaml` and `GenYamlTree` have alternate versions with callbacks to get some control of the output:
 
 ```go
-func GenMarkdownTreeCustom(cmd *Command, dir string, filePrepender, linkHandler func(string) string) error {
+func GenYamlTreeCustom(cmd *Command, dir string, filePrepender, linkHandler func(string) string) error {
 	//...
 }
 ```
 
 ```go
-func GenMarkdownCustom(cmd *Command, out *bytes.Buffer, linkHandler func(string) string) error {
+func GenYamlCustom(cmd *Command, out *bytes.Buffer, linkHandler func(string) string) error {
 	//...
 }
 ```
 
-The `filePrepender` will prepend the return value given the full filepath to the rendered Markdown file. A common use case is to add front matter to use the generated documentation with [Hugo](http://gohugo.io/):
+The `filePrepender` will prepend the return value given the full filepath to the rendered Yaml file. A common use case is to add front matter to use the generated documentation with [Hugo](http://gohugo.io/):
 
 ```go
 const fmTemplate = `---

--- a/doc/yaml_docs_test.go
+++ b/doc/yaml_docs_test.go
@@ -1,0 +1,88 @@
+package doc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+var _ = fmt.Println
+var _ = os.Stderr
+
+func TestGenYamlDoc(t *testing.T) {
+	c := initializeWithRootCmd()
+	// Need two commands to run the command alphabetical sort
+	cmdEcho.AddCommand(cmdTimes, cmdEchoSub, cmdDeprecated)
+	c.AddCommand(cmdPrint, cmdEcho)
+	cmdRootWithRun.PersistentFlags().StringVarP(&flags2a, "rootflag", "r", "two", strtwoParentHelp)
+
+	out := new(bytes.Buffer)
+
+	// We generate on s subcommand so we have both subcommands and parents
+	if err := GenYaml(cmdEcho, out); err != nil {
+		t.Fatal(err)
+	}
+	found := out.String()
+
+	// Our description
+	expected := cmdEcho.Long
+	if !strings.Contains(found, expected) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+
+	// Better have our example
+	expected = cmdEcho.Example
+	if !strings.Contains(found, expected) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+
+	// A local flag
+	expected = "boolone"
+	if !strings.Contains(found, expected) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+
+	// persistent flag on parent
+	expected = "rootflag"
+	if !strings.Contains(found, expected) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+
+	// We better output info about our parent
+	expected = cmdRootWithRun.Short
+	if !strings.Contains(found, expected) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+
+	// And about subcommands
+	expected = cmdEchoSub.Short
+	if !strings.Contains(found, expected) {
+		t.Errorf("Unexpected response.\nExpecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+
+	unexpected := cmdDeprecated.Short
+	if strings.Contains(found, unexpected) {
+		t.Errorf("Unexpected response.\nFound: %v\nBut should not have!!\n", unexpected)
+	}
+}
+
+func TestGenYamlNoTag(t *testing.T) {
+	c := initializeWithRootCmd()
+	// Need two commands to run the command alphabetical sort
+	cmdEcho.AddCommand(cmdTimes, cmdEchoSub, cmdDeprecated)
+	c.AddCommand(cmdPrint, cmdEcho)
+	c.DisableAutoGenTag = true
+	cmdRootWithRun.PersistentFlags().StringVarP(&flags2a, "rootflag", "r", "two", strtwoParentHelp)
+	out := new(bytes.Buffer)
+
+	if err := GenYaml(c, out); err != nil {
+		t.Fatal(err)
+	}
+	found := out.String()
+
+	unexpected := "Auto generated"
+	checkStringOmits(t, found, unexpected)
+
+}


### PR DESCRIPTION
Allow for Cobra to also generate YAML docs for the cli. 

Tests:
```
$ go test -v .
=== RUN   TestGenManDoc
--- PASS: TestGenManDoc (0.00s)
=== RUN   TestGenManNoGenTag
--- PASS: TestGenManNoGenTag (0.00s)
=== RUN   TestGenManSeeAlso
--- PASS: TestGenManSeeAlso (0.00s)
=== RUN   TestManPrintFlagsHidesShortDeperecated
--- PASS: TestManPrintFlagsHidesShortDeperecated (0.00s)
=== RUN   TestGenManTree
--- PASS: TestGenManTree (0.00s)
=== RUN   TestGenMdDoc
--- PASS: TestGenMdDoc (0.00s)
=== RUN   TestGenMdNoTag
--- PASS: TestGenMdNoTag (0.00s)
=== RUN   TestGenYamlDoc
--- PASS: TestGenYamlDoc (0.00s)
=== RUN   TestGenYamlNoTag
--- PASS: TestGenYamlNoTag (0.00s)
PASS
ok  	github.com/spf13/cobra/doc	0.015s
```

Output from the examples in `doc/yaml_docs.md`
test.go
```
$ cat /tmp/test.yaml
command: test
short: my test program
long: my test program
```

kubectl.go
```
$ cat kubectl.yaml
name: kubectl
synopsis: kubectl controls the Kubernetes cluster manager
description: "kubectl controls the Kubernetes cluster manager. \n\nFind more information
  at https://github.com/kubernetes/kubernetes."
options:
- name: alsologtostderr
  default_value: "false"
  usage: log to standard error as well as files
- name: api-version
  usage: |
    DEPRECATED: The API version to use when talking to the server
- name: as
  usage: Username to impersonate for the operation
- name: certificate-authority
  usage: Path to a cert. file for the certificate authority
- name: client-certificate
  usage: Path to a client certificate file for TLS
- name: client-key
  usage: Path to a client key file for TLS
- name: cluster
  usage: The name of the kubeconfig cluster to use
- name: context
  usage: The name of the kubeconfig context to use
- name: insecure-skip-tls-verify
  default_value: "false"
  usage: |
    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
- name: kubeconfig
  usage: Path to the kubeconfig file to use for CLI requests.
- name: log-backtrace-at
  default_value: :0
  usage: when logging hits line file:N, emit a stack trace
- name: log-dir
  usage: If non-empty, write log files in this directory
- name: logtostderr
  default_value: "false"
  usage: log to standard error instead of files
- name: match-server-version
  default_value: "false"
  usage: Require server version to match client version
- name: namespace
  shorthand: "n"
  usage: If present, the namespace scope for this CLI request
- name: password
  usage: Password for basic authentication to the API server
- name: request-timeout
  default_value: "0"
  usage: |
    The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.
- name: server
  shorthand: s
  usage: The address and port of the Kubernetes API server
- name: stderrthreshold
  default_value: "2"
  usage: logs at or above this threshold go to stderr
- name: token
  usage: Bearer token for authentication to the API server
- name: user
  usage: The name of the kubeconfig user to use
- name: username
  usage: Username for basic authentication to the API server
- name: v
  shorthand: v
  default_value: "0"
  usage: log level for V logs
- name: vmodule
  usage: |
    comma-separated list of pattern=N settings for file-filtered logging
see_also:
- annotate - Update the annotations on a resource
- api-versions - Print the supported API versions on the server, in the form of "group/version"
- apply - Apply a configuration to a resource by filename or stdin
- attach - Attach to a running container
- autoscale - Auto-scale a Deployment, ReplicaSet, or ReplicationController
- certificate - Modify certificate resources.
- cluster-info - Display cluster info
- completion - Output shell completion code for the specified shell (bash or zsh)
- config - Modify kubeconfig files
- convert - Convert config files between different API versions
- cordon - Mark node as unschedulable
- cp - Copy files and directories to and from containers.
- create - Create a resource by filename or stdin
- delete - Delete resources by filenames, stdin, resources and names, or by resources
  and label selector
- describe - Show details of a specific resource or group of resources
- drain - Drain node in preparation for maintenance
- edit - Edit a resource on the server
- exec - Execute a command in a container
- explain - Documentation of resources
- expose - Take a replication controller, service, deployment or pod and expose it
  as a new Kubernetes Service
- get - Display one or many resources
- label - Update the labels on a resource
- logs - Print the logs for a container in a pod
- options - Print the list of flags inherited by all commands
- patch - Update field(s) of a resource using strategic merge patch
- port-forward - Forward one or more local ports to a pod
- proxy - Run a proxy to the Kubernetes API server
- replace - Replace a resource by filename or stdin
- rolling-update - Perform a rolling update of the given ReplicationController
- rollout - Manage a deployment rollout
- run - Run a particular image on the cluster
- scale - Set a new size for a Deployment, ReplicaSet, Replication Controller, or
  Job
- set - Set specific features on objects
- taint - Update the taints on one or more nodes
- top - Display Resource (CPU/Memory/Storage) usage.
- uncordon - Mark node as schedulable
- version - Print the client and server version information
```

compared with Markdown:
```
$ cat kubectl.md
## kubectl

kubectl controls the Kubernetes cluster manager

### Synopsis


kubectl controls the Kubernetes cluster manager.

Find more information at https://github.com/kubernetes/kubernetes.


kubectl


### Options


      --alsologtostderr                  log to standard error as well as files
      --as string                        Username to impersonate for the operation
      --certificate-authority string     Path to a cert. file for the certificate authority
      --client-certificate string        Path to a client certificate file for TLS
      --client-key string                Path to a client key file for TLS
      --cluster string                   The name of the kubeconfig cluster to use
      --context string                   The name of the kubeconfig context to use
      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
      --match-server-version             Require server version to match client version
  -n, --namespace string                 If present, the namespace scope for this CLI request
      --password string                  Password for basic authentication to the API server
      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                    The address and port of the Kubernetes API server
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
      --token string                     Bearer token for authentication to the API server
      --user string                      The name of the kubeconfig user to use
      --username string                  Username for basic authentication to the API server
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging


### SEE ALSO
* [kubectl annotate](kubectl_annotate.md)	 - Update the annotations on a resource
* [kubectl api-versions](kubectl_api-versions.md)	 - Print the supported API versions on the server, in the form of "group/version"
* [kubectl apply](kubectl_apply.md)	 - Apply a configuration to a resource by filename or stdin
* [kubectl attach](kubectl_attach.md)	 - Attach to a running container
* [kubectl autoscale](kubectl_autoscale.md)	 - Auto-scale a Deployment, ReplicaSet, or ReplicationController
* [kubectl certificate](kubectl_certificate.md)	 - Modify certificate resources.
* [kubectl cluster-info](kubectl_cluster-info.md)	 - Display cluster info
* [kubectl completion](kubectl_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
* [kubectl config](kubectl_config.md)	 - Modify kubeconfig files
* [kubectl convert](kubectl_convert.md)	 - Convert config files between different API versions
* [kubectl cordon](kubectl_cordon.md)	 - Mark node as unschedulable
* [kubectl cp](kubectl_cp.md)	 - Copy files and directories to and from containers.
* [kubectl create](kubectl_create.md)	 - Create a resource by filename or stdin
* [kubectl delete](kubectl_delete.md)	 - Delete resources by filenames, stdin, resources and names, or by resources and label selector
* [kubectl describe](kubectl_describe.md)	 - Show details of a specific resource or group of resources
* [kubectl drain](kubectl_drain.md)	 - Drain node in preparation for maintenance
* [kubectl edit](kubectl_edit.md)	 - Edit a resource on the server
* [kubectl exec](kubectl_exec.md)	 - Execute a command in a container
* [kubectl explain](kubectl_explain.md)	 - Documentation of resources
* [kubectl expose](kubectl_expose.md)	 - Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
* [kubectl get](kubectl_get.md)	 - Display one or many resources
* [kubectl label](kubectl_label.md)	 - Update the labels on a resource
* [kubectl logs](kubectl_logs.md)	 - Print the logs for a container in a pod
* [kubectl options](kubectl_options.md)	 - Print the list of flags inherited by all commands
* [kubectl patch](kubectl_patch.md)	 - Update field(s) of a resource using strategic merge patch
* [kubectl port-forward](kubectl_port-forward.md)	 - Forward one or more local ports to a pod
* [kubectl proxy](kubectl_proxy.md)	 - Run a proxy to the Kubernetes API server
* [kubectl replace](kubectl_replace.md)	 - Replace a resource by filename or stdin
* [kubectl rolling-update](kubectl_rolling-update.md)	 - Perform a rolling update of the given ReplicationController
* [kubectl rollout](kubectl_rollout.md)	 - Manage a deployment rollout
* [kubectl run](kubectl_run.md)	 - Run a particular image on the cluster
* [kubectl scale](kubectl_scale.md)	 - Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job
* [kubectl set](kubectl_set.md)	 - Set specific features on objects
* [kubectl taint](kubectl_taint.md)	 - Update the taints on one or more nodes
* [kubectl top](kubectl_top.md)	 - Display Resource (CPU/Memory/Storage) usage.
* [kubectl uncordon](kubectl_uncordon.md)	 - Mark node as schedulable
* [kubectl version](kubectl_version.md)	 - Print the client and server version information

###### Auto generated by spf13/cobra on 11-Jan-2017
```