### PR TITLE
Adjust bash completion instructions for compatibility with bash 3.2

### DIFF
--- a/bash_completions.md
+++ b/bash_completions.md
@@ -17,12 +17,12 @@ var completionCmd = &cobra.Command{
 	Short: "Generates bash completion scripts",
 	Long: `To load completion run
 
-. <(bitbucket completion)
+eval "$(bitbucket completion)"
 
 To configure your bash shell to load completions for each session add to your bashrc
 
 # ~/.bashrc or ~/.profile
-. <(bitbucket completion)
+eval "$(bitbucket completion)"
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rootCmd.GenBashCompletion(os.Stdout);


### PR DESCRIPTION
Bash 3.2 is the default bash version on macOS and some Linux, but the old instructions for sourcing completion scripts into one's shell don't work with it:

```
. <(cmd completion)
```

This is because the `source` (`.`) builtin [doesn't work with process substitution](https://lists.gnu.org/archive/html/bug-bash/2006-01/msg00018.html) (the `<(...)` syntax) in 3.2.

The `eval` approach is portable between different bash versions.