### PR TITLE
Remove unneeded imports from README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,6 @@ In a Cobra app, typically the main.go file is very bare. It serves, one purpose,
 package main
 
 import (
-  "fmt"
-  "os"
-
   "{pathToYourApp}/cmd"
 )
 


### PR DESCRIPTION
This cleans up a small issue in README.md