### PR TITLE
Fix reproducibility in TestGolden{Add,Init}Cmd

### DIFF
--- a/cobra/cmd/add_test.go
+++ b/cobra/cmd/add_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 // TestGoldenAddCmd initializes the project "github.com/spf13/testproject"
@@ -20,6 +22,9 @@ func TestGoldenAddCmd(t *testing.T) {
 	// Initialize the project at first.
 	initializeProject(project)
 	defer os.RemoveAll(project.AbsPath())
+	defer viper.Set("year", nil)
+
+	viper.Set("year", 2017) // For reproducible builds
 
 	// Then add the "test" command.
 	cmdName := "test"

--- a/cobra/cmd/init_test.go
+++ b/cobra/cmd/init_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 // TestGoldenInitCmd initializes the project "github.com/spf13/testproject"
@@ -16,6 +18,9 @@ func TestGoldenInitCmd(t *testing.T) {
 	projectName := "github.com/spf13/testproject"
 	project := NewProject(projectName)
 	defer os.RemoveAll(project.AbsPath())
+	defer viper.Set("year", nil)
+
+	viper.Set("year", 2017) // For reproducible builds
 
 	os.Args = []string{"cobra", "init", projectName}
 	if err := rootCmd.Execute(); err != nil {

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -77,7 +77,11 @@ func getLicense() License {
 
 func copyrightLine() string {
 	author := viper.GetString("author")
-	year := time.Now().Format("2006")
+
+	year := viper.GetString("year") // For reproducible builds
+	if year == "" {
+		year = time.Now().Format("2006")
+	}
 
 	return "Copyright © " + year + " " + author
 }


### PR DESCRIPTION
These tests were time-dependent and would start failing in 2018
when the golden files still have the copyright year of 2017.

Fix by hard-coding the year 2017 for the purpose of these two tests
to ensure reproducible builds.

Fixes #503