### PR TITLE
Remove trailing whitespace in rootcmd

### DIFF
--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -174,7 +174,7 @@ func Execute() {
 	}
 }
 
-func init() { {{if .viper}}
+func init() { {{- if .viper}}
 	cobra.OnInitialize(initConfig)
 {{end}}
 	// Here you will define your flags and configuration settings.

--- a/cobra/cmd/testdata/root.go.golden
+++ b/cobra/cmd/testdata/root.go.golden
@@ -49,7 +49,7 @@ func Execute() {
 	}
 }
 
-func init() { 
+func init() {
 	cobra.OnInitialize(initConfig)
 
 	// Here you will define your flags and configuration settings.


### PR DESCRIPTION
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>