### PR TITLE
[minor] specify the color as the required arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ var cmd = &cobra.Command{
   Short: "hello",
   Args: func(cmd *cobra.Command, args []string) error {
     if len(args) < 1 {
-      return errors.New("requires at least one arg")
+      return errors.New("requires a color argument")
     }
     if myapp.IsValidColor(args[0]) {
       return nil


### PR DESCRIPTION
the error is specific to the colors arg, not a generic error, so just making it explicit for README clarity.