### PR TITLE
Issue #412: When AddCommands, update childs' parentsPflags

### DIFF
--- a/command.go
+++ b/command.go
@@ -844,6 +844,13 @@ func (c *Command) AddCommand(cmds ...*Command) {
 		}
 		c.commands = append(c.commands, x)
 		c.commandsAreSorted = false
+		if cmds[i].parentsPflags == nil {
+			cmds[i].parentsPflags = flag.NewFlagSet(cmds[i].Name(), flag.ContinueOnError)
+			cmds[i].parentsPflags.SetOutput(c.flagErrorBuf)
+			cmds[i].parentsPflags.SortFlags = false
+		}
+		cmds[i].parentsPflags.AddFlagSet(c.PersistentFlags())
+		cmds[i].Flags().AddFlagSet(cmds[i].parentsPflags)
 	}
 }
 


### PR DESCRIPTION
I solve issue #412.

Before my PR, when AddCommands(), the children's parentsPFlags were not updated.
So there are some problems such as issue #412.

In my PR, update parentsPFlags when run AddCommands().