### PR TITLE
Derive zsh completion from bash completion

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -1,11 +1,183 @@
+/*
+NOTICE: The zsh wrapper code below is derived from the completion code
+in kubectl (k8s.io/kubernetes/pkg/kubectl/cmd/completion/completion.go),
+with the following license:
+
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cobra
 
 import (
-	"bytes"
-	"fmt"
 	"io"
 	"os"
-	"strings"
+	"text/template"
+)
+
+const (
+	zshHead = `#compdef {{.Name}}
+
+__cobra_bash_source() {
+	alias shopt=':'
+	alias _expand=_bash_expand
+	alias _complete=_bash_comp
+	emulate -L sh
+	setopt kshglob noshglob braceexpand
+
+	source "$@"
+}
+
+__cobra_type() {
+	# -t is not supported by zsh
+	if [ "$1" == "-t" ]; then
+		shift
+
+		# fake Bash 4 to disable "complete -o nospace". Instead
+		# "compopt +-o nospace" is used in the code to toggle trailing
+		# spaces. We don't support that, but leave trailing spaces on
+		# all the time
+		if [ "$1" = "__cobra_compopt" ]; then
+			echo builtin
+			return 0
+		fi
+	fi
+	type "$@"
+}
+
+__cobra_compgen() {
+	local completions w
+	completions=( $(compgen "$@") ) || return $?
+
+	# filter by given word as prefix
+	while [[ "$1" = -* && "$1" != -- ]]; do
+		shift
+		shift
+	done
+	if [[ "$1" == -- ]]; then
+		shift
+	fi
+	for w in "${completions[@]}"; do
+		if [[ "${w}" = "$1"* ]]; then
+			echo "${w}"
+		fi
+	done
+}
+
+__cobra_compopt() {
+	true # don't do anything. Not supported by bashcompinit in zsh
+}
+
+__cobra_ltrim_colon_completions()
+{
+	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+		# Remove colon-word prefix from COMPREPLY items
+		local colon_word=${1%${1##*:}}
+		local i=${#COMPREPLY[*]}
+		while [[ $((--i)) -ge 0 ]]; do
+			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+		done
+	fi
+}
+
+__cobra_get_comp_words_by_ref() {
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
+	words=("${COMP_WORDS[@]}")
+	cword=("${COMP_CWORD[@]}")
+}
+
+__cobra_filedir() {
+	local RET OLD_IFS w qw
+
+	__cobra_debug "_filedir $@ cur=$cur"
+	if [[ "$1" = \~* ]]; then
+		# somehow does not work. Maybe, zsh does not call this at all
+		eval echo "$1"
+		return 0
+	fi
+
+	OLD_IFS="$IFS"
+	IFS=$'\n'
+	if [ "$1" = "-d" ]; then
+		shift
+		RET=( $(compgen -d) )
+	else
+		RET=( $(compgen -f) )
+	fi
+	IFS="$OLD_IFS"
+
+	IFS="," __cobra_debug "RET=${RET[@]} len=${#RET[@]}"
+
+	for w in ${RET[@]}; do
+		if [[ ! "${w}" = "${cur}"* ]]; then
+			continue
+		fi
+		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+			qw="$(__cobra_quote "${w}")"
+			if [ -d "${w}" ]; then
+				COMPREPLY+=("${qw}/")
+			else
+				COMPREPLY+=("${qw}")
+			fi
+		fi
+	done
+}
+
+__cobra_quote() {
+    if [[ $1 == \'* || $1 == \"* ]]; then
+        # Leave out first character
+        printf %q "${1:1}"
+    else
+	printf %q "$1"
+    fi
+}
+
+autoload -U +X bashcompinit && bashcompinit
+
+# use word boundary patterns for BSD or GNU sed
+LWORD='[[:<:]]'
+RWORD='[[:>:]]'
+if sed --help 2>&1 | grep -q GNU; then
+	LWORD='\<'
+	RWORD='\>'
+fi
+
+__{{.Name}}_convert_bash_to_zsh() {
+	sed \
+	-e 's/declare -F/whence -w/' \
+	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
+	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
+	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
+	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
+	-e "s/${LWORD}_filedir${RWORD}/__cobra_filedir/g" \
+	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__cobra_get_comp_words_by_ref/g" \
+	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__cobra_ltrim_colon_completions/g" \
+	-e "s/${LWORD}compgen${RWORD}/__cobra_compgen/g" \
+	-e "s/${LWORD}compopt${RWORD}/__cobra_compopt/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
+	-e "s/\\\$(type${RWORD}/\$(__cobra_type/g" \
+	<<'BASH_COMPLETION_EOF'
+`
+
+	zshTail = `
+BASH_COMPLETION_EOF
+}
+
+__cobra_bash_source <(__{{.Name}}_convert_bash_to_zsh)
+_complete {{.Name}} 2>/dev/null
+`
 )
 
 // GenZshCompletionFile generates zsh completion file.
@@ -21,106 +193,14 @@ func (c *Command) GenZshCompletionFile(filename string) error {
 
 // GenZshCompletion generates a zsh completion file and writes to the passed writer.
 func (c *Command) GenZshCompletion(w io.Writer) error {
-	buf := new(bytes.Buffer)
+	tpl := template.Must(template.New("head").Parse(zshHead))
+	template.Must(tpl.New("tail").Parse(zshTail))
 
-	writeHeader(buf, c)
-	maxDepth := maxDepth(c)
-	writeLevelMapping(buf, maxDepth)
-	writeLevelCases(buf, maxDepth, c)
-
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-func writeHeader(w io.Writer, cmd *Command) {
-	fmt.Fprintf(w, "#compdef %s\n\n", cmd.Name())
-}
-
-func maxDepth(c *Command) int {
-	if len(c.Commands()) == 0 {
-		return 0
+	if err := tpl.ExecuteTemplate(w, "head", c); err != nil {
+		return err
 	}
-	maxDepthSub := 0
-	for _, s := range c.Commands() {
-		subDepth := maxDepth(s)
-		if subDepth > maxDepthSub {
-			maxDepthSub = subDepth
-		}
+	if err := c.GenBashCompletion(w); err != nil {
+		return err
 	}
-	return 1 + maxDepthSub
-}
-
-func writeLevelMapping(w io.Writer, numLevels int) {
-	fmt.Fprintln(w, `_arguments \`)
-	for i := 1; i <= numLevels; i++ {
-		fmt.Fprintf(w, `  '%d: :->level%d' \`, i, i)
-		fmt.Fprintln(w)
-	}
-	fmt.Fprintf(w, `  '%d: :%s'`, numLevels+1, "_files")
-	fmt.Fprintln(w)
-}
-
-func writeLevelCases(w io.Writer, maxDepth int, root *Command) {
-	fmt.Fprintln(w, "case $state in")
-	defer fmt.Fprintln(w, "esac")
-
-	for i := 1; i <= maxDepth; i++ {
-		fmt.Fprintf(w, "  level%d)\n", i)
-		writeLevel(w, root, i)
-		fmt.Fprintln(w, "  ;;")
-	}
-	fmt.Fprintln(w, "  *)")
-	fmt.Fprintln(w, "    _arguments '*: :_files'")
-	fmt.Fprintln(w, "  ;;")
-}
-
-func writeLevel(w io.Writer, root *Command, i int) {
-	fmt.Fprintf(w, "    case $words[%d] in\n", i)
-	defer fmt.Fprintln(w, "    esac")
-
-	commands := filterByLevel(root, i)
-	byParent := groupByParent(commands)
-
-	for p, c := range byParent {
-		names := names(c)
-		fmt.Fprintf(w, "      %s)\n", p)
-		fmt.Fprintf(w, "        _arguments '%d: :(%s)'\n", i, strings.Join(names, " "))
-		fmt.Fprintln(w, "      ;;")
-	}
-	fmt.Fprintln(w, "      *)")
-	fmt.Fprintln(w, "        _arguments '*: :_files'")
-	fmt.Fprintln(w, "      ;;")
-
-}
-
-func filterByLevel(c *Command, l int) []*Command {
-	cs := make([]*Command, 0)
-	if l == 0 {
-		cs = append(cs, c)
-		return cs
-	}
-	for _, s := range c.Commands() {
-		cs = append(cs, filterByLevel(s, l-1)...)
-	}
-	return cs
-}
-
-func groupByParent(commands []*Command) map[string][]*Command {
-	m := make(map[string][]*Command)
-	for _, c := range commands {
-		parent := c.Parent()
-		if parent == nil {
-			continue
-		}
-		m[parent.Name()] = append(m[parent.Name()], c)
-	}
-	return m
-}
-
-func names(commands []*Command) []string {
-	ns := make([]string, len(commands))
-	for i, c := range commands {
-		ns[i] = c.Name()
-	}
-	return ns
+	return tpl.ExecuteTemplate(w, "tail", c)
 }

--- a/zsh_completions_test.go
+++ b/zsh_completions_test.go
@@ -6,84 +6,30 @@ import (
 	"testing"
 )
 
+const (
+	expectedTail = `BASH_COMPLETION_EOF
+}
+
+__cobra_bash_source <(__trivialapp_convert_bash_to_zsh)
+_complete trivialapp 2>/dev/null
+`
+	expectedHead = `#compdef trivialapp`
+)
+
 func TestZshCompletion(t *testing.T) {
-	tcs := []struct {
-		name                string
-		root                *Command
-		expectedExpressions []string
-	}{
-		{
-			name:                "trivial",
-			root:                &Command{Use: "trivialapp"},
-			expectedExpressions: []string{"#compdef trivial"},
-		},
-		{
-			name: "linear",
-			root: func() *Command {
-				r := &Command{Use: "linear"}
+	root := &Command{Use: "trivialapp"}
 
-				sub1 := &Command{Use: "sub1"}
-				r.AddCommand(sub1)
-
-				sub2 := &Command{Use: "sub2"}
-				sub1.AddCommand(sub2)
-
-				sub3 := &Command{Use: "sub3"}
-				sub2.AddCommand(sub3)
-				return r
-			}(),
-			expectedExpressions: []string{"sub1", "sub2", "sub3"},
-		},
-		{
-			name: "flat",
-			root: func() *Command {
-				r := &Command{Use: "flat"}
-				r.AddCommand(&Command{Use: "c1"})
-				r.AddCommand(&Command{Use: "c2"})
-				return r
-			}(),
-			expectedExpressions: []string{"(c1 c2)"},
-		},
-		{
-			name: "tree",
-			root: func() *Command {
-				r := &Command{Use: "tree"}
-
-				sub1 := &Command{Use: "sub1"}
-				r.AddCommand(sub1)
-
-				sub11 := &Command{Use: "sub11"}
-				sub12 := &Command{Use: "sub12"}
-
-				sub1.AddCommand(sub11)
-				sub1.AddCommand(sub12)
-
-				sub2 := &Command{Use: "sub2"}
-				r.AddCommand(sub2)
-
-				sub21 := &Command{Use: "sub21"}
-				sub22 := &Command{Use: "sub22"}
-
-				sub2.AddCommand(sub21)
-				sub2.AddCommand(sub22)
-
-				return r
-			}(),
-			expectedExpressions: []string{"(sub11 sub12)", "(sub21 sub22)"},
-		},
+	buf := &bytes.Buffer{}
+	err := root.GenZshCompletion(buf)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
+	actual := buf.String()
 
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			tc.root.GenZshCompletion(buf)
-			output := buf.String()
-
-			for _, expectedExpression := range tc.expectedExpressions {
-				if !strings.Contains(output, expectedExpression) {
-					t.Errorf("Expected completion to contain %q somewhere; got %q", expectedExpression, output)
-				}
-			}
-		})
+	if !strings.HasPrefix(actual, expectedHead) {
+		t.Error("Unexpected head")
+	}
+	if !strings.HasSuffix(actual, expectedTail) {
+		t.Error("Unexpected tail")
 	}
 }


### PR DESCRIPTION
This is a temporary fix to get some zsh completion. The idea is taken from kubectl where the bash completion script is wrapped with some zsh adapter code. The zsh magic is taken from kubectl.

There is an old PR #646 where a native zsh completion should be implemented. Sad thing is, there has been no progress for more than half. Since there should be a working out-of-the box solution, we should use this as an temporary drop-in until there is a better native zsh implementation.

Also see discussion in #107 