### PR TITLE
substitute wrong word in md_docs

### DIFF
--- a/doc/md_docs.md
+++ b/doc/md_docs.md
@@ -1,6 +1,6 @@
 # Generating Markdown Docs For Your Own cobra.Command
 
-Generating man pages from a cobra command is incredibly easy. An example is as follows:
+Generating Markdown pages from a cobra command is incredibly easy. An example is as follows:
 
 ```go
 package main


### PR DESCRIPTION
I noticed that was used 'man' instead of 'Markdown'