### PR TITLE
Support default value of $GOPATH

### DIFF
--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
-	"os/exec"
 )
 
 var cmdDirs = [...]string{"cmd", "cmds", "command", "commands"}

--- a/cobra/cmd/helpers.go
+++ b/cobra/cmd/helpers.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"os/exec"
 )
 
 var cmdDirs = [...]string{"cmd", "cmds", "command", "commands"}
@@ -31,7 +32,27 @@ func init() {
 	envGoPath := os.Getenv("GOPATH")
 	goPaths := filepath.SplitList(envGoPath)
 	if len(goPaths) == 0 {
-		er("$GOPATH is not set")
+		// Adapted from https://github.com/Masterminds/glide/pull/798/files.
+		// As of Go 1.8 the GOPATH is no longer required to be set. Instead there
+		// is a default value. If there is no GOPATH check for the default value.
+		// Note, checking the GOPATH first to avoid invoking the go toolchain if
+		// possible.
+
+		goExecutable := os.Getenv("COBRA_GO_EXECUTABLE")
+		if len(goExecutable) <= 0 {
+			goExecutable = "go"
+		}
+
+		out, err := exec.Command(goExecutable, "env", "GOPATH").Output()
+		if err != nil {
+			er(err)
+		}
+
+		toolchainGoPath := strings.TrimSpace(string(out))
+		goPaths = filepath.SplitList(toolchainGoPath)
+		if len(goPaths) == 0 {
+			er("$GOPATH is not set")
+		}
 	}
 	srcPaths = make([]string, 0, len(goPaths))
 	for _, goPath := range goPaths {


### PR DESCRIPTION
Fixes #527.

This handles the default `$GOPATH` by checking if the environment variable exists, otherwise using the output of `go env GOPATH`. It is the same method as the Glide project (https://github.com/Masterminds/glide/pull/798/files).

This `init` script is the only place where the `GOPATH` environment variable is accessed, so this change should be sufficient for the project.

A questionable feature is the `COBRA_GO_EXECUTABLE` environment variable - I copied it from Glide, but it might not be needed.