### PR TITLE
#655 Validate Required Flags Before Prerun

### DIFF
--- a/command.go
+++ b/command.go
@@ -736,6 +736,10 @@ func (c *Command) execute(a []string) (err error) {
 		return err
 	}
 
+	if err := c.validateRequiredFlags(); err != nil {
+		return err
+	}
+
 	for p := c; p != nil; p = p.Parent() {
 		if p.PersistentPreRunE != nil {
 			if err := p.PersistentPreRunE(c, argWoFlags); err != nil {
@@ -747,6 +751,7 @@ func (c *Command) execute(a []string) (err error) {
 			break
 		}
 	}
+
 	if c.PreRunE != nil {
 		if err := c.PreRunE(c, argWoFlags); err != nil {
 			return err
@@ -755,9 +760,6 @@ func (c *Command) execute(a []string) (err error) {
 		c.PreRun(c, argWoFlags)
 	}
 
-	if err := c.validateRequiredFlags(); err != nil {
-		return err
-	}
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {
 			return err


### PR DESCRIPTION
Validated Required Flags before Running Preruns. Any error in Prerun results in Validation Not Happening. As a result Required Flags can't be used in Preruns Safely.

Refer: https://github.com/spf13/cobra/issues/655