### PR TITLE
Add config to prevent addition of copyright notice

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -92,3 +92,6 @@ license:
 
 You can also use built-in licenses. For example, **GPLv2**, **GPLv3**, **LGPL**,
 **AGPL**, **MIT**, **2-Clause BSD** or **3-Clause BSD**.
+
+You can prevent the generation of the `// Copyright © 2015 AUTHOR <EMAIL>` line
+at the top of the file by setting `author` to `none`.

--- a/cobra/cmd/add.go
+++ b/cobra/cmd/add.go
@@ -120,9 +120,9 @@ func validateCmdName(source string) string {
 }
 
 func createCmdFile(license License, path, cmdName string) {
-	template := `{{comment .copyright}}
-{{if .license}}{{comment .license}}{{end}}
-
+	template := `{{if .copyright}}{{comment .copyright}}
+{{end}}{{if .license}}{{comment .license}}
+{{end}}
 package {{.cmdPackage}}
 
 import (

--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -106,9 +106,9 @@ func createLicenseFile(license License, path string) {
 }
 
 func createMainFile(project *Project) {
-	mainTemplate := `{{ comment .copyright }}
-{{if .license}}{{ comment .license }}{{end}}
-
+	mainTemplate := `{{if .copyright}}{{comment .copyright}}
+{{end}}{{if .license}}{{comment .license}}
+{{end}}
 package main
 
 import "{{ .importpath }}"
@@ -134,9 +134,9 @@ func main() {
 }
 
 func createRootCmdFile(project *Project) {
-	template := `{{comment .copyright}}
-{{if .license}}{{comment .license}}{{end}}
-
+	template := `{{if .copyright}}{{comment .copyright}}
+{{end}}{{if .license}}{{comment .license}}
+{{end}}
 package cmd
 
 import (

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -77,6 +77,9 @@ func getLicense() License {
 
 func copyrightLine() string {
 	author := viper.GetString("author")
+	if author == "none" {
+		return ""
+	}
 
 	year := viper.GetString("year") // For tests.
 	if year == "" {


### PR DESCRIPTION
Some projects do not add copyright headers to the tops of their files.
Right now you can specify `license: none` to prevent a license from
being generated for the file. But you will still get a line like:
  `// Copyright © 2017 NAME HERE <EMAIL ADDRESS>`

This change allows passing `author: none` to prevent that line from
being generated. The change does not alter the defaults. However, it
does slightly change the formatting templates to prevent the
extraneous addition of newlines when an author or liciece line is not
requested.