### PR TITLE
Add ArgDescriptionForUseLine to add custom suffix to use line

### DIFF
--- a/command.go
+++ b/command.go
@@ -68,6 +68,11 @@ type Command struct {
 	// but accepted if entered manually.
 	ArgAliases []string
 
+	// ArgDescriptionForUseLine will be appended to the usage line of a command
+	// line of a command when printing help or generating docs
+	// to allow you to describe the meaning of the arguments the command takes.
+	ArgDescriptionForUseLine string
+
 	// BashCompletionFunction is custom functions used by the bash autocompletion generator.
 	BashCompletionFunction string
 
@@ -1179,6 +1184,9 @@ func (c *Command) UseLine() string {
 	}
 	if c.HasAvailableFlags() && !strings.Contains(useline, "[flags]") {
 		useline += " [flags]"
+	}
+	if c.ArgDescriptionForUseLine != "" {
+		useline += " " + c.ArgDescriptionForUseLine
 	}
 	return useline
 }

--- a/command_test.go
+++ b/command_test.go
@@ -830,6 +830,16 @@ func TestFlagsInUsage(t *testing.T) {
 	checkStringContains(t, output, "[flags]")
 }
 
+func TestArgsInUsage(t *testing.T) {
+	rootCmd := &Command{Use: "root", Args: NoArgs, ArgDescriptionForUseLine: "name [arg...]", Run: func(*Command, []string) {}}
+	output, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	checkStringContains(t, output, "[flags] name [arg...]")
+}
+
 func TestHelpExecutedOnNonRunnableChild(t *testing.T) {
 	rootCmd := &Command{Use: "root", Run: emptyRun}
 	childCmd := &Command{Use: "child", Long: "Long description"}


### PR DESCRIPTION
I wanted to be able to describe the meaning of the arguments in the usage line:

    app subcmd [flags] cmd [args...]

I'm open to alternative names.
I suppose really it's just a suffix for the UseLine so it wouldn't _have_ to be about "args".

What do you think?