### PR TITLE
Fixed usage not being displayed on nonrunnable command

### DIFF
--- a/command.go
+++ b/command.go
@@ -431,7 +431,7 @@ func (c *Command) HelpTemplate() string {
 	}
 	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
-{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+{{end}}{{if or .Runnable .HasSubCommands .HasFlags}}{{.UsageString}}{{end}}`
 }
 
 // VersionTemplate return version template for the command.
@@ -721,6 +721,10 @@ func (c *Command) execute(a []string) (err error) {
 		}
 	}
 
+	if err := c.validateRequiredFlags(); err != nil {
+		return err
+	}
+
 	if !c.Runnable() {
 		return flag.ErrHelp
 	}
@@ -755,9 +759,6 @@ func (c *Command) execute(a []string) (err error) {
 		c.PreRun(c, argWoFlags)
 	}
 
-	if err := c.validateRequiredFlags(); err != nil {
-		return err
-	}
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {
 			return err

--- a/command_test.go
+++ b/command_test.go
@@ -835,12 +835,12 @@ func TestHelpExecutedOnNonRunnableChild(t *testing.T) {
 	childCmd := &Command{Use: "child", Long: "Long description"}
 	rootCmd.AddCommand(childCmd)
 
-	output, err := executeCommand(rootCmd, "child")
+	output, err := executeCommand(rootCmd, "child", "--help")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	checkStringContains(t, output, childCmd.Long)
+	checkStringContains(t, output, "Usage")
 }
 
 func TestVersionFlagExecuted(t *testing.T) {


### PR DESCRIPTION
Cobra didn't display the usage when the command was not a runnable, even when the `--help` flag was passed. 

Fixes https://github.com/spf13/cobra/issues/790, the side effect is that the usage will keep showing on nonrunnable commands. 