### PR TITLE
Fix cobra generator readme file

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -20,7 +20,7 @@ Cobra init is pretty smart. You can provide it a full path, or simply a path
 similar to what is expected in the import.
 
 ```
-cobra init github.com/spf13/newApp
+cobra init --pkg-name github.com/spf13/newApp
 ```
 
 ### cobra add


### PR DESCRIPTION
When following the current instructions I found the following error:

```
Error: required flag(s) "pkg-name" not set
```

This change updates the _cobra init_ step to clarify that a flag is required to specify the package name.