### PR TITLE
Update README.md

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -20,7 +20,7 @@ Cobra init is pretty smart. You can provide it a full path, or simply a path
 similar to what is expected in the import.
 
 ```
-cobra init github.com/spf13/newApp
+cobra init --pkg-name github.com/spf13/app
 ```
 
 ### cobra add


### PR DESCRIPTION
Current command example fails with error `Error: required flag(s) "pkg-name" not set`

This fixes that, as well as fixing the package name to be consistent with the name lower down in the instructions.