### PR TITLE
Used goimports to fix import order

### DIFF
--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -15,10 +15,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"os"
 	"path"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (

--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra/cobra/tpl"
 	"os"
 	"text/template"
+
+	"github.com/spf13/cobra/cobra/tpl"
 )
 
 // Project contains name, license and paths to projects.


### PR DESCRIPTION
Keeps the list sorted and prevents future merge conflicts.