### PR TITLE
__ltrim_colon_completions is not always available on macOS

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -133,7 +133,7 @@ __handle_reply()
     fi
 
     # available in bash-completion >= 2, not always present on macOS
-    if command -v __ltrim_colon_completions >/dev/null; then
+    if declare -F __ltrim_colon_completions >/dev/null; then
         __ltrim_colon_completions "$cur"
     fi
 }

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -132,7 +132,10 @@ __handle_reply()
         declare -F __custom_func >/dev/null && __custom_func
     fi
 
-    __ltrim_colon_completions "$cur"
+    # available in bash-completion >= 2, not always present on macOS
+    if command -v __ltrim_colon_completions >/dev/null; then
+        __ltrim_colon_completions "$cur"
+    fi
 }
 
 # The arguments should be in the form "ext1|ext2|extn"


### PR DESCRIPTION
So bash-completion should check first