### PR TITLE
Add EnableWindowsMouseTrap variable again 

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -45,6 +45,9 @@ var EnablePrefixMatching = false
 // To disable sorting, set it to false.
 var EnableCommandSorting = true
 
+// EnableWindowsMouseTrap enables an information splash screen on Windows if the CLI is started from explorer.exe.
+var EnableWindowsMouseTrap = true
+
 // AddTemplateFunc adds a template function that's available to Usage and Help
 // template generation.
 func AddTemplateFunc(name string, tmplFunc interface{}) {

--- a/command_win.go
+++ b/command_win.go
@@ -18,9 +18,11 @@ You need to open cmd.exe and run it from there.
 `
 
 func preExecHook(c *Command) {
-	if mousetrap.StartedByExplorer() {
-		c.Print(MousetrapHelpText)
-		time.Sleep(5 * time.Second)
-		os.Exit(1)
+	if EnableWindowsMouseTrap {
+		if mousetrap.StartedByExplorer() {
+			c.Print(MousetrapHelpText)
+			time.Sleep(5 * time.Second)
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
In commit 193b182195dad17ec904d4851f33e3ee3696bf07 EnableWindowsMouseTrap variable was removed. This variable allowed to control whether mousetrap was enabled or not for Windows