### PR TITLE
Update .gitignore to track cobra subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ Session.vim
 tags
 
 *.exe
-cobra
+/cobra/cobra
 cobra.test
 
 .idea/


### PR DESCRIPTION
The 'cobra' entry on .gitignore was meant to ignore a potential 'cobra'
executable generated by 'go build' during development. However, 'cobra'
is a directory containing the command line tool, and such a generic
entry in .gitignore ignores too much.

Instead of the generic 'cobra' entry, ignore only a specific
'/cobra/cobra' path.