### PR TITLE
remove help command before adding it

### DIFF
--- a/command.go
+++ b/command.go
@@ -788,6 +788,7 @@ func (c *Command) initHelpCmd() {
 			},
 		}
 	}
+	c.RemoveCommand(c.helpCommand)
 	c.AddCommand(c.helpCommand)
 }
 


### PR DESCRIPTION
This fixes an issue where each Execute call grows the number of times
`help` appears in the help command by 1.