### PR TITLE
Add Prototool as a project built with Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Many of the most widely used Go projects are built using Cobra including:
 * [rclone](http://rclone.org/)
 * [nehm](https://github.com/bogem/nehm)
 * [Pouch](https://github.com/alibaba/pouch)
+* [Prototool](https://github.com/uber/prototool)
 
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
 [![CircleCI status](https://circleci.com/gh/spf13/cobra.png?circle-token=:circle-token "CircleCI status")](https://circleci.com/gh/spf13/cobra)


### PR DESCRIPTION
https://github.com/uber/prototool

#832 should be merged first to fix the build.