### PR TITLE
Add framework for dynamic tab completions

### DIFF
--- a/command.go
+++ b/command.go
@@ -143,6 +143,10 @@ type Command struct {
 	//FParseErrWhitelist flag parse errors to be ignored
 	FParseErrWhitelist FParseErrWhitelist
 
+	// RunPreRunsDuringCompletion defines if the (Persistent)PreRun functions should be run before calling the
+	// completion functions
+	RunPreRunsDuringCompletion bool
+
 	// commands is the list of commands supported by this program.
 	commands []*Command
 	// parent is a parent command for this command.
@@ -200,6 +204,10 @@ type Command struct {
 	outWriter io.Writer
 	// errWriter is a writer defined by the user that replaces stderr
 	errWriter io.Writer
+
+	// flagCompletions is a map of flag to a function that returns a list of values to suggest during tab completion for
+	// this flag
+	flagCompletions map[*flag.Flag]DynamicFlagCompletion
 }
 
 // SetArgs sets arguments for the command. It is set to os.Args[1:] by default, if desired, can be overridden
@@ -736,6 +744,8 @@ func (c *Command) ArgsLenAtDash() int {
 	return c.Flags().ArgsLenAtDash()
 }
 
+const FlagCompletionEnvVar = "COBRA_FLAG_COMPLETION"
+
 func (c *Command) execute(a []string) (err error) {
 	if c == nil {
 		return fmt.Errorf("Called Execute() on a nil Command")
@@ -851,6 +861,90 @@ func (c *Command) execute(a []string) (err error) {
 	return nil
 }
 
+func (c *Command) complete(flagName string, a []string) (err error) {
+	if c == nil {
+		return fmt.Errorf("Called Execute() on a nil Command")
+	}
+
+	// initialize help and version flag at the last point possible to allow for user
+	// overriding
+	c.InitDefaultHelpFlag()
+	c.InitDefaultVersionFlag()
+
+	var flagToComplete *flag.Flag
+	var currentCompletionValue string
+
+	oldFlags := c.Flags()
+	c.flags = nil
+	oldFlags.VisitAll(func(f *flag.Flag) {
+		if f.Name == flagName {
+			flagToComplete = f
+		} else {
+			c.Flags().AddFlag(f)
+		}
+	})
+	if flagToComplete.Shorthand != "" {
+		c.Flags().StringVarP(&currentCompletionValue, flagName, flagToComplete.Shorthand, "", "")
+	} else {
+		c.Flags().StringVar(&currentCompletionValue, flagName, "", "")
+	}
+	c.Flag(flagName).NoOptDefVal = "_hack_"
+
+	err = c.ParseFlags(a)
+	if err != nil {
+		return c.FlagErrorFunc()(c, err)
+	}
+
+	c.preRun()
+
+	currentCommand := c
+	completionFunc := currentCommand.flagCompletions[flagToComplete]
+	for completionFunc == nil && currentCommand.HasParent() {
+		currentCommand = currentCommand.Parent()
+		completionFunc = currentCommand.flagCompletions[flagToComplete]
+	}
+	if completionFunc == nil {
+		return fmt.Errorf("%s does not have completions enabled", flagName)
+	}
+
+	if c.RunPreRunsDuringCompletion {
+		argWoFlags := c.Flags().Args()
+		if c.DisableFlagParsing {
+			argWoFlags = a
+		}
+
+		for p := c; p != nil; p = p.Parent() {
+			if p.PersistentPreRunE != nil {
+				if err := p.PersistentPreRunE(c, argWoFlags); err != nil {
+					return err
+				}
+				break
+			} else if p.PersistentPreRun != nil {
+				p.PersistentPreRun(c, argWoFlags)
+				break
+			}
+		}
+		if c.PreRunE != nil {
+			if err := c.PreRunE(c, argWoFlags); err != nil {
+				return err
+			}
+		} else if c.PreRun != nil {
+			c.PreRun(c, argWoFlags)
+		}
+	}
+
+	values, err := completionFunc(currentCompletionValue)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range values {
+		c.Print(v + "\x00")
+	}
+
+	return nil
+}
+
 func (c *Command) preRun() {
 	for _, x := range initializers {
 		x()
@@ -909,6 +1003,16 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	cmd.commandCalledAs.called = true
 	if cmd.commandCalledAs.name == "" {
 		cmd.commandCalledAs.name = cmd.Name()
+	}
+
+	flagName, flagCompletionEnabled := os.LookupEnv(FlagCompletionEnvVar)
+	if flagCompletionEnabled {
+		err = cmd.complete(flagName, flags)
+		if err != nil {
+			c.Println("Error:", err.Error())
+		}
+
+		return cmd, err
 	}
 
 	err = cmd.execute(flags)


### PR DESCRIPTION
By setting the COBRA_FLAG_COMPLETION environment variable, the normal execution path of the command
is short circuited, and instead the function registered by `MarkCustomFlagCompletion` is executed.

All flags other than the one being completed get parsed according to whatever type they are defined
as, but the flag being completed is parsed as a raw string and passed into the custom compeltion.