### PR TITLE
remove hard-coded "[flags]" in UseLine

### DIFF
--- a/command.go
+++ b/command.go
@@ -994,9 +994,6 @@ func (c *Command) UseLine() string {
 	} else {
 		useline = c.Use
 	}
-	if c.HasAvailableFlags() && !strings.Contains(useline, "[flags]") {
-		useline += " [flags]"
-	}
 	return useline
 }
 


### PR DESCRIPTION
remove hard-coded `[flags]` introduced by #422, which is changing the usage template. This will break some downstream projects, like [kubernetes](https://github.com/kubernetes/kubernetes/pull/53631#issuecomment-344054069).

@bogem @eparis 