### PR TITLE
adding --force flag to initCmd

### DIFF
--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -88,18 +88,18 @@ func initializeProject(project *Project) {
 	} else if !isEmpty(project.AbsPath()) && !force { // If path exists and is not empty don't use it
 		er("Cobra will not create a new project in a non empty directory: " + project.AbsPath())
 	} else if !isEmpty(project.AbsPath()) && force {  // If path exists and force flag is true, use it but check to see if files exist first
-		if !exists(project.AbsPath() + "/"  + project.License().Name) {
-			fmt.Println(project.AbsPath() + "/LICENSE.txt exists... Skipping")
+		if !exists(project.AbsPath() + "/"  + "LICENSE.txt") {
+			fmt.Println(project.AbsPath() + "/LICENSE.txt does not exist... Creating")
 			createLicenseFile(project.License(), project.AbsPath())
 		}
 
 		if !exists(project.AbsPath() + "/"  + "main.go") {
-			fmt.Println(project.AbsPath() + "/main.go exists... Skipping")
+			fmt.Println(project.AbsPath() + "/main.go does not exist... Creating")
 			createMainFile(project)
 		}
 
 		if !exists(project.AbsPath() + "/"  + "cmd/root.go") {
-			fmt.Println(project.AbsPath() + "/cmd/root.go exists... Skipping")
+			fmt.Println(project.AbsPath() + "/cmd/root.go does not exist... Creating")
 			createRootCmdFile(project)
 		}
 	} else {


### PR DESCRIPTION
# What is this change?  

This PR adds a --force (shorthand -f)  flag to `cobra init`

# What does it fix?  

Cobra will not currently init inside of a non empty directory

# Is this a bug fix or a feature? 

Feature, existing users who do not use the flag will be unaffected. This is simply for advanced users who want the option of creating a cobra cli in an existing project.

# Does it break any existing functionality or force me to update to a new version?  

No and No.

# How has it been tested?  

`--- FAIL: TestGoldenAddCmd (0.00s)
    add_test.go:83: Lack 1 file(s): [root.go]
--- FAIL: TestGoldenInitCmd (0.00s)
    init_test.go:81: Lack 4 file(s): [cmd LICENSE main.go cmd/root.go]
FAIL
exit status 1
FAIL	github.com/apaz037/cobra/cobra/cmd	0.014s`

^ Will work on tests soon.**
