### PR TITLE
Fix regression when calling *_custom_func

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -61,6 +61,7 @@ __%[1]s_contains_word()
 __%[1]s_handle_reply()
 {
     __%[1]s_debug "${FUNCNAME[0]}"
+    local comp
     case $cur in
         -*)
             if [[ $(type -t compopt) = "builtin" ]]; then
@@ -72,8 +73,8 @@ __%[1]s_handle_reply()
             else
                 allflags=("${flags[*]} ${two_word_flags[*]}")
             fi
-            while IFS='' read -r c; do
-                COMPREPLY+=("$c")
+            while IFS='' read -r comp; do
+                COMPREPLY+=("$comp")
             done < <(compgen -W "${allflags[*]}" -- "$cur")
             if [[ $(type -t compopt) = "builtin" ]]; then
                 [[ "${COMPREPLY[0]}" == *= ]] || compopt +o nospace
@@ -124,13 +125,13 @@ __%[1]s_handle_reply()
     if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
         completions+=("${must_have_one_flag[@]}")
     fi
-    while IFS='' read -r c; do
-        COMPREPLY+=("$c")
+    while IFS='' read -r comp; do
+        COMPREPLY+=("$comp")
     done < <(compgen -W "${completions[*]}" -- "$cur")
 
     if [[ ${#COMPREPLY[@]} -eq 0 && ${#noun_aliases[@]} -gt 0 && ${#must_have_one_noun[@]} -ne 0 ]]; then
-        while IFS='' read -r c; do
-            COMPREPLY+=("$c")
+        while IFS='' read -r comp; do
+            COMPREPLY+=("$comp")
         done < <(compgen -W "${noun_aliases[*]}" -- "$cur")
     fi
 


### PR DESCRIPTION
PR #889 introduced a small regression where the global variable `$c` is no longer set when `*custom_func` is called.  This is because `$c` is re-used by mistake in the new `read` loop.

This PR simply changes the name of the variable used in the loop.

I've proposed a PR to the `helm/helm` projet which uses the `$c` variable in `__helm_custom_func` and when testing with the `master` branch of Cobra, things started failing.  With this PR applied, the `helm/helm` PR works again.

See https://github.com/helm/helm/pull/7078/files#diff-84d051076d41e254e011a57e40b82a34R279 for the line using `$c` in the PR.

/cc @rsteube @jharshman 