### PR TITLE
Check if root cmd is runnable and run if it is

### DIFF
--- a/command.go
+++ b/command.go
@@ -892,7 +892,10 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	}
 
 	var flags []string
-	if c.TraverseChildren {
+	if c.Runnable() {
+		cmd = c
+		flags = args
+	} else if c.TraverseChildren {
 		cmd, flags, err = c.Traverse(args)
 	} else {
 		cmd, flags, err = c.Find(args)


### PR DESCRIPTION
Should resolve #974 
"Should" because I am not sure if it resolves it, I tried cloning repo and copying it to my project folder as module - didn't work out.
Though I didn't change much, it should now save rootCmd to cmd and Run it to be able to parse flags as in #974.