### PR TITLE
Add Mercure in the list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Many of the most widely used Go projects are built using Cobra, such as:
 [mattermost-server](https://github.com/mattermost/mattermost-server),
 [Gardener](https://github.com/gardener/gardenctl),
 [Linkerd](https://linkerd.io/),
+[Mercure](https://mercure.rocks/),
 etc.
 
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)


### PR DESCRIPTION
[The Mercure project](https://github.com/dunglas/mercure) is now built on top of Cobra!