### PR TITLE
fixes config flag behaviour. related to #374 #375

### DIFF
--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -205,13 +205,15 @@ func init() {
 {{ if .viper }}
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" { // enable ability to specify config file via flag
-		viper.SetConfigFile(cfgFile)
-	}
 
 	viper.SetConfigName(".{{ .appName }}") // name of config file (without extension)
 	viper.AddConfigPath("$HOME")  // adding home directory as first search path
 	viper.AutomaticEnv()          // read in environment variables that match
+
+	// Checking for the cfgFile after setting default paths.
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -57,13 +57,15 @@ func init() {
 
 // Read in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" { // enable ability to specify config file via flag
-		viper.SetConfigFile(cfgFile)
-	}
 
 	viper.SetConfigName(".cobra") // name of config file (without extension)
 	viper.AddConfigPath("$HOME")  // adding home directory as first search path
 	viper.AutomaticEnv()          // read in environment variables that match
+
+	// Checking for the cfgFile after setting default paths.
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {


### PR DESCRIPTION
**Expected behaviour:**

`--config` flag should override the default config path ($HOME/.\<project\>.yaml)

**Observed behaviour**
`--config` flag is overriden by the default config path

**Fix**
Run `SetConfigFile` after setting defaults.

Related to #374 and #375 