### PR TITLE
Partial Revert of #922

### DIFF
--- a/command.go
+++ b/command.go
@@ -18,7 +18,6 @@ package cobra
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,8 +27,6 @@ import (
 
 	flag "github.com/spf13/pflag"
 )
-
-var ErrSubCommandRequired = errors.New("subcommand is required")
 
 // FParseErrWhitelist configures Flag parse errors to be ignored
 type FParseErrWhitelist flag.ParseErrorsWhitelist
@@ -801,7 +798,7 @@ func (c *Command) execute(a []string) (err error) {
 	}
 
 	if !c.Runnable() {
-		return ErrSubCommandRequired
+		return flag.ErrHelp
 	}
 
 	c.preRun()
@@ -950,14 +947,6 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		if err == flag.ErrHelp {
 			cmd.HelpFunc()(cmd, args)
 			return cmd, nil
-		}
-
-		// If command wasn't runnable, show full help, but do return the error.
-		// This will result in apps by default returning a non-success exit code, but also gives them the option to
-		// handle specially.
-		if err == ErrSubCommandRequired {
-			cmd.HelpFunc()(cmd, args)
-			return cmd, err
 		}
 
 		// If root command has SilentErrors flagged,

--- a/command_test.go
+++ b/command_test.go
@@ -903,8 +903,8 @@ func TestHelpExecutedOnNonRunnableChild(t *testing.T) {
 	rootCmd.AddCommand(childCmd)
 
 	output, err := executeCommand(rootCmd, "child")
-	if err != ErrSubCommandRequired {
-		t.Errorf("Expected error")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
 
 	checkStringContains(t, output, childCmd.Long)


### PR DESCRIPTION
Issue Reference: https://github.com/spf13/cobra/issues/1056
Bug Introduced: #922 

#922 Introduced a new error type that emitted when a command was not runnable. This caused all commands w/o a run function set to error w/ that message and a status code of 1.

This change reverts the addition of that new error. Similar
functionality can be accomplished by leveraging RunE.