### PR TITLE
fix test build breakage with go1.11

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1164,12 +1164,13 @@ func TestPersistentHooks(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	// TODO: This test fails, but should not.
-	// Related to https://github.com/spf13/cobra/issues/252.
-	//
-	// if parentPersPreArgs != "one two" {
-	// 	t.Errorf("Expected parentPersPreArgs %q, got %q", "one two", parentPersPreArgs)
-	// }
+	// TODO: currently PersistenPreRun* defined in parent does not
+	// run if the matchin child subcommand has PersistenPreRun.
+	// If the behavior changes (https://github.com/spf13/cobra/issues/252)
+	// this test must be fixed.
+	if parentPersPreArgs != "" {
+		t.Errorf("Expected blank parentPersPreArgs, got %q", parentPersPreArgs)
+	}
 	if parentPreArgs != "" {
 		t.Errorf("Expected blank parentPreArgs, got %q", parentPreArgs)
 	}
@@ -1179,12 +1180,13 @@ func TestPersistentHooks(t *testing.T) {
 	if parentPostArgs != "" {
 		t.Errorf("Expected blank parentPostArgs, got %q", parentPostArgs)
 	}
-	// TODO: This test fails, but should not.
-	// Related to https://github.com/spf13/cobra/issues/252.
-	//
-	// if parentPersPostArgs != "one two" {
-	// 	t.Errorf("Expected parentPersPostArgs %q, got %q", "one two", parentPersPostArgs)
-	// }
+	// TODO: currently PersistenPostRun* defined in parent does not
+	// run if the matchin child subcommand has PersistenPostRun.
+	// If the behavior changes (https://github.com/spf13/cobra/issues/252)
+	// this test must be fixed.
+	if parentPersPostArgs != "" {
+		t.Errorf("Expected blank parentPersPostArgs, got %q", parentPersPostArgs)
+	}
 
 	if childPersPreArgs != "one two" {
 		t.Errorf("Expected childPersPreArgs %q, got %q", "one two", childPersPreArgs)


### PR DESCRIPTION
As discussed in golang/go#26109, vet typecheck is enabled
in go1.11 and the command_test.go can't be compiled any
more with go1.11 due to the unread variables in the
command_test.go.

Instead of removing the unused variables, this CL reads the
variables and compares the values against the current
behavior so when the related issue is fixed, this test can
be updated accordingly.