### PR TITLE
README: Use valid exit code value in `os.Exit` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ import (
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 ```
@@ -329,7 +329,7 @@ import (
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 ```


### PR DESCRIPTION
Exit code value range is 0-255. I think the examples in the main README document should be valid both syntactically and semantically.