### PR TITLE
Parent Handling improved

### DIFF
--- a/cobra/cmd/add.go
+++ b/cobra/cmd/add.go
@@ -143,7 +143,7 @@ func createCmdFile(license License, path, cmdName string, cmdVariable string) {
 {{if .license}}{{comment .license}}{{end}}
 
 package {{.cmdPackage}}
-//This is a test
+
 import (
 	"fmt"
 

--- a/cobra/cmd/add_test.go
+++ b/cobra/cmd/add_test.go
@@ -31,9 +31,9 @@ func TestGoldenAddCmd(t *testing.T) {
 	initializeProject(project)
 
 	// Then add the "test" command.
-	cmdName := "test"
-	cmdPath := filepath.Join(project.CmdPath(), cmdName+".go")
-	createCmdFile(project.License(), cmdPath, cmdName)
+	// cmdName := "test"
+	// cmdPath := filepath.Join(project.CmdPath(), cmdName+".go")
+	// createCmdFile(project.License(), cmdPath, cmdName)
 
 	expectedFiles := []string{".", "root.go", "test.go"}
 	gotFiles := []string{}

--- a/cobra/main.go
+++ b/cobra/main.go
@@ -13,7 +13,9 @@
 
 package main
 
-import "github.com/spf13/cobra/cobra/cmd"
+import (
+	"cobra/cobra/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Fixes #266, #273 (should be sufficient), #604.

In short it checks if there is another parentCmd thant `rootCmd` and constructs from this information a unique cmd Variable. For example if there is a command like `<appName> compile clean` the var is compileCleanCmd.

It is needed to edit the tests.