### PR TITLE
terminates the flags when -- is found in commandline

### DIFF
--- a/command.go
+++ b/command.go
@@ -475,6 +475,9 @@ Loop:
 		s := args[0]
 		args = args[1:]
 		switch {
+		case s == "--":
+			// "--" terminates the flags
+			break Loop
 		case strings.HasPrefix(s, "--") && !strings.Contains(s, "=") && !hasNoOptDefVal(s[2:], flags):
 			// If '--flag arg' then
 			// delete arg from args.


### PR DESCRIPTION
Fixes kubernetes/kubernetes#61184

When `--` is found in the command line, the args come after should not be treated as regular flags.

Just like the example shown in kubernetes/kubernetes#61184, the `normalizeNameFunc` should be only applicable for args before `--`.

@eparis @bogem PTAL