### PR TITLE
Remove "Lesser" from header for GPL-2.0 template

### DIFF
--- a/cobra/cmd/license_gpl_2.go
+++ b/cobra/cmd/license_gpl_2.go
@@ -30,7 +30,7 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.`,
 		Text: `                    GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991


### PR DESCRIPTION
This removes "Lesser" from the GPL-2.0 header template, since that header is meant to be referring to GPL-2.0 and not LGPL-2.0.

Fixes #879 

Signed-off-by: Steve Winslow <swinslow@gmail.com>