### PR TITLE
Fix handling of custom license, make license fields actual templates

### DIFF
--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -16,7 +16,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -117,10 +116,7 @@ func main() {
 	cmd.Execute()
 }
 `
-	data := make(map[string]interface{})
-	data["copyright"] = copyrightLine()
-	data["license"] = project.License().Header
-	data["importpath"] = path.Join(project.Name(), filepath.Base(project.CmdPath()))
+	data := project.ProjectToMap()
 
 	mainScript, err := executeTemplate(mainTemplate, data)
 	if err != nil {
@@ -215,11 +211,8 @@ func initConfig() {
 }{{ end }}
 `
 
-	data := make(map[string]interface{})
-	data["copyright"] = copyrightLine()
+	data := project.ProjectToMap()
 	data["viper"] = viper.GetBool("useViper")
-	data["license"] = project.License().Header
-	data["appName"] = path.Base(project.Name())
 
 	rootCmdScript, err := executeTemplate(template, data)
 	if err != nil {

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -63,7 +63,7 @@ func getLicense() License {
 	// If user wants to have custom license, use that.
 	if viper.IsSet("license.header") || viper.IsSet("license.text") {
 		return License{Header: viper.GetString("license.header"),
-			Text: "license.text"}
+			Text: viper.GetString("license.text")}
 	}
 
 	// If user wants to have built-in license, use that.

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -76,6 +76,12 @@ func getLicense() License {
 }
 
 func copyrightLine() string {
+	copyright := viper.GetString("copyright")
+
+	if copyright != "" {
+		return copyright
+	}
+
 	author := viper.GetString("author")
 
 	year := viper.GetString("year") // For tests.

--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -14,6 +15,32 @@ type Project struct {
 	srcPath string
 	license License
 	name    string
+}
+
+// ProjectToMap returns a map representation of a Project suitable for using
+// in template expansion.
+func (p *Project) ProjectToMap() map[string]interface{} {
+	ret := make(map[string]interface{})
+	ret["absPath"] = p.absPath
+	ret["cmdPath"] = p.cmdPath
+	ret["srcPath"] = p.srcPath
+	ret["name"] = p.name
+
+	m := make(map[string]string)
+	m["Name"] = p.license.Name
+	m["Text"] = p.license.Text
+	m["Header"] = p.license.Header
+
+	ret["License"] = m
+
+	ret["copyright"] = copyrightLine()
+	ret["importpath"] = path.Join(p.Name(), filepath.Base(p.CmdPath()))
+	ret["appName"] = path.Base(p.Name())
+
+	expHeader, _ := executeTemplate(p.License().Header, ret)
+	ret["license"] = expHeader
+
+	return ret
 }
 
 // NewProject returns Project with specified project name.


### PR DESCRIPTION
This pull request causes license fields to actually behave as templates where interpolation can occur. It also generates correct `LICENSE` files in the case of custom licenses specified via YAML config file.

Inconsistency in the values available for interpolation is fixed by introducing a single function to convert from the `Project` structure into a `map[string]...` that exposes information for template expansion.

No changes to the `README` are required as this pull request actually causes behavior to match documentation.
