### PR TITLE
Do not add a space after a single flag completion

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -136,6 +136,12 @@ __handle_reply()
     if declare -F __ltrim_colon_completions >/dev/null; then
         __ltrim_colon_completions "$cur"
     fi
+
+    # If there is only 1 completion and it is a flag with an = it will be completed
+    # but we don't want a space after the =
+    if [[ "${#COMPREPLY[@]}" -eq "1" ]] && [[ $(type -t compopt) = "builtin" ]] && [[ "${COMPREPLY[0]}" == --*= ]]; then
+       compopt -o nospace
+    fi
 }
 
 # The arguments should be in the form "ext1|ext2|extn"


### PR DESCRIPTION
If one has a program with`cmd.MarkFlagRequired("flagname")` and the user enters:
```
program [tab][tab]
```
The result will be `program --flagname=[[:space:]]` when we really want `program --flagname=` (with no space).  If the user instead did:
```
program -[tab][tab]
```
The result would have been correct.

This checks if there is a single value in COMPREPLY and if so if that value is a flag. If so it will not add the extra space on the end of the completed command line.