### PR TITLE
Run tests against go 1.11 and drop 1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ version: 2
 jobs:
   go-current:
     docker:
-      - image: circleci/golang:1.10.0
+      - image: circleci/golang:1.11
     <<: *base
   go-previous:
     docker:
-      - image: circleci/golang:1.9.4
+      - image: circleci/golang:1.10
     <<: *base
   go-latest:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,49 @@
+version: 2
+
+references:
+  workspace: &workspace
+    /go/src/github.com/spf13/cobra
+
+  run_tests: &run_tests
+    run:
+      name: "All Commands"
+      command: |
+        mkdir -p bin
+        curl -Lso bin/shellcheck https://github.com/caarlos0/shellcheck-docker/releases/download/v0.4.6/shellcheck
+        chmod +x bin/shellcheck
+        go get -t -v ./...
+        PATH=$PATH:$PWD/bin go test -v ./...
+        go build
+        if [ -z $NOVET ]; then
+          diff -u <(echo -n) <(go tool vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
+        fi
+
+jobs:
+  go-current:
+    docker:
+      - image: circleci/golang:1.11
+    working_directory: *workspace
+    steps:
+      - checkout
+      - *run_tests
+      - run:
+          name: "Check formatting"
+          command: diff -u <(echo -n) <(gofmt -d -s .)
+  go-previous:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: *workspace
+    steps:
+      - checkout
+      - *run_tests
+  go-latest:
+    docker:
+      - image: circleci/golang:latest
+    working_directory: *workspace
+    steps:
+      - checkout
+      - *run_tests
+
 workflows:
   version: 2
   main:
@@ -5,34 +51,3 @@ workflows:
       - go-current
       - go-previous
       - go-latest
-base: &base
-  working_directory: /go/src/github.com/spf13/cobra
-  steps:
-    - checkout
-    - run:
-        name: "All Commands"
-        command: |
-          mkdir -p bin
-          curl -Lso bin/shellcheck https://github.com/caarlos0/shellcheck-docker/releases/download/v0.4.6/shellcheck
-          chmod +x bin/shellcheck
-          go get -t -v ./...
-          PATH=$PATH:$PWD/bin go test -v ./...
-          go build
-          diff -u <(echo -n) <(gofmt -d -s .)
-          if [ -z $NOVET ]; then
-            diff -u <(echo -n) <(go tool vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
-          fi
-version: 2
-jobs:
-  go-current:
-    docker:
-      - image: circleci/golang:1.11
-    <<: *base
-  go-previous:
-    docker:
-      - image: circleci/golang:1.10
-    <<: *base
-  go-latest:
-    docker:
-      - image: circleci/golang:latest
-    <<: *base

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 matrix:
   include:
-    - go: 1.9.4
-    - go: 1.10.0
+    - go: 1.10.x
+    - go: 1.11.x
     - go: tip
   allow_failures:
     - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - go: 1.10.x
     - go: 1.11.x
     - go: tip
+    - go: 1.11.x
+      script: diff -u <(echo -n) <(gofmt -d -s .)
   allow_failures:
     - go: tip
 
@@ -15,7 +17,6 @@ before_install:
 script:
   - PATH=$PATH:$PWD/bin go test -v ./...
   - go build
-  - diff -u <(echo -n) <(gofmt -d -s .)
   - if [ -z $NOVET ]; then
       diff -u <(echo -n) <(go tool vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
     fi

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -71,7 +71,7 @@ func TestBashCompletions(t *testing.T) {
 		ArgAliases:             []string{"pods", "nodes", "services", "replicationcontrollers", "po", "no", "svc", "rc"},
 		ValidArgs:              []string{"pod", "node", "service", "replicationcontroller"},
 		BashCompletionFunction: bashCompletionFunc,
-		Run: emptyRun,
+		Run:                    emptyRun,
 	}
 	rootCmd.Flags().IntP("introot", "i", -1, "help message for flag introot")
 	rootCmd.MarkFlagRequired("introot")


### PR DESCRIPTION
The formatting of gofmt changed slightly in go 1.11.  The release notes recommend to use a specific binary of gofmt.  See https://golang.org/doc/go1.11#gofmt

This PR adapts to the new formatting applied by gofmt and changes the configs for travis and circleci to run gofmt only with go 1.11.