### PR TITLE
Bash completion aliases

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -222,7 +222,7 @@ __%[1]s_handle_command()
         next_command="_${last_command}_${words[c]//:/__}"
     else
         if [[ $c -eq 0 ]]; then
-            next_command="_root_command"
+            next_command="_%[1]s_root_command"
         else
             next_command="_${words[c]//:/__}"
         fi
@@ -457,7 +457,7 @@ func gen(buf *bytes.Buffer, cmd *Command) {
 	commandName = strings.Replace(commandName, ":", "__", -1)
 
 	if cmd.Root() == cmd {
-		buf.WriteString(fmt.Sprint("_root_command()\n{\n"))
+		buf.WriteString(fmt.Sprintf("_%s_root_command()\n{\n", commandName))
 	} else {
 		buf.WriteString(fmt.Sprintf("_%s()\n{\n", commandName))
 	}
@@ -473,6 +473,7 @@ func gen(buf *bytes.Buffer, cmd *Command) {
 
 // GenBashCompletion generates bash completion file and writes to the passed writer.
 func (c *Command) GenBashCompletion(w io.Writer) error {
+	fmt.Println("called")
 	buf := new(bytes.Buffer)
 	writePreamble(buf, c.Name())
 	if len(c.BashCompletionFunction) > 0 {

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -473,7 +473,6 @@ func gen(buf *bytes.Buffer, cmd *Command) {
 
 // GenBashCompletion generates bash completion file and writes to the passed writer.
 func (c *Command) GenBashCompletion(w io.Writer) error {
-	fmt.Println("called")
 	buf := new(bytes.Buffer)
 	writePreamble(buf, c.Name())
 	if len(c.BashCompletionFunction) > 0 {

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -222,7 +222,7 @@ __%[1]s_handle_command()
         next_command="_${last_command}_${words[c]//:/__}"
     else
         if [[ $c -eq 0 ]]; then
-            next_command="_$(basename "${words[c]//:/__}")"
+            next_command="_root_command"
         else
             next_command="_${words[c]//:/__}"
         fi
@@ -243,7 +243,7 @@ __%[1]s_handle_word()
         __%[1]s_handle_flag
     elif __%[1]s_contains_word "${words[c]}" "${commands[@]}"; then
         __%[1]s_handle_command
-    elif [[ $c -eq 0 ]] && __%[1]s_contains_word "$(basename "${words[c]}")" "${commands[@]}"; then
+    elif [[ $c -eq 0 ]]; then
         __%[1]s_handle_command
     else
         __%[1]s_handle_noun
@@ -455,7 +455,13 @@ func gen(buf *bytes.Buffer, cmd *Command) {
 	commandName := cmd.CommandPath()
 	commandName = strings.Replace(commandName, " ", "_", -1)
 	commandName = strings.Replace(commandName, ":", "__", -1)
-	buf.WriteString(fmt.Sprintf("_%s()\n{\n", commandName))
+
+	if cmd.Root() == cmd {
+		buf.WriteString(fmt.Sprint("_root_command()\n{\n"))
+	} else {
+		buf.WriteString(fmt.Sprintf("_%s()\n{\n", commandName))
+	}
+
 	buf.WriteString(fmt.Sprintf("    last_command=%q\n", commandName))
 	writeCommands(buf, cmd)
 	writeFlags(buf, cmd)

--- a/bash_completions.md
+++ b/bash_completions.md
@@ -204,3 +204,17 @@ __kubectl_get_namespaces()
     fi
 }
 ```
+# Using bash aliases for commands
+
+You can also configure the `bash aliases` for the commands and they will also support completions.
+
+```bash
+alias aliasname=origcommand
+complete -o default -F __start_origcommand aliasname
+
+# and now when you run `aliasname` completion will make
+# suggestions as it did for `origcommand`.
+
+$) aliasname <tab><tab>
+completion     firstcommand   secondcommand
+```


### PR DESCRIPTION
This is continuation of PR #588 ( i messed up branch during rebasing from master).

I've taken out the code to support "cobra command aliases" which needed to use flaghash. I will work on that as a separate PR.

This current changes are just to support bash aliases for the root command

so we can do like: 

alias aliasname=origname
complete -o default -F __start_origname aliasname

and then we can use aliasname with completions working.