### PR TITLE
Print err instead of home

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ func main() {
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
-			fmt.Println(home)
+			fmt.Println(err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
When `home` can't be determined it doesn't make sense to print it.
The value of `err` should be printed instead.