### PR TITLE
add persistent flag in the MarkRequired exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ when a flag has not been set, mark it as required:
 ```go
 rootCmd.Flags().StringVarP(&Region, "region", "r", "", "AWS region (required)")
 rootCmd.MarkFlagRequired("region")
+rootCmd.PersistentFlags().StringVarP(&Database, "database", "d", "Database IP")
+rootCmd.MarkPersistentFlagRequired("database")
 ```
 
 ## Positional and Custom Arguments


### PR DESCRIPTION
When making a persistent flag required we need to use `MarkPersistentFlagRequired` instead of `MarkFlagRequired`

This PR adds a persistent flag to the example in the Required Flag section of the readme.