### PR TITLE
Fix README example to be consistent with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,9 @@ populate it with the following:
 package cmd
 
 import (
-  "github.com/spf13/cobra"
   "fmt"
+
+  "github.com/spf13/cobra"
 )
 
 func init() {


### PR DESCRIPTION
Alphabetize and separate builtin imports from external imports
to be gofmt-compliant and consistent with other examples in README.