### PR TITLE
Replace deprecated SetOutput func with SetOut and SetErr in test

### DIFF
--- a/cobra/cmd/golden_test.go
+++ b/cobra/cmd/golden_test.go
@@ -13,8 +13,10 @@ var update = flag.Bool("update", false, "update .golden files")
 
 func init() {
 	// Mute commands.
-	addCmd.SetOutput(new(bytes.Buffer))
-	initCmd.SetOutput(new(bytes.Buffer))
+	addCmd.SetOut(new(bytes.Buffer))
+	addCmd.SetErr(new(bytes.Buffer))
+	initCmd.SetOut(new(bytes.Buffer))
+	initCmd.SetErr(new(bytes.Buffer))
 }
 
 // ensureLF converts any \r\n to \n

--- a/command_test.go
+++ b/command_test.go
@@ -21,7 +21,8 @@ func executeCommand(root *Command, args ...string) (output string, err error) {
 
 func executeCommandWithContext(ctx context.Context, root *Command, args ...string) (output string, err error) {
 	buf := new(bytes.Buffer)
-	root.SetOutput(buf)
+	root.SetOut(buf)
+	root.SetErr(buf)
 	root.SetArgs(args)
 
 	err = root.ExecuteContext(ctx)
@@ -31,7 +32,8 @@ func executeCommandWithContext(ctx context.Context, root *Command, args ...strin
 
 func executeCommandC(root *Command, args ...string) (c *Command, output string, err error) {
 	buf := new(bytes.Buffer)
-	root.SetOutput(buf)
+	root.SetOut(buf)
+	root.SetErr(buf)
 	root.SetArgs(args)
 
 	c, err = root.ExecuteC()


### PR DESCRIPTION
This PR replaced deprecated SetOutput function used in test to make it easier to remove the SetOutput in the future.