### PR TITLE
fixed typo in cobra readme

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -28,9 +28,9 @@ cobra init github.com/spf13/newApp
 Once an application is initialized, Cobra can create additional commands for you.
 Let's say you created an app and you wanted the following commands for it:
 
-* app serve
-* app config
-* app config create
+* add serve
+* add config
+* add config create
 
 In your project directory (where your main.go file is) you would run the following:
 


### PR DESCRIPTION
Fixed typo showing cobra commands. Cobra "add" command is written as "app".