### PR TITLE
Update hyperlink in GPLv3 license template

### DIFF
--- a/cobra/cmd/license_gpl_3.go
+++ b/cobra/cmd/license_gpl_3.go
@@ -705,7 +705,7 @@ into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<http://www.gnu.org/licenses/why-not-lgpl.html>.
 `,
 	}
 }


### PR DESCRIPTION
Was comparing the difference between the license generated by `cobra` and the one created by Github and found that the link at the bottom is not the same. Comparing both links, I found that the `http://www.gnu.org/philosophy/why-not-lgpl.html` link redirects to `http://www.gnu.org/licenses/why-not-lgpl.html`. This PR updates the link in the file to the canonical link.