### PR TITLE
Add support for context.Context

### DIFF
--- a/command.go
+++ b/command.go
@@ -209,7 +209,7 @@ type Command struct {
 }
 
 // Context returns underlying command context. If command wasn't
-// executed with ExecuteContext the returned context will be nil.
+// executed with ExecuteContext Context returns Background context.
 func (c *Command) Context() context.Context {
 	return c.ctx
 }
@@ -886,6 +886,10 @@ func (c *Command) Execute() error {
 
 // ExecuteC executes the command.
 func (c *Command) ExecuteC() (cmd *Command, err error) {
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
+
 	// Regardless of what command execute is called on, run on Root only
 	if c.HasParent() {
 		return c.Root().ExecuteC()

--- a/command.go
+++ b/command.go
@@ -17,6 +17,7 @@ package cobra
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -143,8 +144,10 @@ type Command struct {
 	// TraverseChildren parses flags on all parents before executing child command.
 	TraverseChildren bool
 
-	//FParseErrWhitelist flag parse errors to be ignored
+	// FParseErrWhitelist flag parse errors to be ignored
 	FParseErrWhitelist FParseErrWhitelist
+
+	ctx context.Context
 
 	// commands is the list of commands supported by this program.
 	commands []*Command
@@ -203,6 +206,12 @@ type Command struct {
 	outWriter io.Writer
 	// errWriter is a writer defined by the user that replaces stderr
 	errWriter io.Writer
+}
+
+// Context returns underlying command context. If command wasn't
+// executed with ExecuteContext the returned context will be nil.
+func (c *Command) Context() context.Context {
+	return c.ctx
 }
 
 // SetArgs sets arguments for the command. It is set to os.Args[1:] by default, if desired, can be overridden
@@ -860,6 +869,13 @@ func (c *Command) preRun() {
 	}
 }
 
+// ExecuteContext is the same as Execute(), but sets the ctx on the command.
+// Retrieve ctx by calling cmd.Context() inside your *Run lifecycle functions.
+func (c *Command) ExecuteContext(ctx context.Context) error {
+	c.ctx = ctx
+	return c.Execute()
+}
+
 // Execute uses the args (os.Args[1:] by default)
 // and run through the command tree finding appropriate matches
 // for commands and then corresponding flags.
@@ -912,6 +928,12 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	cmd.commandCalledAs.called = true
 	if cmd.commandCalledAs.name == "" {
 		cmd.commandCalledAs.name = cmd.Name()
+	}
+
+	// We have to pass global context to children command
+	// if context is present on the parent command.
+	if cmd.ctx == nil {
+		cmd.ctx = c.ctx
 	}
 
 	err = cmd.execute(flags)
@@ -1558,7 +1580,7 @@ func (c *Command) ParseFlags(args []string) error {
 	beforeErrorBufLen := c.flagErrorBuf.Len()
 	c.mergePersistentFlags()
 
-	//do it here after merging all flags and just before parse
+	// do it here after merging all flags and just before parse
 	c.Flags().ParseErrorsWhitelist = flag.ParseErrorsWhitelist(c.FParseErrWhitelist)
 
 	err := c.Flags().Parse(args)

--- a/command_test.go
+++ b/command_test.go
@@ -147,7 +147,7 @@ func TestSubcommandExecuteC(t *testing.T) {
 }
 
 func TestExecuteContext(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	ctxRun := func(cmd *Command, args []string) {
 		if cmd.Context() != ctx {
@@ -171,6 +171,33 @@ func TestExecuteContext(t *testing.T) {
 	}
 
 	if _, err := executeCommandWithContext(ctx, rootCmd, "child", "grandchild"); err != nil {
+		t.Errorf("Command child must not fail: %+v", err)
+	}
+}
+
+func TestExecute_NoContext(t *testing.T) {
+	run := func(cmd *Command, args []string) {
+		if cmd.Context() != context.Background() {
+			t.Errorf("Command %s must have background context", cmd.Use)
+		}
+	}
+
+	rootCmd := &Command{Use: "root", Run: run, PreRun: run}
+	childCmd := &Command{Use: "child", Run: run, PreRun: run}
+	granchildCmd := &Command{Use: "grandchild", Run: run, PreRun: run}
+
+	childCmd.AddCommand(granchildCmd)
+	rootCmd.AddCommand(childCmd)
+
+	if _, err := executeCommand(rootCmd, ""); err != nil {
+		t.Errorf("Root command must not fail: %+v", err)
+	}
+
+	if _, err := executeCommand(rootCmd, "child"); err != nil {
+		t.Errorf("Subcommand must not fail: %+v", err)
+	}
+
+	if _, err := executeCommand(rootCmd, "child", "grandchild"); err != nil {
 		t.Errorf("Command child must not fail: %+v", err)
 	}
 }


### PR DESCRIPTION
This PR adds support for `context.Context`. It could help people struggling with passing context to the Run functions, that previously had to wrap `cobra.Command` initialization inside another function that would accept context.

So now instead of doing:

```go
func createFooCommand(ctx context.Context) *cobra.Command {
    return &cobra.Command{
        Use: "foo",
        Run: func(cmd *cobra.Command, args []string) {
            // Use context here
            // ...
        }
    }
}
```

you would do:

```go
cmd := &cobra.Command{
    Use: "foo",
    Run: func(cmd *cobra.Command, args []string) {
        ctx := cmd.Context()
        // Use context here
        // ...
    }
}


// Get ctx from somewhere else.
cmd.ExecuteContext(ctx)
```

This PR is fully backward-compatible, and doesn't require users to use context at all.

It renders this PR https://github.com/spf13/cobra/pull/727 (which seems to have conficlits, and also goes against the idiomatic way of using context) irrelevant.