### PR TITLE
Run Persistent*Run from root to sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ the version template. The template can be customized using the
 
 ## PreRun and PostRun Hooks
 
-It is possible to run functions before or after the main `Run` function of your command. The `PersistentPreRun` and `PreRun` functions will be executed before `Run`. `PersistentPostRun` and `PostRun` will be executed after `Run`.  The `Persistent*Run` functions will be inherited by children if they do not declare their own.  These functions are run in the following order:
+It is possible to run functions before or after the main `Run` function of your command. The `PersistentPreRun` and `PreRun` functions will be executed before `Run`. `PersistentPostRun` and `PostRun` will be executed after `Run`.  If parent and child commands declare `Persistent*Run` functions, they will be run in order from parent to child.  These functions are run in the following order:
 
 - `PersistentPreRun`
 - `PreRun`

--- a/command.go
+++ b/command.go
@@ -736,17 +736,22 @@ func (c *Command) execute(a []string) (err error) {
 		return err
 	}
 
+	persistentPreRuns := []*Command{}
 	for p := c; p != nil; p = p.Parent() {
+		persistentPreRuns = append(persistentPreRuns, p)
+	}
+
+	for i := len(persistentPreRuns) - 1; i >= 0; i-- {
+		p := persistentPreRuns[i]
 		if p.PersistentPreRunE != nil {
 			if err := p.PersistentPreRunE(c, argWoFlags); err != nil {
 				return err
 			}
-			break
 		} else if p.PersistentPreRun != nil {
 			p.PersistentPreRun(c, argWoFlags)
-			break
 		}
 	}
+
 	if c.PreRunE != nil {
 		if err := c.PreRunE(c, argWoFlags); err != nil {
 			return err
@@ -765,6 +770,7 @@ func (c *Command) execute(a []string) (err error) {
 	} else {
 		c.Run(c, argWoFlags)
 	}
+
 	if c.PostRunE != nil {
 		if err := c.PostRunE(c, argWoFlags); err != nil {
 			return err
@@ -772,15 +778,20 @@ func (c *Command) execute(a []string) (err error) {
 	} else if c.PostRun != nil {
 		c.PostRun(c, argWoFlags)
 	}
+
+	persistentPostRuns := []*Command{}
 	for p := c; p != nil; p = p.Parent() {
+		persistentPostRuns = append(persistentPostRuns, p)
+	}
+
+	for i := len(persistentPostRuns) - 1; i >= 0; i-- {
+		p := persistentPostRuns[i]
 		if p.PersistentPostRunE != nil {
 			if err := p.PersistentPostRunE(c, argWoFlags); err != nil {
 				return err
 			}
-			break
 		} else if p.PersistentPostRun != nil {
 			p.PersistentPostRun(c, argWoFlags)
-			break
 		}
 	}
 

--- a/command_test.go
+++ b/command_test.go
@@ -1117,9 +1117,15 @@ func TestPersistentHooks(t *testing.T) {
 		childPersPostArgs string
 	)
 
+	var (
+		lastPersPreRunCalled  string
+		lastPersPostRunCalled string
+	)
+
 	parentCmd := &Command{
 		Use: "parent",
 		PersistentPreRun: func(_ *Command, args []string) {
+			lastPersPreRunCalled = "parentCmd"
 			parentPersPreArgs = strings.Join(args, " ")
 		},
 		PreRun: func(_ *Command, args []string) {
@@ -1132,6 +1138,7 @@ func TestPersistentHooks(t *testing.T) {
 			parentPostArgs = strings.Join(args, " ")
 		},
 		PersistentPostRun: func(_ *Command, args []string) {
+			lastPersPostRunCalled = "parentCmd"
 			parentPersPostArgs = strings.Join(args, " ")
 		},
 	}
@@ -1139,6 +1146,7 @@ func TestPersistentHooks(t *testing.T) {
 	childCmd := &Command{
 		Use: "child",
 		PersistentPreRun: func(_ *Command, args []string) {
+			lastPersPreRunCalled = "childCmd"
 			childPersPreArgs = strings.Join(args, " ")
 		},
 		PreRun: func(_ *Command, args []string) {
@@ -1151,6 +1159,7 @@ func TestPersistentHooks(t *testing.T) {
 			childPostArgs = strings.Join(args, " ")
 		},
 		PersistentPostRun: func(_ *Command, args []string) {
+			lastPersPostRunCalled = "childCmd"
 			childPersPostArgs = strings.Join(args, " ")
 		},
 	}
@@ -1164,12 +1173,8 @@ func TestPersistentHooks(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	// TODO: currently PersistenPreRun* defined in parent does not
-	// run if the matchin child subcommand has PersistenPreRun.
-	// If the behavior changes (https://github.com/spf13/cobra/issues/252)
-	// this test must be fixed.
-	if parentPersPreArgs != "" {
-		t.Errorf("Expected blank parentPersPreArgs, got %q", parentPersPreArgs)
+	if parentPersPreArgs != "one two" {
+		t.Errorf("Expected %q parentPersPreArgs, got %q", "one two", parentPersPreArgs)
 	}
 	if parentPreArgs != "" {
 		t.Errorf("Expected blank parentPreArgs, got %q", parentPreArgs)
@@ -1180,12 +1185,8 @@ func TestPersistentHooks(t *testing.T) {
 	if parentPostArgs != "" {
 		t.Errorf("Expected blank parentPostArgs, got %q", parentPostArgs)
 	}
-	// TODO: currently PersistenPostRun* defined in parent does not
-	// run if the matchin child subcommand has PersistenPostRun.
-	// If the behavior changes (https://github.com/spf13/cobra/issues/252)
-	// this test must be fixed.
-	if parentPersPostArgs != "" {
-		t.Errorf("Expected blank parentPersPostArgs, got %q", parentPersPostArgs)
+	if parentPersPostArgs != "one two" {
+		t.Errorf("Expected %q parentPersPostArgs, got %q", "one two", parentPersPostArgs)
 	}
 
 	if childPersPreArgs != "one two" {
@@ -1202,6 +1203,13 @@ func TestPersistentHooks(t *testing.T) {
 	}
 	if childPersPostArgs != "one two" {
 		t.Errorf("Expected childPersPostArgs %q, got %q", "one two", childPersPostArgs)
+	}
+
+	if lastPersPreRunCalled != "childCmd" {
+		t.Errorf("Expected %q PersistentPreRun to be the last called, got %q", "childCmd", lastPersPreRunCalled)
+	}
+	if lastPersPostRunCalled != "childCmd" {
+		t.Errorf("Expected %q PersistentPostRun to be the last called, got %q", "childCmd", lastPersPostRunCalled)
 	}
 }
 


### PR DESCRIPTION
```
Call all Persitent*Run defined from sub to root

Signed-off-by: Alexander Trost <galexrt@googlemail.com>
```

Resolves #252

I haven't updated the docs with the "new" behavior yet, because I want to see if this is wanted.