### PR TITLE
Use go get so missing dependencies are fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ commands you want. It's the easiest way to incorporate Cobra into your applicati
 
 In order to use the cobra command, compile it using the following command:
 
-    > go install github.com/spf13/cobra/cobra
+    > go get github.com/spf13/cobra/cobra
 
 This will create the cobra executable under your go path bin directory!
 


### PR DESCRIPTION
If the developer is missing any dependencies, for instance `github.com/spf13/cobra/cobra`, `go install` will fail:

```bash
../../spf13/viper/util.go:29:2: cannot find package "gopkg.in/yaml.v2" in any of:
        /Users/campoy/src/golang.org/x/go/src/gopkg.in/yaml.v2 (from $GOROOT)
        /Users/campoy/src/gopkg.in/yaml.v2 (from $GOPATH)
```

While `go get github.com/spf13/cobra/cobra` will build the tool successfully.