### PR TITLE
Fix two word flags

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -199,7 +199,8 @@ __%[1]s_handle_flag()
     fi
 
     # skip the argument to a two word flag
-    if __%[1]s_contains_word "${words[c]}" "${two_word_flags[@]}"; then
+    if [[ ${words[c]} != *"="* ]] && __%[1]s_contains_word "${words[c]}" "${two_word_flags[@]}"; then
+			  __%[1]s_debug "${FUNCNAME[0]}: found a flag ${words[c]}, skip the next argument"
         c=$((c+1))
         # if we are looking for a flags value, don't show commands
         if [[ $c -eq $cword ]]; then
@@ -379,6 +380,10 @@ func writeFlag(buf *bytes.Buffer, flag *pflag.Flag, cmd *Command) {
 	}
 	format += "\")\n"
 	buf.WriteString(fmt.Sprintf(format, name))
+	if len(flag.NoOptDefVal) == 0 {
+		format = "    two_word_flags+=(\"--%s\")\n"
+		buf.WriteString(fmt.Sprintf(format, name))
+	}
 	writeFlagHandler(buf, "--"+name, flag.Annotations, cmd)
 }
 

--- a/bash_completions_test.go
+++ b/bash_completions_test.go
@@ -95,6 +95,10 @@ func TestBashCompletions(t *testing.T) {
 	rootCmd.Flags().String("theme", "", "theme to use (located in /themes/THEMENAME/)")
 	rootCmd.Flags().SetAnnotation("theme", BashCompSubdirsInDir, []string{"themes"})
 
+	// For two word flags check
+	rootCmd.Flags().StringP("two", "t", "", "this is two word flags")
+	rootCmd.Flags().BoolP("two-w-default", "T", false, "this is not two word flags")
+
 	echoCmd := &Command{
 		Use:     "echo [string to echo]",
 		Aliases: []string{"say"},
@@ -182,6 +186,12 @@ func TestBashCompletions(t *testing.T) {
 	check(t, output, fmt.Sprintf(`flags_completion+=("__%s_handle_subdirs_in_dir_flag themes")`, rootCmd.Name()))
 	// check for subdirs_in_dir flags in a subcommand
 	checkRegex(t, output, fmt.Sprintf(`_root_echo\(\)\n{[^}]*flags_completion\+=\("__%s_handle_subdirs_in_dir_flag config"\)`, rootCmd.Name()))
+
+	// check two word flags
+	check(t, output, `two_word_flags+=("--two")`)
+	check(t, output, `two_word_flags+=("-t")`)
+	checkOmit(t, output, `two_word_flags+=("--two-w-default")`)
+	checkOmit(t, output, `two_word_flags+=("-T")`)
 
 	checkOmit(t, output, deprecatedCmd.Name())
 


### PR DESCRIPTION
Flags like `--namespace` can also be a two-word flag, but the current completion considers only shorthand flags as two-word flags.

I also added test cases for two-word flags.