### PR TITLE
Fixed completion of dash parameters arguments

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -88,8 +88,8 @@ __handle_reply()
                 local index flag
                 flag="${cur%%=*}"
                 __index_of_word "${flag}" "${flags_with_completion[@]}"
+                COMPREPLY=()
                 if [[ ${index} -ge 0 ]]; then
-                    COMPREPLY=()
                     PREFIX=""
                     cur="${cur#*=}"
                     ${flags_completion[${index}]}


### PR DESCRIPTION
Fixed a bug when completing a dash argument ending with "=" will duplicate the parameter if there is nothing after the "=" character.
Example:
kubectl --log-dir=<tab>
would cause:
kubectl --log-dir=--log-dir=