### PR TITLE
Fix TestGlobalNormFuncPropagation() on gccgo

### DIFF
--- a/cobra_test.go
+++ b/cobra_test.go
@@ -1166,7 +1166,7 @@ func TestGlobalNormFuncPropagation(t *testing.T) {
 
 	rootCmd := initialize()
 	rootCmd.SetGlobalNormalizationFunc(normFunc)
-	if reflect.ValueOf(normFunc) != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()) {
+	if reflect.ValueOf(normFunc).Pointer() != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()).Pointer() {
 		t.Error("rootCmd seems to have a wrong normalization function")
 	}
 


### PR DESCRIPTION
According to golang/go#9504 and https://golang.org/pkg/reflect/#Value,
== should not be used on two reflect.Values, but comparing the results
of their Interface() method does not work in this case, so let's
compare the results of their Pointer() method instead.

See https://stackoverflow.com/questions/9643205/how-do-i-compare-two-functions-for-pointer-equality-in-the-latest-go-weekly