### PR TITLE
chore(ci): add release note generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-notary:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Release Notary Action
+        uses: docker://outillage/release-notary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allows for better changelogs for apps such as dependabot and renovate.

Please compare the release notes sections here: https://github.com/outillage/release-notary/pull/180 and here: https://github.com/outillage/release-notary/pull/120

This PR will change to look like the latter. Non-conventional commit messages will go into `other` section meaning this does not break any flow. The advantage however is that people using Renovate will see the changes directly in the `Release Notes` section and don't have to manually check.

References #259 