### PR TITLE
Updating bash_completions to clarify markdown

### DIFF
--- a/bash_completions.md
+++ b/bash_completions.md
@@ -106,7 +106,7 @@ node                 pod                    replicationcontroller  service
 
 If your nouns have a number of aliases, you can define them alongside `ValidArgs` using `ArgAliases`:
 
-```go`
+```go
 argAliases []string = { "pods", "nodes", "services", "svc", "replicationcontrollers", "rc" }
 
 cmd := &cobra.Command{


### PR DESCRIPTION
"Plural form and shortcuts for nouns" section had a stray backtick, making Markdown rendering for code examples strange. Removed said backtick.