### PR TITLE
zsh: extend flag description quotation

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -332,5 +332,7 @@ func zshCompFlagCouldBeSpecifiedMoreThenOnce(f *pflag.Flag) bool {
 }
 
 func zshCompQuoteFlagDescription(s string) string {
-	return strings.Replace(s, "'", `'\''`, -1)
+	return strings.NewReplacer("'", `'\''`,
+		"[", `\[`,
+		"]", `\]`).Replace(s)
 }


### PR DESCRIPTION
Added `[` and `]` to quotation.