### PR TITLE
Fix TraverseChildren used with multiple subcommands

### DIFF
--- a/command.go
+++ b/command.go
@@ -1360,6 +1360,9 @@ func (c *Command) ParseFlags(args []string) error {
 		return nil
 	}
 
+	if c.flagErrorBuf == nil {
+		c.flagErrorBuf = new(bytes.Buffer)
+	}
 	beforeErrorBufLen := c.flagErrorBuf.Len()
 	c.mergePersistentFlags()
 	err := c.Flags().Parse(args)

--- a/command_test.go
+++ b/command_test.go
@@ -439,6 +439,32 @@ func TestTraverseWithBadChildFlag(t *testing.T) {
 	}
 }
 
+func TestTraverseWithTwoSubcommands(t *testing.T) {
+	cmd := &Command{
+		Use:              "do",
+		TraverseChildren: true,
+	}
+
+	sub := &Command{
+		Use:              "sub",
+		TraverseChildren: true,
+	}
+	cmd.AddCommand(sub)
+
+	subsub := &Command{
+		Use: "subsub",
+	}
+	sub.AddCommand(subsub)
+
+	c, _, err := cmd.Traverse([]string{"sub", "subsub"})
+	if err != nil {
+		t.Fatalf("Expected no error: %s", err)
+	}
+	if c.Name() != subsub.Name() {
+		t.Fatalf("wrong command %q expected %q", c.Name(), subsub.Name())
+	}
+}
+
 func TestRequiredFlags(t *testing.T) {
 	c := &Command{Use: "c", Run: func(*Command, []string) {}}
 	output := new(bytes.Buffer)


### PR DESCRIPTION
This PR fixes a nil dereference when `TraverseChildren` is used with multiple subcommands.