### PR TITLE
Changed default usage command to just "help"

### DIFF
--- a/command.go
+++ b/command.go
@@ -837,7 +837,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		}
 		if !c.SilenceErrors {
 			c.Println("Error:", err.Error())
-			c.Printf("Run '%v --help' for usage.\n", c.CommandPath())
+			c.Printf("Run '%v help' for usage.\n", c.CommandPath())
 		}
 		return c, err
 	}


### PR DESCRIPTION
Cobra's `InitDefaultHelpCmd()` sets `help` and not `--help` as the command to print the usage. It makes more sense for the default `usageTemplate` to point to the default help command.