### PR TITLE
Prefix bash functions with root command name

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -317,7 +317,7 @@ func writeFlagHandler(buf *bytes.Buffer, name string, annotations map[string][]s
 
 			var ext string
 			if len(value) > 0 {
-				ext = fmt.Sprintf("__%s_handle_filename_extension_flag ", cmd.Name()) + strings.Join(value, "|")
+				ext = fmt.Sprintf("__%s_handle_filename_extension_flag ", cmd.Root().Name()) + strings.Join(value, "|")
 			} else {
 				ext = "_filedir"
 			}
@@ -335,7 +335,7 @@ func writeFlagHandler(buf *bytes.Buffer, name string, annotations map[string][]s
 
 			var ext string
 			if len(value) == 1 {
-				ext = fmt.Sprintf("__%s_handle_subdirs_in_dir_flag ", cmd.Name()) + value[0]
+				ext = fmt.Sprintf("__%s_handle_subdirs_in_dir_flag ", cmd.Root().Name()) + value[0]
 			} else {
 				ext = "_filedir -d"
 			}

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -18,6 +19,16 @@ func checkOmit(t *testing.T, found, unexpected string) {
 func check(t *testing.T, found, expected string) {
 	if !strings.Contains(found, expected) {
 		t.Errorf("Expecting to contain: \n %q\nGot:\n %q\n", expected, found)
+	}
+}
+
+func checkRegex(t *testing.T, found, pattern string) {
+	matched, err := regexp.MatchString(pattern, found)
+	if err != nil {
+		t.Errorf("Error thrown performing MatchString: \n %s\n", err)
+	}
+	if !matched {
+		t.Errorf("Expecting to match: \n %q\nGot:\n %q\n", pattern, found)
 	}
 }
 
@@ -86,6 +97,11 @@ func TestBashCompletions(t *testing.T) {
 		Run:     emptyRun,
 	}
 
+	echoCmd.Flags().String("filename", "", "Enter a filename")
+	echoCmd.MarkFlagFilename("filename", "json", "yaml", "yml")
+	echoCmd.Flags().String("config", "", "config to use (located in /config/PROFILE/)")
+	echoCmd.Flags().SetAnnotation("config", BashCompSubdirsInDir, []string{"config"})
+
 	printCmd := &Command{
 		Use:   "print [string to print]",
 		Args:  MinimumNArgs(1),
@@ -148,10 +164,14 @@ func TestBashCompletions(t *testing.T) {
 	check(t, output, `must_have_one_noun+=("three")`)
 	// check for filename extension flags
 	check(t, output, fmt.Sprintf(`flags_completion+=("__%s_handle_filename_extension_flag json|yaml|yml")`, rootCmd.Name()))
+	// check for filename extension flags in a subcommand
+	checkRegex(t, output, fmt.Sprintf(`_root_echo\(\)\n{[^}]*flags_completion\+=\("__%s_handle_filename_extension_flag json\|yaml\|yml"\)`, rootCmd.Name()))
 	// check for custom flags
 	check(t, output, `flags_completion+=("__complete_custom")`)
 	// check for subdirs_in_dir flags
 	check(t, output, fmt.Sprintf(`flags_completion+=("__%s_handle_subdirs_in_dir_flag themes")`, rootCmd.Name()))
+	// check for subdirs_in_dir flags in a subcommand
+	checkRegex(t, output, fmt.Sprintf(`_root_echo\(\)\n{[^}]*flags_completion\+=\("__%s_handle_subdirs_in_dir_flag config"\)`, rootCmd.Name()))
 
 	checkOmit(t, output, deprecatedCmd.Name())
 


### PR DESCRIPTION
Prior to this PR the autocomplete bash functions were being prefixed with the root command name, but references to those functions from subcommands were having the subcommands prefixed instead - causing the function lookups to fail and error out.

As spotted by @janetkuo in kubernetes/kubernetes#60517:
```
kubectl create -f [Tab] failed with the following message: kubectl
create -f __create_handle_filename_extension_flag: command not found
```
in this case the function being invoked should be:
```
__kubectl_handle_filename_extension_flag
```
This PR switches to using `cmd.Root().Name()` in order to use the root rather than subcommand.

![kubectl_autocomplete](https://user-images.githubusercontent.com/83862/36763532-49a6ea18-1c20-11e8-891f-a10ff0d7604f.gif)