### PR TITLE
Ensure that '--version' flag works properly for root command

### DIFF
--- a/command.go
+++ b/command.go
@@ -685,7 +685,7 @@ func (c *Command) execute(a []string) (err error) {
 		return err
 	}
 
-	if helpVal || !c.Runnable() {
+	if helpVal {
 		return flag.ErrHelp
 	}
 
@@ -703,6 +703,10 @@ func (c *Command) execute(a []string) (err error) {
 			}
 			return err
 		}
+	}
+
+	if !c.Runnable() {
+		return flag.ErrHelp
 	}
 
 	c.preRun()

--- a/command_test.go
+++ b/command_test.go
@@ -867,7 +867,7 @@ func TestVersionTemplate(t *testing.T) {
 }
 
 func TestVersionFlagExecutedOnSubcommand(t *testing.T) {
-	rootCmd := &Command{Use: "root", Version: "1.0.0", Run: emptyRun}
+	rootCmd := &Command{Use: "root", Version: "1.0.0"}
 	rootCmd.AddCommand(&Command{Use: "sub", Run: emptyRun})
 
 	output, err := executeCommand(rootCmd, "--version", "sub")


### PR DESCRIPTION
Make it so that, in the case that the root command is not runnable
but has subcommands, specifying a '--version' flag will still
run the "version" behavior.