### PR TITLE
Rename main func to initConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ func Execute() {
 	rootCmd.Execute()
 }
 
-func main() {
+func initConfig() {
   // Don't forget to read config either from cfgFile or from home directory!
 	if cfgFile != "" {
 		// Use config file from the flag.


### PR DESCRIPTION
The function called `main` in the manual creation example should be called
`initConfig`.