### PR TITLE
Add a field to disable [flags] in UseLine()

### DIFF
--- a/command.go
+++ b/command.go
@@ -118,6 +118,10 @@ type Command struct {
 	// will be printed by generating docs for this command.
 	DisableAutoGenTag bool
 
+	// DisableFlagsInUseLine will disable the addition of [flags] to the usage
+	// line of a command when printing help or generating docs
+	DisableFlagsInUseLine bool
+
 	// DisableSuggestions disables the suggestions based on Levenshtein distance
 	// that go along with 'unknown command' messages.
 	DisableSuggestions bool
@@ -995,6 +999,9 @@ func (c *Command) UseLine() string {
 		useline = c.parent.CommandPath() + " " + c.Use
 	} else {
 		useline = c.Use
+	}
+	if c.DisableFlagsInUseLine {
+		return useline
 	}
 	if c.HasAvailableFlags() && !strings.Contains(useline, "[flags]") {
 		useline += " [flags]"


### PR DESCRIPTION
`Command.UseLine()` will append a `[flags]` string for any command that has flags. This behaviour is often wrong. For example, in the following cases:

* the use line documents flags using some other string (`[FLAGS]`, `[OPTIONS]`, etc)
* the use line includes positional arguments, and https://godoc.org/github.com/spf13/pflag#SetInterspersed is set to false. This requires that flags appear before any positional arguments, so appending the string to the end of the use line is incorrect.

To fix these two problems I've added a new field to disable adding `[flags]` to the `UseLine`. The application will be responsible for included the string in the appropriate position in the usage line.