### PR TITLE
fix(diff): use arg '--strip-trailing-cr'

### DIFF
--- a/cobra/cmd/golden_test.go
+++ b/cobra/cmd/golden_test.go
@@ -43,7 +43,7 @@ func compareFiles(pathA, pathB string) error {
 			// Don't execute diff if it can't be found.
 			return nil
 		}
-		diffCmd := exec.Command(diffPath, "-u", pathA, pathB)
+		diffCmd := exec.Command(diffPath, "-u", "--strip-trailing-cr", pathA, pathB)
 		diffCmd.Stdout = output
 		diffCmd.Stderr = output
 


### PR DESCRIPTION
Running the tests on windows, when two files do not match, diff shows all the content as changed. This PR tells diff to ignore line endings, so it is easier to find the differences.