### PR TITLE
Return nil error in validateRequiredFlags when help command

### DIFF
--- a/command.go
+++ b/command.go
@@ -879,6 +879,10 @@ func (c *Command) ValidateArgs(args []string) error {
 }
 
 func (c *Command) validateRequiredFlags() error {
+	if c.Name() == "help" {
+		return nil
+	}
+
 	flags := c.Flags()
 	missingFlagNames := []string{}
 	flags.VisitAll(func(pflag *flag.Flag) {


### PR DESCRIPTION
Hi guys!

When setting required flags to the root commands:
```
rootCmd.MarkPersistentFlagRequired("user")
```
seems that the help command throws an error before showing the help when those flags are not set:
```
$ ./cli help
Error: required flag(s) "user" not set
...
```
It does not make sense to me that required flags have to be validated when calling the `help` command. I do not know whether this would have more impact than skipping the validation.

In any case, thanks for your time!