### PR TITLE
add example code of generating Zsh completion

### DIFF
--- a/zsh_completions.md
+++ b/zsh_completions.md
@@ -4,6 +4,14 @@ Cobra supports native Zsh completion generated from the root `cobra.Command`.
 The generated completion script should be put somewhere in your `$fpath` named
 `_<YOUR COMMAND>`.
 
+```go
+// Output to given io.Writer
+rootCmd.GenZshCompletion(os.Stdout)
+
+// Output to given file
+rootCmd.GenZshCompletionFile("/path/to/fpath/_your_command")
+```
+
 ### What's Supported
 
 * Completion for all non-hidden subcommands using their `.Short` description.


### PR DESCRIPTION
Current zsh_completion.md only shows what cobra supports for generating Zsh completion, not how to do id. So I added basic usage.

I hope this help.