### PR TITLE
Make sure we quote brackets when generating zsh completion

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -332,5 +332,7 @@ func zshCompFlagCouldBeSpecifiedMoreThenOnce(f *pflag.Flag) bool {
 }
 
 func zshCompQuoteFlagDescription(s string) string {
-	return strings.Replace(s, "'", `'\''`, -1)
+	return strings.NewReplacer("'", `'\''`,
+		"[", `\[`,
+		"]", `\]`).Replace(s)
 }

--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -25,6 +25,7 @@ var (
 		"extractFlags":                zshCompExtractFlag,
 		"genFlagEntryForZshArguments": zshCompGenFlagEntryForArguments,
 		"extractArgsCompletions":      zshCompExtractArgumentCompletionHintsForRendering,
+		"escapeText":                  zshCompQuoteFlagDescription,
 	}
 	zshCompletionText = `
 {{/* should accept Command (that contains subcommands) as parameter */}}
@@ -41,7 +42,7 @@ function {{$cmdPath}} {
   case $state in
   cmnds)
     commands=({{range .Commands}}{{if not .Hidden}}
-      "{{.Name}}:{{.Short}}"{{end}}{{end}}
+      "{{.Name}}:{{.Short | escapeText}}"{{end}}{{end}}
     )
     _describe "command" commands
     ;;
@@ -334,5 +335,7 @@ func zshCompFlagCouldBeSpecifiedMoreThenOnce(f *pflag.Flag) bool {
 func zshCompQuoteFlagDescription(s string) string {
 	return strings.NewReplacer("'", `'\''`,
 		"[", `\[`,
-		"]", `\]`).Replace(s)
+		"]", `\]`,
+		"$(", `\$(`,
+	).Replace(s)
 }

--- a/zsh_completions_test.go
+++ b/zsh_completions_test.go
@@ -158,6 +158,17 @@ func TestGenZshCompletion(t *testing.T) {
 			},
 		},
 		{
+			name: "flag description with brackets ([]) shouldn't break the completion file",
+			root: func() *Command {
+				r := genTestCommand("root", true)
+				r.Flags().Bool("level", false, "[ALERT]")
+				return r
+			}(),
+			expectedExpressions: []string{
+				`--level[\[ALERT\]]`,
+			},
+		},
+		{
 			name: "argument completion for file with and without patterns",
 			root: func() *Command {
 				r := genTestCommand("root", true)

--- a/zsh_completions_test.go
+++ b/zsh_completions_test.go
@@ -240,6 +240,25 @@ func TestGenZshCompletion(t *testing.T) {
 				`--ptest\[ptest]:filename:_files -g "-\(/\)"`,
 			},
 		},
+		{
+			name: "escape text in subcommand description",
+			root: func() *Command {
+				r := &Command{
+					Use:  "rootcmd",
+					Long: "Long rootcmd description",
+				}
+				d := &Command{
+					Use:   "subcmd1",
+					Short: "$(echo foo)",
+					Run:   emptyRun,
+				}
+				r.AddCommand(d)
+				return r
+			}(),
+			expectedExpressions: []string{
+				`\$\(echo foo\)`,
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
zsh completion would fail when we have brackets in description, for example :

```
% source   <(./tkn completion zsh)
% tkn task list[TAB]
_arguments:comparguments:319: invalid option definition: --template[Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].]:filename:_files
```