### PR TITLE
Enable CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+workflows:
+  version: 2
+  main:
+    jobs:
+      - go-current
+      - go-previous
+      - go-latest
+base: &base
+  working_directory: /go/src/github.com/spf13/cobra
+  steps:
+    - checkout
+    - run:
+        name: "All Commands"
+        command: |
+          mkdir -p bin
+          curl -Lso bin/shellcheck https://github.com/caarlos0/shellcheck-docker/releases/download/v0.4.3/shellcheck
+          chmod +x bin/shellcheck
+          go get -t -v ./...
+          PATH=$PATH:$PWD/bin go test -v ./...
+          go build
+          diff -u <(echo -n) <(gofmt -d -s .)
+          if [ -z $NOVET ]; then
+            diff -u <(echo -n) <(go tool vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
+          fi
+version: 2
+jobs:
+  go-current:
+    docker:
+      - image: circleci/golang:1.8.3
+    <<: *base
+  go-previous:
+    docker:
+      - image: circleci/golang:1.7.6
+    <<: *base
+  go-latest:
+    docker:
+      - image: circleci/golang:latest
+    <<: *base


### PR DESCRIPTION
I wrote a basic config on how to get everything that's currently building right now with CircleCI 2.0. This offers faster, more flexible CI builds. Here's how this compares:

Travis CI builds (master branch)
- longest run/total: 3min 19secs
- all:
  - Go v1.76 - 0min 51secs
  - Go v1.83 - 0min 54secs
  - Go latest - 3min 19secs

CircleCI 1.0 (master branch)
- Go 1.9.1 - 1min 36secs

CircleCI 2.0 (branch of master branch)
- longest run/total: 0min 38secs
- all:
  - Go v1.76 - 0min 33secs
  - Go v1.83 - 0min 34secs
  - Go latest - 0min 14secs

If interested, we could also do test metadata collection, more versions of Go to test with, etc.

Lastly, if there's interest in merging this or not, it might make sense to bump the testing here and/or in `.travis.yml` to test on Go v1.9.x. Especially with Go v1.10 around the corner.

If there's any request or questions, please let me know.