### PR TITLE
remove dot after the abs path

### DIFF
--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -65,7 +65,7 @@ Init will not use an existing directory with contents.`,
 		initializeProject(project)
 
 		fmt.Fprintln(cmd.OutOrStdout(), `Your Cobra application is ready at
-`+project.AbsPath()+`.
+`+project.AbsPath()+`
 
 Give it a try by going there and running `+"`go run main.go`."+`
 Add commands to it by running `+"`cobra add [cmdname]`.")


### PR DESCRIPTION
after doing cobra init pkg/name/command, it prints the abs path with a dot. which is a little annoying to copy

Kindly merge if you think this change is acceptable.