### PR TITLE
Remove confusing duplicate Execute from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,6 @@ func init() {
   viper.SetDefault("license", "apache")
 }
 
-func Execute() {
-  RootCmd.Execute()
-}
-
 func initConfig() {
   // Don't forget to read config either from cfgFile or from home directory!
   if cfgFile != "" {


### PR DESCRIPTION
This part of the example is a bit confusing since you use `cmd.RootCmd.Execute()` everywhere, but never use this function.