### PR TITLE
Allow a default function to argument

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	zshCompArgumentDefaultComp  = "cobra_annotations_zsh_completion_default_function"
 	zshCompArgumentAnnotation   = "cobra_annotations_zsh_completion_argument_annotation"
 	zshCompArgumentFilenameComp = "cobra_annotations_zsh_completion_argument_file_completion"
 	zshCompArgumentWordComp     = "cobra_annotations_zsh_completion_argument_word_completion"
@@ -25,6 +26,7 @@ var (
 		"extractFlags":                zshCompExtractFlag,
 		"genFlagEntryForZshArguments": zshCompGenFlagEntryForArguments,
 		"extractArgsCompletions":      zshCompExtractArgumentCompletionHintsForRendering,
+		"extractDefaultCompletion":    zshCompExtractCommandDefaultCompletion,
 	}
 	zshCompletionText = `
 {{/* should accept Command (that contains subcommands) as parameter */}}
@@ -64,7 +66,7 @@ function {{genZshFuncName .}} {
 {{"  _arguments"}}{{range extractFlags .}} \
     {{genFlagEntryForZshArguments . -}}
 {{end}}{{range extractArgsCompletions .}} \
-    {{.}}{{end}}
+    {{.}}{{end}}{{extractDefaultCompletion .}}
 }
 {{end}}
 
@@ -163,6 +165,14 @@ func (c *Command) MarkZshCompPositionalArgumentWords(argPosition int, words ...s
 		Options: words,
 	}
 	return c.zshCompSetArgsAnnotations(annotation)
+}
+
+func zshCompExtractCommandDefaultCompletion(c *Command) string {
+	annotationString, ok := c.Annotations[zshCompArgumentDefaultComp]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(" \\ \n    '1: :%s'", annotationString)
 }
 
 func zshCompExtractArgumentCompletionHintsForRendering(c *Command) ([]string, error) {

--- a/zsh_completions.md
+++ b/zsh_completions.md
@@ -30,10 +30,10 @@ The generated completion script should be put somewhere in your `$fpath` named
     specified for 2nd) and the command has `ValidArgs` it will be used as
     completion options for 1st argument.
   * Argument completions only offered for commands with no subcommands.
+  * Arbitary completion for a command. Using
+    `cobra_annotations_zsh_completion_default_function` annotation you can
+    specify a function for the first argument to a command to complete to.
 
 ### What's not yet Supported
 
-* Custom completion scripts are not supported yet (We should probably create zsh
-  specific one, doesn't make sense to re-use the bash one as the functions will
-  be different).
 * Whatever other feature you're looking for and doesn't exist :)

--- a/zsh_completions_test.go
+++ b/zsh_completions_test.go
@@ -203,6 +203,19 @@ func TestGenZshCompletion(t *testing.T) {
 			},
 		},
 		{
+			name: "argument completion when we have a default completion action.",
+			root: func() *Command {
+				r := genTestCommand("root", true)
+				var annotations = make(map[string]string)
+				annotations[zshCompArgumentDefaultComp] = "DEFAULT_COMPLETION_FUNCTION"
+				r.Annotations = annotations
+				return r
+			}(),
+			expectedExpressions: []string{
+				`'1: :DEFAULT_COMPLETION_FUNCTION'`,
+			},
+		},
+		{
 			name: "argument completion when command has ValidArgs and no annotation for argument at argPosition 1",
 			root: func() *Command {
 				r := genTestCommand("root", true)


### PR DESCRIPTION
If user add an annotation with the
`cobra_annotations_zsh_completion_default_function` key and a value to a
function it will be used as a default completion for that command.