### PR TITLE
clean(travis): remove shellcheck from before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,10 @@ matrix:
       go: 1.12.x
       script: diff -u <(echo -n) <(gofmt -d -s .)
 
-before_install:
-  - mkdir -p bin
-  - curl -Lso bin/shellcheck https://github.com/caarlos0/shellcheck-docker/releases/download/v0.6.0/shellcheck
-  - chmod +x bin/shellcheck
-  - go get -u github.com/kyoh86/richgo
+before_install: go get -u github.com/kyoh86/richgo
+
 script:
-  - PATH=$PATH:$PWD/bin richgo test -v ./...
+  - richgo test -v ./...
   - go build
   - if [ -z $NOVET ]; then
       diff -u <(echo -n) <(go vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');


### PR DESCRIPTION
This PR removes installing shellcheck from caarlos0/shellcheck-docker in the before_install step of Travis jobs.

- The Ubuntu Xenial host in Travis CI includes shellcheck v0.6.0 already (https://docs.travis-ci.com/user/reference/xenial/#compilers-and-build-toolchain).
- The URL is currently wrong (the binary name is `shellcheck_linux`, not `shellcheck`). Hence, we are actually using the version provided by Travis, not the one we download.
- The latest version available in caarlos0/shellcheck-docker is [v0.6.0](https://github.com/caarlos0/shellcheck-docker/releases/latest)