### PR TITLE
 [fix bug: can not use cobra in project name endwith `cmd`] add func findCmdSuffix

### DIFF
--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -92,7 +92,8 @@ func NewProjectFromPath(absPath string) *Project {
 	}
 
 	p := new(Project)
-	p.absPath = strings.TrimSuffix(absPath, findCmdDir(absPath))
+
+	p.absPath = findCmdPath(absPath)
 	p.name = filepath.ToSlash(trimSrcPath(p.absPath, p.SrcPath()))
 	return p
 }
@@ -128,6 +129,15 @@ func (p *Project) CmdPath() string {
 		p.cmdPath = filepath.Join(p.absPath, findCmdDir(p.absPath))
 	}
 	return p.cmdPath
+}
+
+// findCmdPath returns the cmd path.
+func findCmdPath(path string) string {
+	cmdDir := findCmdDir(path)
+	if filepathHasPrefix(cmdDir, string(os.PathSeparator)) {
+		return strings.TrimSuffix(path, cmdDir)
+	}
+	return strings.TrimSuffix(path, string(os.PathSeparator)+cmdDir)
 }
 
 // findCmdDir checks if base of absPath is cmd dir and returns it or


### PR DESCRIPTION
If cobra init a project named endwith 'cmd', will result the problem, when add command, the `command.go` will create in the wrong place

```cmd
$ cobra init tcmd
$ cd tcmd
$ cobra add hello

```
hello.go create in the path `src/t/cmd/hello.go` not `src/tcmd/cmd/hello.go`

to fix this bug, add os.PathSeparator to the findCmdDir func, thus 

`p.absPath = strings.TrimSuffix(absPath, findCmdDir(absPath))`

can get the correct path