### PR TITLE
Remove Circle CI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Many of the most widely used Go projects are built using Cobra, such as:
 etc.
 
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
-[![CircleCI status](https://circleci.com/gh/spf13/cobra.png?circle-token=:circle-token "CircleCI status")](https://circleci.com/gh/spf13/cobra)
 [![GoDoc](https://godoc.org/github.com/spf13/cobra?status.svg)](https://godoc.org/github.com/spf13/cobra)
 [![Go Report Card](https://goreportcard.com/badge/github.com/spf13/cobra)](https://goreportcard.com/report/github.com/spf13/cobra)
 


### PR DESCRIPTION
Circle CI is no longer used. This PR removes the badge from the README.