### PR TITLE
Fix SilenceUsage and SilenceErrors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ providing a way to handle the errors in one location. The current list of functi
 * PersistentPostRunE
 
 If you would like to silence the default `error` and `usage` output in favor of your own, you can set `SilenceUsage`
-and `SilenceErrors` to `false` on the command. A child command respects these flags if they are set on the parent
+and `SilenceErrors` to `true` on the command. A child command respects these flags if they are set on the parent
 command.
 
 **Example Usage using RunE:**


### PR DESCRIPTION
You have to set them to true to silence the default output, not false.