### PR TITLE
Small correction in README

### DIFF
--- a/user_guide.md
+++ b/user_guide.md
@@ -281,7 +281,7 @@ func init() {
 
 In this example, the persistent flag `author` is bound with `viper`.
 **Note**: the variable `author` will not be set to the value from config,
-when the `--author` flag is not provided by user.
+when the `--author` flag is provided by user.
 
 More in [viper documentation](https://github.com/spf13/viper#working-with-flags).
 


### PR DESCRIPTION
I thought this sentence seemed *off*:

> **Note**, that the variable `author` will not be set to the value from config, when the `--author` flag is not provided by user.

In the [Viper documentation](https://github.com/spf13/viper):

> Viper uses the following precedence order. Each item takes precedence over the item below it:
> * explicit call to Set
> * flag
> * env
> * config
> * key/value store
> * default

One would assume that:

> ...the variable `author` will not be set to the value from config, when the `--author` flag *is* provided by user.

Testing with `cobra init` bears this out:

`cobra init --pkg-name test`

```go
/*
Copyright © 2020 Nickolas Kraus

*/
```

`cobra init --pkg-name test --author Me`

```go
/*
Copyright © 2020 Me

*/
```
