### PR TITLE
Add Execute func example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ var rootCmd = &cobra.Command{
     // Do Stuff Here
   },
 }
+
+func Execute() {
+  if err := rootCmd.Execute(); err != nil {
+    fmt.Println(err)
+    os.Exit(1)
+  }
+}
 ```
 
 You will additionally define flags and handle configuration in your init() function.


### PR DESCRIPTION
Hi,

I'm a golang rookie and had a hard time grasping where the `cmd.Execute()` function came from in the first Getting Started section of the `README.md`. Hopefully it helps other not spending unnecessary time connecting the dots 😄 

This trivial addition defines the `cmd.Execute()` function that is referenced further down in the `main.go` example.

Found it in another repo that contains a minimal Cobra example: https://github.com/dharmeshkakadia/cobra-example/blob/master/cmd/root.go#L41, seems reasonable and does the trick.