### PR TITLE
used viper to get license.txt

### DIFF
--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -63,7 +63,7 @@ func getLicense() License {
 	// If user wants to have custom license, use that.
 	if viper.IsSet("license.header") || viper.IsSet("license.text") {
 		return License{Header: viper.GetString("license.header"),
-			Text: "license.text"}
+			Text: viper.GetString("license.text")}
 	}
 
 	// If user wants to have built-in license, use that.


### PR DESCRIPTION
look like viper.GetString wasn't used to get license text from viper