### PR TITLE
Update pflag link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ and flags that are only available to that command.
 In the example above, 'port' is the flag.
 
 Flag functionality is provided by the [pflag
-library](https://github.com/ogier/pflag), a fork of the flag standard library
+library](https://github.com/spf13/pflag), a fork of the flag standard library
 which maintains the same interface while adding POSIX compliance.
 
 ## Usage


### PR DESCRIPTION
Cobra is not using that version of pflag, but a fork of it.

It's a minor issue, but I ran into a bunch of dependency hell issues because I accidentally updated that one instead of the fork while trying to update cobra in a project.