### PR TITLE
Fix attemptd assignment to non-variable in bash 3

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -176,7 +176,7 @@ __handle_flag()
 
     # keep flag value with flagname as flaghash
     # flaghash variable is an associative array which is only supported in bash > 3.
-    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" > 3 ]]; then
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
         if [ -n "${flagvalue}" ] ; then
             flaghash[${flagname}]=${flagvalue}
         elif [ -n "${words[ $((c+1)) ]}" ] ; then

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -175,12 +175,15 @@ __handle_flag()
     fi
 
     # keep flag value with flagname as flaghash
-    if [ -n "${flagvalue}" ] ; then
-        flaghash[${flagname}]=${flagvalue}
-    elif [ -n "${words[ $((c+1)) ]}" ] ; then
-        flaghash[${flagname}]=${words[ $((c+1)) ]}
-    else
-        flaghash[${flagname}]="true" # pad "true" for bool flag
+    # flaghash variable is an associative array which is only supported in bash > 3.
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" > 3 ]]; then
+        if [ -n "${flagvalue}" ] ; then
+            flaghash[${flagname}]=${flagvalue}
+        elif [ -n "${words[ $((c+1)) ]}" ] ; then
+            flaghash[${flagname}]=${words[ $((c+1)) ]}
+        else
+            flaghash[${flagname}]="true" # pad "true" for bool flag
+        fi
     fi
 
     # skip the argument to a two word flag


### PR DESCRIPTION
flaghash variable is an associative array which is only supported in bash > 3.

```
kubectl get service --namespace=kube-system k-bash: --namespace=: attempted assignment to non-variable (error token is "=")
```

fixes https://github.com/kubernetes/kubectl/issues/121, https://github.com/kubernetes/kubernetes/issues/29322, https://github.com/kubernetes/kubernetes/issues/32676
