### PR TITLE
[Fix] [Travis] Execute 'go vet', use stages, use language conf list, add go 1.12.x, update shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: go
 
+stages:
+  - diff
+  - test
+
 matrix:
   include:
     - go: 1.10.x
     - go: 1.11.x
     - go: tip
-    - go: 1.11.x
+    - stage: diff
+      go: 1.11.x
       script: diff -u <(echo -n) <(gofmt -d -s .)
   allow_failures:
     - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ stages:
 go:
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 matrix:
-  include:
-    - stage: diff
-      go: 1.11.x
-      script: diff -u <(echo -n) <(gofmt -d -s .)
   allow_failures:
     - go: tip
+  include:
+    - stage: diff
+      go: 1.12.x
+      script: diff -u <(echo -n) <(gofmt -d -s .)
 
 before_install:
   - mkdir -p bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ script:
   - PATH=$PATH:$PWD/bin go test -v ./...
   - go build
   - if [ -z $NOVET ]; then
-      diff -u <(echo -n) <(go tool vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
+      diff -u <(echo -n) <(go vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
 before_install:
   - mkdir -p bin
-  - curl -Lso bin/shellcheck https://github.com/caarlos0/shellcheck-docker/releases/download/v0.4.3/shellcheck
+  - curl -Lso bin/shellcheck https://github.com/caarlos0/shellcheck-docker/releases/download/v0.6.0/shellcheck
   - chmod +x bin/shellcheck
 script:
   - PATH=$PATH:$PWD/bin go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ stages:
   - diff
   - test
 
+go:
+  - 1.10.x
+  - 1.11.x
+  - tip
+
 matrix:
   include:
-    - go: 1.10.x
-    - go: 1.11.x
-    - go: tip
     - stage: diff
       go: 1.11.x
       script: diff -u <(echo -n) <(gofmt -d -s .)


### PR DESCRIPTION
This PR includes several minor enhancements to `.travis.yml`:

- Execute 'go vet' instead of 'go tool vet', to fix the error with go `>1.11` (i.e. `tip` and/or `1.12`).
- Move the job that gets `diff` of `gofmt` to a separate stage in Travis, because it is not a test.
- Use language configuration list instead of explicit entries in `matrix.include`. This is a more natural way to handle the config in Travis.
- Run tests against go `1.12.x`.
- Update `shellcheck-docker` to `v0.6.0`.

This PR conflicts with #832. I can either rebase on top of @peter-edge's branch, or let him rebase on top of this. @eparis, wdyt?