### PR TITLE
added variable to allow configuration of mousetrap message duration

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 	"unicode"
 )
 
@@ -55,6 +56,12 @@ var MousetrapHelpText string = `This is a command line tool.
 
 You need to open cmd.exe and run it from there.
 `
+
+// MousetrapDisplayDuration controls how long the MousetrapHelpText message is displayed on Windows
+// if the CLI is started from explorer.exe. Set to 0 to wait for the return key to be pressed.
+// To disable the mousetrap, just set MousetrapHelpText to blank string ("").
+// Works only on Microsoft Windows.
+var MousetrapDisplayDuration time.Duration = 5 * time.Second
 
 // AddTemplateFunc adds a template function that's available to Usage and Help
 // template generation.

--- a/command_win.go
+++ b/command_win.go
@@ -3,6 +3,7 @@
 package cobra
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -14,7 +15,12 @@ var preExecHookFn = preExecHook
 func preExecHook(c *Command) {
 	if MousetrapHelpText != "" && mousetrap.StartedByExplorer() {
 		c.Print(MousetrapHelpText)
-		time.Sleep(5 * time.Second)
+		if MousetrapDisplayDuration > 0 {
+			time.Sleep(MousetrapDisplayDuration)
+		} else {
+			c.Println("Press return to continue...")
+			fmt.Scanln()
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
New variable `MousetrapDisplayDuration` allows to modify the default display duration of 5s, or to completely disable the timeout and wait for the user to press the return key.

This allows for greater flexibility, instead of having to define a custom `preExecHook` for even such a small change. The requirement arose as in a UAT few users weren't able to read the message within the small default time span of only 5s. IMHO, if you wanted to keep the Mousetrap feature included, it should be configurable at least at a bare minimum.

This PR does not change the default behaviour.