### PR TITLE
Adding Mattermost as Go project that is built using Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Many of the most widely used Go projects are built using Cobra including:
 * [rclone](http://rclone.org/)
 * [nehm](https://github.com/bogem/nehm)
 * [Pouch](https://github.com/alibaba/pouch)
+* [Mattermost](https://github.com/mattermost) ([mattermost-server](https://github.com/mattermost))
 
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
 [![CircleCI status](https://circleci.com/gh/spf13/cobra.png?circle-token=:circle-token "CircleCI status")](https://circleci.com/gh/spf13/cobra)


### PR DESCRIPTION
Adding [Mattermost](https://github.com/mattermost) ([mattermost-server](https://github.com/mattermost/mattermost-server)) as one of the Go projects that are built using Cobra.

Changes only apply to [README.md](https://github.com/spf13/cobra/blob/master/README.md)