### PR TITLE
Update the bash completion example for kubectl

### DIFF
--- a/bash_completions.md
+++ b/bash_completions.md
@@ -6,15 +6,16 @@ Generating bash completions from a cobra command is incredibly easy. An actual p
 package main
 
 import (
-        "io/ioutil"
-        "os"
+	"io/ioutil"
+	"os"
 
-        "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 func main() {
-        kubectl := cmd.NewFactory(nil).NewKubectlCommand(os.Stdin, ioutil.Discard, ioutil.Discard)
-        kubectl.GenBashCompletionFile("out.sh")
+	kubectl := cmd.NewKubectlCommand(util.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl.GenBashCompletionFile("out.sh")
 }
 ```
 


### PR DESCRIPTION
The current example is not working.