### PR TITLE
add goreportcard to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ etc.
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
 [![CircleCI status](https://circleci.com/gh/spf13/cobra.png?circle-token=:circle-token "CircleCI status")](https://circleci.com/gh/spf13/cobra)
 [![GoDoc](https://godoc.org/github.com/spf13/cobra?status.svg)](https://godoc.org/github.com/spf13/cobra)
+[![Go Report Card](https://goreportcard.com/badge/github.com/spf13/cobra)](https://goreportcard.com/report/github.com/spf13/cobra)
 
 # Table of Contents
 


### PR DESCRIPTION
Add Go Report Card badge to README.md
This covers https://github.com/spf13/cobra/issues/940 albeit using a different service.