### PR TITLE
Add framework for dynamic tab completions

### DIFF
--- a/shell_completions.go
+++ b/shell_completions.go
@@ -93,7 +93,7 @@ type DynamicFlagCompletion func(currentValue string) (suggestedValues []string, 
 // RunPreRunsDuringCompletion is set to true. All flags other than the flag currently being completed will be parsed
 // according to their type. The flag being completed is parsed as a raw string with no format requirements
 //
-// Shell Completion compatibility matrix: zsh
+// Shell Completion compatibility matrix: bash, zsh
 func (c *Command) MarkDynamicFlagCompletion(name string, completion DynamicFlagCompletion) error {
 	flag := c.Flag(name)
 	if flag == nil {
@@ -107,9 +107,6 @@ func (c *Command) MarkDynamicFlagCompletion(name string, completion DynamicFlagC
 		c.flagCompletions = make(map[*pflag.Flag]DynamicFlagCompletion)
 	}
 	c.flagCompletions[flag] = completion
-	if flag.Annotations == nil {
-		flag.Annotations = map[string][]string{}
-	}
-	flag.Annotations[zshCompDynamicCompletion] = []string{zshCompGenFlagCompletionFuncName(c)}
+
 	return nil
 }

--- a/shell_completions.go
+++ b/shell_completions.go
@@ -103,10 +103,10 @@ func (c *Command) MarkDynamicFlagCompletion(name string, completion DynamicFlagC
 		return fmt.Errorf("%s takes no parameters", name)
 	}
 
-	if c.flagCompletions == nil {
-		c.flagCompletions = make(map[*pflag.Flag]DynamicFlagCompletion)
+	if c.dynamicFlagCompletions == nil {
+		c.dynamicFlagCompletions = make(map[*pflag.Flag]DynamicFlagCompletion)
 	}
-	c.flagCompletions[flag] = completion
+	c.dynamicFlagCompletions[flag] = completion
 
 	return nil
 }

--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -91,7 +91,7 @@ function {{genZshFlagDynamicCompletionFuncName .}} {
     return $?
   fi
 
-  if ! error_message="$("${tokens[@]}" 2>&1 > "$output")" ; then
+  if ! error_message="$($tokens 2>&1 > "$output")" ; then
     local st="$?"
     _message "Exception occurred during completion: $error_message"
     return "$st"
@@ -102,7 +102,7 @@ function {{genZshFlagDynamicCompletionFuncName .}} {
     args+="$line"
   done < "$output"
 
-  _values "$1" "$args[@]"
+  _values "$1" $args
 
   unset COBRA_FLAG_COMPLETION
   rm "$output"

--- a/zsh_completions_test.go
+++ b/zsh_completions_test.go
@@ -77,7 +77,7 @@ func TestGenZshCompletion(t *testing.T) {
 				`_arguments -C \\\n.*'--debug\[description]'`,
 				`function _rootcmd_subcmd1 {`,
 				`function _rootcmd_subcmd1 {`,
-				`_arguments \\\n.*'\(-o --option\)'{-o,--option}'\[option description]:' \\\n`,
+				`_arguments \\\n.*'\(-o --option\)'{-o,--option}'\[option description]:option' \\\n`,
 			},
 		},
 		{


### PR DESCRIPTION
By setting the COBRA_FLAG_COMPLETION environment variable, the normal execution path of the command
is short circuited, and instead the function registered by `MarkCustomFlagCompletion` is executed.

All flags other than the one being completed get parsed according to whatever type they are defined
as, but the flag being completed is parsed as a raw string and passed into the custom compeltion.