### PR TITLE
Use os.UserHomeDir() in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ import (
   "fmt"
   "os"
 
-  homedir "github.com/mitchellh/go-homedir"
   "github.com/spf13/cobra"
   "github.com/spf13/viper"
 )
@@ -239,7 +238,7 @@ func initConfig() {
     viper.SetConfigFile(cfgFile)
   } else {
     // Find home directory.
-    home, err := homedir.Dir()
+    home, err := os.UserHomeDir()
     if err != nil {
       fmt.Println(err)
       os.Exit(1)


### PR DESCRIPTION
Related to https://github.com/spf13/cobra/pull/853, replaced `mitchellh/go-homedir` with `os.UserHomeDir()` in README.md.