### PR TITLE
Omit LICENSE file when license is set to none

### DIFF
--- a/cobra/cmd/init_test.go
+++ b/cobra/cmd/init_test.go
@@ -2,21 +2,29 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func getProject() *Project {
-	wd, _ := os.Getwd()
 	return &Project{
-		AbsolutePath: fmt.Sprintf("%s/testproject", wd),
+		AbsolutePath: fmt.Sprintf("%s/testproject", mustTempDir()),
 		Legal:        getLicense(),
 		Copyright:    copyrightLine(),
 		AppName:      "testproject",
 		PkgName:      "github.com/spf13/testproject",
 		Viper:        true,
 	}
+}
+
+func mustTempDir() string {
+	dir, err := ioutil.TempDir("", "cobra_cli_test_")
+	if err != nil {
+		panic(err)
+	}
+	return dir
 }
 
 func TestGoldenInitCmd(t *testing.T) {

--- a/cobra/cmd/licenses.go
+++ b/cobra/cmd/licenses.go
@@ -36,9 +36,11 @@ type License struct {
 	Header          string   // License header for source files
 }
 
+var noLicense = License{"None", []string{"none", "false"}, "", ""}
+
 func init() {
 	// Allows a user to not use a license.
-	Licenses["none"] = License{"None", []string{"none", "false"}, "", ""}
+	Licenses["none"] = noLicense
 
 	initApache2()
 	initMit()

--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -64,6 +64,9 @@ func (p *Project) Create() error {
 	}
 
 	// create license
+	if p.Legal.Name == noLicense.Name {
+		return nil
+	}
 	return p.createLicenseFile()
 }
 


### PR DESCRIPTION
Since the documented purpose of `--license none` is to have no license, creating a project should not create an empty LICENSE file.
