### PR TITLE
`cobra init` no longer works as documented

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -20,7 +20,7 @@ Cobra init is pretty smart. You can provide it a full path, or simply a path
 similar to what is expected in the import.
 
 ```
-cobra init github.com/spf13/newApp
+cobra init ${GOPATH}/src/github.com/spf13/newApp --pkg-name=github.com/spf13/newApp
 ```
 
 ### cobra add


### PR DESCRIPTION
`cobra init github.com/spf13/newApp` results in `Error: required flag(s) "pkg-name" not set`

This alternative works but it's not intuitive to me as a noob user that it's correct.

In order to test what it does, I tried `cobra init a --pkg-name=b` but then `main.go` attempts to (incorrectly) `import "b/cmd"`

I think (!?) I'd expect what you original had: `cobra init github.com/spf13/newApp` creating a directory under `{GOPATH}/src/github.com/spf13/newApp` with `github.com/spf13/newApp` as the package name.