### PR TITLE
Add MarkPersistentFlagRequired to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,12 @@ rootCmd.Flags().StringVarP(&Region, "region", "r", "", "AWS region (required)")
 rootCmd.MarkFlagRequired("region")
 ```
 
+Pesistent flags should be marked as required using a separate function:
+```go
+rootCmd.PersistentFlags().StringVarP(&Region, "region", "r", "", "AWS region (required)")
+rootCmd.MarkPersistentFlagRequired("region")
+```
+
 ## Positional and Custom Arguments
 
 Validation of positional arguments can be specified using the `Args` field


### PR DESCRIPTION
It wasn't clear from the doc that Persistent Flags must be marked required using a separate function (only found it out from https://github.com/spf13/cobra/issues/723).