### PR TITLE
fix undefined cfgFile in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ import (
   "github.com/spf13/viper"
 )
 
+var cfgFile string
+
 func init() {
   cobra.OnInitialize(initConfig)
   rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")


### PR DESCRIPTION
Someone forgot to initialize cfgFile variable on documentation example which leads to error when doing go get