### PR TITLE
Add DisableHelpSubCommand option

### DIFF
--- a/command.go
+++ b/command.go
@@ -130,6 +130,10 @@ type Command struct {
 	// line of a command when printing help or generating docs
 	DisableFlagsInUseLine bool
 
+	// DisableHelpSubCommand will disable the addition of the "help" subcommand.
+	// The "-h" and "--help" flags will still be available.
+	DisableHelpSubCommand bool
+
 	// DisableSuggestions disables the suggestions based on Levenshtein distance
 	// that go along with 'unknown command' messages.
 	DisableSuggestions bool
@@ -938,7 +942,7 @@ func (c *Command) InitDefaultVersionFlag() {
 // It is called automatically by executing the c or by calling help and usage.
 // If c already has help command or c has no subcommands, it will do nothing.
 func (c *Command) InitDefaultHelpCmd() {
-	if !c.HasSubCommands() {
+	if c.DisableHelpSubCommand || !c.HasSubCommands() {
 		return
 	}
 


### PR DESCRIPTION
This option stops the creation of a "help" subcommand for when a CLI
tool only wants to have "-h" and "--help" to get examples/usage.

This can (in certain situations) help reduce abiguity in documentation.
Instead of having two ways to get help about a subcommand ("app help foo"
and "app foo --help") there can be only one.

As this option defaults to false, the default behavior remains the same.

Closes #587