### PR TITLE
fix: ensure that testproject is removed even after a failure

### DIFF
--- a/cobra/cmd/add_test.go
+++ b/cobra/cmd/add_test.go
@@ -7,25 +7,13 @@ import (
 )
 
 func TestGoldenAddCmd(t *testing.T) {
-
-	wd, _ := os.Getwd()
 	command := &Command{
 		CmdName:   "test",
 		CmdParent: parentName,
-		Project: &Project{
-			AbsolutePath: fmt.Sprintf("%s/testproject", wd),
-			Legal:        getLicense(),
-			Copyright:    copyrightLine(),
-
-			// required to init
-			AppName: "testproject",
-			PkgName: "github.com/spf13/testproject",
-			Viper:   true,
-		},
+		Project:   getProject(),
 	}
 	defer os.RemoveAll(command.AbsolutePath)
 
-	// init project first
 	command.Project.Create()
 	if err := command.Create(); err != nil {
 		t.Fatal(err)

--- a/cobra/cmd/add_test.go
+++ b/cobra/cmd/add_test.go
@@ -23,15 +23,10 @@ func TestGoldenAddCmd(t *testing.T) {
 			Viper:   true,
 		},
 	}
+	defer os.RemoveAll(command.AbsolutePath)
 
 	// init project first
 	command.Project.Create()
-	defer func() {
-		if _, err := os.Stat(command.AbsolutePath); err == nil {
-			os.RemoveAll(command.AbsolutePath)
-		}
-	}()
-
 	if err := command.Create(); err != nil {
 		t.Fatal(err)
 	}

--- a/cobra/cmd/init_test.go
+++ b/cobra/cmd/init_test.go
@@ -7,24 +7,23 @@ import (
 	"testing"
 )
 
-func TestGoldenInitCmd(t *testing.T) {
-
+func getProject() *Project {
 	wd, _ := os.Getwd()
-	project := &Project{
+	return &Project{
 		AbsolutePath: fmt.Sprintf("%s/testproject", wd),
 		Legal:        getLicense(),
 		Copyright:    copyrightLine(),
-
-		// required to init
-		AppName: "testproject",
-		PkgName: "github.com/spf13/testproject",
-		Viper:   true,
+		AppName:      "testproject",
+		PkgName:      "github.com/spf13/testproject",
+		Viper:        true,
 	}
+}
+
+func TestGoldenInitCmd(t *testing.T) {
+	project := getProject()
 	defer os.RemoveAll(project.AbsolutePath)
 
-	// init project first
-	err := project.Create()
-	if err != nil {
+	if err := project.Create(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cobra/cmd/init_test.go
+++ b/cobra/cmd/init_test.go
@@ -12,19 +12,17 @@ func TestGoldenInitCmd(t *testing.T) {
 	wd, _ := os.Getwd()
 	project := &Project{
 		AbsolutePath: fmt.Sprintf("%s/testproject", wd),
-		PkgName:      "github.com/spf13/testproject",
 		Legal:        getLicense(),
 		Copyright:    copyrightLine(),
-		Viper:        true,
-		AppName:      "testproject",
+
+		// required to init
+		AppName: "testproject",
+		PkgName: "github.com/spf13/testproject",
+		Viper:   true,
 	}
+	defer os.RemoveAll(project.AbsolutePath)
 
-	defer func() {
-		if _, err := os.Stat(project.AbsolutePath); err == nil {
-			os.RemoveAll(project.AbsolutePath)
-		}
-	}()
-
+	// init project first
 	err := project.Create()
 	if err != nil {
 		t.Fatal(err)

--- a/cobra/cmd/init_test.go
+++ b/cobra/cmd/init_test.go
@@ -19,16 +19,16 @@ func TestGoldenInitCmd(t *testing.T) {
 		AppName:      "testproject",
 	}
 
-	err := project.Create()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	defer func() {
 		if _, err := os.Stat(project.AbsolutePath); err == nil {
 			os.RemoveAll(project.AbsolutePath)
 		}
 	}()
+
+	err := project.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	expectedFiles := []string{"LICENSE", "main.go", "cmd/root.go"}
 	for _, f := range expectedFiles {

--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -75,6 +75,7 @@ func (p *Project) createLicenseFile() error {
 	if err != nil {
 		return err
 	}
+	defer licenseFile.Close()
 
 	licenseTemplate := template.Must(template.New("license").Parse(p.Legal.Text))
 	return licenseTemplate.Execute(licenseFile, data)


### PR DESCRIPTION
In https://github.com/spf13/cobra/commit/984374f5b622efc94388e2872915c2d97404adba a `defer func()` was added after a possible `t.Fatal(err)`. This PR moves it before, to ensure that testproject files are removed after a failure.