### PR TITLE
Refactor flags mechanisms

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -569,7 +569,7 @@ func TestChildCommandFlags(t *testing.T) {
 	if r.Error == nil {
 		t.Errorf("invalid input should generate error")
 	}
-	if !strings.Contains(r.Error.Error(), "invalid argument \"10E\" for i10E") {
+	if !strings.Contains(r.Error.Error(), "invalid syntax") {
 		t.Errorf("Wrong error message displayed, \n %s", r.Error)
 	}
 }
@@ -987,7 +987,7 @@ func TestFlagsBeforeCommand(t *testing.T) {
 
 	// With parsing error properly reported
 	x = fullSetupTest("-i10E echo")
-	if !strings.Contains(x.Error.Error(), "invalid argument \"10E\" for i10E") {
+	if !strings.Contains(x.Error.Error(), "invalid syntax") {
 		t.Errorf("Wrong error message displayed, \n %s", x.Error)
 	}
 

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -1147,6 +1147,14 @@ func TestGlobalNormFuncPropagation(t *testing.T) {
 	}
 }
 
+func TestFlagOnPflagCommandLine(t *testing.T) {
+	flagName := "flagOnCommandLine"
+	pflag.CommandLine.String(flagName, "", "about my flag")
+	r := fullSetupTest("--help")
+
+	checkResultContains(t, r, flagName)
+}
+
 func TestAddTemplateFunctions(t *testing.T) {
 	AddTemplateFunc("t", func() bool { return true })
 	AddTemplateFuncs(template.FuncMap{

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -675,7 +675,7 @@ func TestPersistentFlags(t *testing.T) {
 	fullSetupTest("echo times -s again -c -p test here")
 
 	if strings.Join(tt, " ") != "test here" {
-		t.Errorf("flags didn't leave proper args remaining..%s given", tt)
+		t.Errorf("flags didn't leave proper args remaining. %s given", tt)
 	}
 
 	if flags1 != "again" {

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -3,7 +3,6 @@ package cobra
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -12,9 +11,6 @@ import (
 
 	"github.com/spf13/pflag"
 )
-
-var _ = fmt.Println
-var _ = os.Stderr
 
 var tp, te, tt, t1, tr []string
 var rootPersPre, echoPre, echoPersPre, timesPersPre []string
@@ -166,20 +162,22 @@ func flagInit() {
 	cmdRootWithRun.ResetFlags()
 	cmdSubNoRun.ResetFlags()
 	cmdCustomFlags.ResetFlags()
-	cmdRootNoRun.PersistentFlags().StringVarP(&flags2a, "strtwo", "t", "two", strtwoParentHelp)
-	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
-	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
-	cmdPrint.Flags().IntVarP(&flagi3, "intthree", "i", 345, "help message for flag intthree")
-	cmdCustomFlags.Flags().IntVar(&flagi4, "intfour", 456, "help message for flag intfour")
-	cmdEcho.PersistentFlags().StringVarP(&flags1, "strone", "s", "one", "help message for flag strone")
-	cmdEcho.PersistentFlags().BoolVarP(&flagbp, "persistentbool", "p", false, "help message for flag persistentbool")
-	cmdTimes.PersistentFlags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
-	cmdPrint.PersistentFlags().StringVarP(&flags3, "strthree", "s", "three", "help message for flag strthree")
-	cmdEcho.Flags().BoolVarP(&flagb1, "boolone", "b", true, "help message for flag boolone")
-	cmdTimes.Flags().BoolVarP(&flagb2, "booltwo", "c", false, "help message for flag booltwo")
-	cmdPrint.Flags().BoolVarP(&flagb3, "boolthree", "b", true, "help message for flag boolthree")
 	cmdVersion1.ResetFlags()
 	cmdVersion2.ResetFlags()
+
+	cmdRootNoRun.PersistentFlags().StringVarP(&flags2a, "strtwo", "t", "two", strtwoParentHelp)
+	cmdCustomFlags.Flags().IntVar(&flagi4, "intfour", 456, "help message for flag intfour")
+	cmdEcho.Flags().BoolVarP(&flagb1, "boolone", "b", true, "help message for flag boolone")
+	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
+	cmdEcho.PersistentFlags().BoolVarP(&flagbp, "persistentbool", "p", false, "help message for flag persistentbool")
+	cmdEcho.PersistentFlags().StringVarP(&flags1, "strone", "s", "one", "help message for flag strone")
+	cmdPrint.Flags().IntVarP(&flagi3, "intthree", "i", 345, "help message for flag intthree")
+	cmdTimes.Flags().BoolVarP(&flagb2, "booltwo", "c", false, "help message for flag booltwo")
+	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
+	cmdTimes.Flags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
+	cmdTimes.PersistentFlags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
+	cmdPrint.Flags().BoolVarP(&flagb3, "boolthree", "b", true, "help message for flag boolthree")
+	cmdPrint.PersistentFlags().StringVarP(&flags3, "strthree", "s", "three", "help message for flag strthree")
 }
 
 func commandInit() {
@@ -858,7 +856,6 @@ func TestFlagAccess(t *testing.T) {
 	}
 	if inherited.Lookup("strtwo") != nil {
 		t.Errorf("InheritedFlags shouldn not contain overwritten flag strtwo")
-
 	}
 }
 
@@ -1150,14 +1147,6 @@ func TestGlobalNormFuncPropagation(t *testing.T) {
 	}
 }
 
-func TestFlagOnPflagCommandLine(t *testing.T) {
-	flagName := "flagOnCommandLine"
-	pflag.CommandLine.String(flagName, "", "about my flag")
-	r := fullSetupTest("--help")
-
-	checkResultContains(t, r, flagName)
-}
-
 func TestAddTemplateFunctions(t *testing.T) {
 	AddTemplateFunc("t", func() bool { return true })
 	AddTemplateFuncs(template.FuncMap{
@@ -1183,5 +1172,25 @@ func TestUsageIsNotPrintedTwice(t *testing.T) {
 	r := simpleTester(cmd, "")
 	if strings.Count(r.Output, "Usage:") != 1 {
 		t.Error("Usage output is not printed exactly once")
+	}
+}
+
+func BenchmarkInheritedFlags(b *testing.B) {
+	initialize()
+	cmdEcho.AddCommand(cmdTimes)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cmdTimes.InheritedFlags()
+	}
+}
+
+func BenchmarkLocalFlags(b *testing.B) {
+	initialize()
+	cmdEcho.AddCommand(cmdTimes)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cmdTimes.LocalFlags()
 	}
 }

--- a/command.go
+++ b/command.go
@@ -1228,13 +1228,7 @@ func (c *Command) Parent() *Command {
 // mergePersistentFlags merges c.PersistentFlags() to c.Flags()
 // and adds missing persistent flags of all parents.
 func (c *Command) mergePersistentFlags() {
-	if c.HasPersistentFlags() {
-		c.PersistentFlags().VisitAll(func(f *flag.Flag) {
-			if c.Flags().Lookup(f.Name) == nil {
-				c.Flags().AddFlag(f)
-			}
-		})
-	}
+	c.Flags().AddFlagSet(c.PersistentFlags())
 
 	added := c.updateParentsPflags()
 	if len(added) > 0 {

--- a/command.go
+++ b/command.go
@@ -1258,6 +1258,8 @@ func (c *Command) updateParentsPflags() (added []*flag.Flag) {
 		c.parentsPflags.SortFlags = false
 	}
 
+	c.Root().PersistentFlags().AddFlagSet(flag.CommandLine)
+
 	c.VisitParents(func(x *Command) {
 		if x.HasPersistentFlags() {
 			x.PersistentFlags().VisitAll(func(f *flag.Flag) {


### PR DESCRIPTION
I think It's more obvious now to understand the inheritance of flags.

Updates #395
Fix #403
Fix #404

Performance improvements:
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkInheritedFlags-4     6536          5595          -14.40%
BenchmarkLocalFlags-4         3193          3235          +1.32%

benchmark                     old allocs     new allocs     delta
BenchmarkInheritedFlags-4     49             39             -20.41%
BenchmarkLocalFlags-4         23             21             -8.70%

benchmark                     old bytes     new bytes     delta
BenchmarkInheritedFlags-4     2040          1000          -50.98%
BenchmarkLocalFlags-4         1008          544           -46.03%
```

Also merge of https://github.com/spf13/pflag/pull/119 will significantly improve performance:
```
BenchmarkInheritedFlags-4   	 1000000	      1365 ns/op	       0 B/op	       0 allocs/op
BenchmarkLocalFlags-4       	 2000000	       900 ns/op	       0 B/op	       0 allocs/op
```