### PR TITLE
zsh: sort the commands to keep a determinist output

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -81,16 +82,24 @@ func writeLevel(w io.Writer, root *Command, i int) {
 	commands := filterByLevel(root, i)
 	byParent := groupByParent(commands)
 
-	for p, c := range byParent {
-		names := names(c)
-		fmt.Fprintf(w, "      %s)\n", p)
+	// sort the parents to keep a determinist order
+	parents := make([]string, len(byParent))
+	j := 0
+	for parent := range byParent {
+		parents[j] = parent
+		j++
+	}
+	sort.StringSlice(parents).Sort()
+
+	for _, parent := range parents {
+		names := names(byParent[parent])
+		fmt.Fprintf(w, "      %s)\n", parent)
 		fmt.Fprintf(w, "        _arguments '%d: :(%s)'\n", i, strings.Join(names, " "))
 		fmt.Fprintln(w, "      ;;")
 	}
 	fmt.Fprintln(w, "      *)")
 	fmt.Fprintln(w, "        _arguments '*: :_files'")
 	fmt.Fprintln(w, "      ;;")
-
 }
 
 func filterByLevel(c *Command, l int) []*Command {


### PR DESCRIPTION
It's a minor thing but it has become an annoyance as I have the bash and zsh completion generation hooked in a `go:generate` directive.

Currently the zsh completion doesn't sort the commands. As go doesn't guarantee a deterministic iteration over a map (and actually scramble it on purpose), this means that the zsh completion file can be different with each build.

This PR fix that.