### PR TITLE
Revert change so help is printed on stdout again

### DIFF
--- a/command.go
+++ b/command.go
@@ -372,7 +372,9 @@ func (c *Command) HelpFunc() func(*Command, []string) {
 	}
 	return func(c *Command, a []string) {
 		c.mergePersistentFlags()
-		err := tmpl(c.OutOrStderr(), c.HelpTemplate(), c)
+		// The help should be sent to stdout
+		// See https://github.com/spf13/cobra/issues/1002
+		err := tmpl(c.OutOrStdout(), c.HelpTemplate(), c)
 		if err != nil {
 			c.Println(err)
 		}


### PR DESCRIPTION
Fixes #1002
For backwards compatibility reasons, and to follow the need of
https://github.com/kubernetes/kubernetes/pull/26077#issuecomment-230818900
the help message should be printed on stdout.

/cc @bruceadowns @bogem @jharshman 