### PR TITLE
Return error when usage was output due to non-runnable command

### DIFF
--- a/command.go
+++ b/command.go
@@ -311,7 +311,7 @@ func (c *Command) HelpFunc() func(*Command, []string) {
 	}
 	return func(c *Command, a []string) {
 		c.mergePersistentFlags()
-		err := tmpl(c.OutOrStdout(), c.HelpTemplate(), c)
+		err := tmpl(c.OutOrStderr(), c.HelpTemplate(), c)
 		if err != nil {
 			c.Println(err)
 		}

--- a/command.go
+++ b/command.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	flag "github.com/spf13/pflag"
-	"strings"
 )
 
 var NotRunnable = errors.New("Command not runnable; need subcommand.")

--- a/command.go
+++ b/command.go
@@ -17,6 +17,7 @@ package cobra
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -713,7 +714,7 @@ func (c *Command) execute(a []string) (err error) {
 	}
 
 	if !c.Runnable() {
-		return flag.ErrHelp
+		return errors.New("Subcommand required.")
 	}
 
 	c.preRun()

--- a/command_test.go
+++ b/command_test.go
@@ -836,8 +836,8 @@ func TestHelpExecutedOnNonRunnableChild(t *testing.T) {
 	rootCmd.AddCommand(childCmd)
 
 	output, err := executeCommand(rootCmd, "child")
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+	if err != NotRunnable {
+		t.Error("Expected error for missing subcommand.")
 	}
 
 	checkStringContains(t, output, childCmd.Long)


### PR DESCRIPTION
This allows programs to detect running a non-runnable command as a failure condition and return a non-zero exit code, if they want to. For most existing programs, it will probably result in that behavior by default (assuming they exit non-zero whenever Execute() returns an error).

Usage output in this scenario is also now sent to stderr instead of stdout, which is better for scripting and seems more consistent with surrounding code.

Fixes #582 