### PR TITLE
Update error output to use Help() instead of UsageString()

### DIFF
--- a/command.go
+++ b/command.go
@@ -861,7 +861,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		// If root command has SilentUsage flagged,
 		// all subcommands should respect it
 		if !cmd.SilenceUsage && !c.SilenceUsage {
-			c.Println(cmd.UsageString())
+			cmd.Help()
 		}
 	}
 	return cmd, err


### PR DESCRIPTION
When an error occurs due to invalid user input, the error is printed followed by the usage instructions of the command.

The problem is when you have changed the help template through `SetHelpTemplate` as this will show the default help template.

Calling `cmd.Help()` seems to do the trick and uses the new template to generate the content.