### PR TITLE
Add Set* functions to allow overriding of localised values after create

### DIFF
--- a/command.go
+++ b/command.go
@@ -186,6 +186,30 @@ type Command struct {
 	versionTemplate string
 }
 
+// SetUse allows you to set the Use property after the command has been created, primarily intended to
+// facilitate localisation
+func (c *Command) SetUse(s string) {
+	c.Use = s
+}
+
+// SetShort allows you to set the Short property after the command has been created, primarily intended to
+// facilitate localisation
+func (c *Command) SetShort(s string) {
+	c.Short = s
+}
+
+// SetLong allows you to set the Long property after the command has been created, primarily intended to
+// facilitate localisation
+func (c *Command) SetLong(s string) {
+	c.Long = s
+}
+
+// SetExample allows you to set the Example property after the command has been created, primarily intended to
+// facilitate localisation
+func (c *Command) SetExample(s string) {
+	c.Example = s
+}
+
 // SetArgs sets arguments for the command. It is set to os.Args[1:] by default, if desired, can be overridden
 // particularly useful when testing.
 func (c *Command) SetArgs(a []string) {


### PR DESCRIPTION
Currently you can only set the following properties at the time of creation:

 * Use
 * Short
 * Long
 * Example

These are all properties that would hold localised strings. This PR allows you to modify them after creation of the struct, which in turn opens the door for localisation.

Of course you could in theory localise these at the time of creation, but this falls apart when you use Cobra to specify the localisation.

Regardless of use case, it seems fairly harmless to allow users to override these after creation.