### PR TITLE
Add ability to get available sub commands

### DIFF
--- a/command.go
+++ b/command.go
@@ -1073,6 +1073,18 @@ func (c *Command) HasAvailableSubCommands() bool {
 	return false
 }
 
+// AvailableSubCommands returns available sub commands.
+func (c *Command) AvailableSubCommands() []*Command {
+	subCmds := []*Command{}
+
+	for _, sub := range c.commands {
+		if sub.IsAvailableCommand() {
+			subCmds = append(subCmds, sub)
+		}
+	}
+	return subCmds
+}
+
 // HasParent determines if the command is a child command.
 func (c *Command) HasParent() bool {
 	return c.parent != nil

--- a/command_test.go
+++ b/command_test.go
@@ -347,3 +347,22 @@ func TestSetHelpCommand(t *testing.T) {
 		t.Errorf("Expected to contain %q message, but got %q", correctMessage, output.String())
 	}
 }
+
+// TestAvailableSubCommands checks, if AvailableSubCommands works correctly
+func TestAvailableSubCommands(t *testing.T) {
+	doNothing := func(*Command, []string) {}
+
+	rootCmd := &Command{Run: doNothing}
+
+	helpSubCmd := &Command{Use: "H", Run: doNothing}
+	deprecatedSubCmd := &Command{Use: "D", Deprecated: "no reason", Run: doNothing}
+	availableSubCmd := &Command{Use: "A", Run: doNothing}
+
+	rootCmd.AddCommand(helpSubCmd, deprecatedSubCmd, availableSubCmd)
+	rootCmd.SetHelpCommand(helpSubCmd)
+
+	res, expect := rootCmd.AvailableSubCommands(), []*Command{availableSubCmd}
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("Expected %v, but got %v", expect, res)
+	}
+}


### PR DESCRIPTION
Hi @bogem, @spf13 

I'm using cobra in our project and reading cobra project. I found that we don't have ability to retrieve available sub commands, but we have ability to determine that a command has available sub commands. Does it make senses to add this functionality in cobra?

Thanks

