### PR TITLE
Allow Use property to have an escaped space

### DIFF
--- a/command.go
+++ b/command.go
@@ -1203,9 +1203,9 @@ func (c *Command) CommandPath() string {
 func (c *Command) UseLine() string {
 	var useline string
 	if c.HasParent() {
-		useline = c.parent.CommandPath() + " " + c.Use
+		useline = c.parent.CommandPath() + " " + replaceEscapedSpaces(c.Use)
 	} else {
-		useline = c.Use
+		useline = replaceEscapedSpaces(c.Use)
 	}
 	if c.DisableFlagsInUseLine {
 		return useline
@@ -1260,11 +1260,29 @@ func (c *Command) DebugFlags() {
 // Name returns the command's name: the first word in the use line.
 func (c *Command) Name() string {
 	name := c.Use
-	i := strings.Index(name, " ")
+	i := getIndexOfFirstNonEscapedSpace(name)
 	if i >= 0 {
 		name = name[:i]
 	}
-	return name
+	return replaceEscapedSpaces(name)
+}
+
+func getIndexOfFirstNonEscapedSpace(s string) int {
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '\\':
+			i++ // The next character is escaped, so advance another position to skip over it
+		case ' ':
+			return i
+		}
+		i++
+	}
+	return -1
+}
+
+func replaceEscapedSpaces(s string) string {
+	return strings.Replace(s, "\\ ", " ", -1)
 }
 
 // HasAlias determines if a given string is an alias of the command.

--- a/command_test.go
+++ b/command_test.go
@@ -1955,3 +1955,28 @@ func TestFParseErrWhitelistSiblingCommand(t *testing.T) {
 	}
 	checkStringContains(t, output, "unknown flag: --unknown")
 }
+
+func TestHelpDisplaysRootCommandNameWithEscapedSpace(t *testing.T) {
+	rootCmd := &Command{Use: "kubectl\\ myplugin", Run: emptyRun}
+	rootCmd.AddCommand(&Command{Use: "child", Run: emptyRun})
+
+	output, err := executeCommand(rootCmd, "help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	checkStringContains(t, output, "kubectl myplugin [command]")
+}
+
+func TestSubcommandHelpDisplaysRootCommandNameWithEscapedSpace(t *testing.T) {
+	rootCmd := &Command{Use: "kubectl\\ myplugin", Run: emptyRun}
+	childCmd := &Command{Use: "child", Long: "Long description", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+
+	output, err := executeCommand(rootCmd, "help", "child")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	checkStringContains(t, output, "kubectl myplugin child [flags]")
+}


### PR DESCRIPTION
This PR is a possible change to implement https://github.com/spf13/cobra/issues/1057

It allows you to specify a command name that has a space by passing in an escaped space.  This is needed for some commands that might have a space in them, as is the case for kubectl plugins for example.

My attempt was to preserve the existing functionality, so no existing behaviors are changed, and just add the optional ability to use an escaped space in the `Use` property.

See the linked issue above for more details and a code example of the problem this is attempting to solve.

With this PR, you would be able to do something like this
```
package main

import (
	"spf13/cobra"
)

func main() {
	rootCmd := &cobra.Command{
		Use: "kubectl\\ myplugin",  // <------ Notice the escaped space
	}

	rootCmd.AddCommand(&cobra.Command{
		Use: "dosomething",
		Run: func(cmd *cobra.Command, args []string) {
		},
	})

	_ = rootCmd.Execute()
}
```

and the output will be:
```
go run main.go --help
```
```
Usage:
  kubectl myplugin [command]

Available Commands:
  dosomething 
  help        Help about any command

Flags:
  -h, --help   help for kubectl myplugin

Use "kubectl myplugin [command] --help" for more information about a command.
```

I'm open to feedback, or if this is not in line with cobra's philosophy, let me know, but I wanted to make an attempt at proposing a solution for the issue I opened.  

Thanks!
