### PR TITLE
YAML documentation contains "Usage"

### DIFF
--- a/doc/yaml_docs.go
+++ b/doc/yaml_docs.go
@@ -37,6 +37,7 @@ type cmdDoc struct {
 	Name             string
 	Synopsis         string      `yaml:",omitempty"`
 	Description      string      `yaml:",omitempty"`
+	Usage            string      `yaml:",omitempty"`
 	Options          []cmdOption `yaml:",omitempty"`
 	InheritedOptions []cmdOption `yaml:"inherited_options,omitempty"`
 	Example          string      `yaml:",omitempty"`
@@ -97,6 +98,10 @@ func GenYamlCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string) str
 
 	yamlDoc.Synopsis = forceMultiLine(cmd.Short)
 	yamlDoc.Description = forceMultiLine(cmd.Long)
+
+	if cmd.Runnable() {
+		yamlDoc.Usage = cmd.UseLine()
+	}
 
 	if len(cmd.Example) > 0 {
 		yamlDoc.Example = cmd.Example

--- a/doc/yaml_docs_test.go
+++ b/doc/yaml_docs_test.go
@@ -57,6 +57,17 @@ func TestGenYamlTree(t *testing.T) {
 	}
 }
 
+func TestGenYamlDocRunnable(t *testing.T) {
+	// Testing a runnable command: should contain the "usage" field
+	buf := new(bytes.Buffer)
+	if err := GenYaml(rootCmd, buf); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	checkStringContains(t, output, "usage: "+rootCmd.Use)
+}
+
 func BenchmarkGenYamlToFile(b *testing.B) {
 	file, err := ioutil.TempFile("", "")
 	if err != nil {


### PR DESCRIPTION
When generating documentation in YAML format, include the "Usage" field.

That is present in the Markdown docs, but not in the YAML ones.