### PR TITLE
Remove/replace SetOutput on Command - deprecated

### DIFF
--- a/command.go
+++ b/command.go
@@ -218,13 +218,6 @@ func (c *Command) SetArgs(a []string) {
 	c.args = a
 }
 
-// SetOutput sets the destination for usage and error messages.
-// If output is nil, os.Stderr is used.
-// Deprecated: Use SetOut and/or SetErr instead
-func (c *Command) SetOutput(output io.Writer) {
-	c.outWriter = output
-	c.errWriter = output
-}
 
 // SetOut sets the destination for usage messages.
 // If newOut is nil, os.Stdout is used.

--- a/command.go
+++ b/command.go
@@ -218,7 +218,6 @@ func (c *Command) SetArgs(a []string) {
 	c.args = a
 }
 
-
 // SetOut sets the destination for usage messages.
 // If newOut is nil, os.Stdout is used.
 func (c *Command) SetOut(newOut io.Writer) {

--- a/command.go
+++ b/command.go
@@ -218,6 +218,14 @@ func (c *Command) SetArgs(a []string) {
 	c.args = a
 }
 
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+// Deprecated: Use SetOut and/or SetErr instead
+func (c *Command) SetOutput(output io.Writer) {
+	c.outWriter = output
+	c.errWriter = output
+}
+
 // SetOut sets the destination for usage messages.
 // If newOut is nil, os.Stdout is used.
 func (c *Command) SetOut(newOut io.Writer) {

--- a/command_test.go
+++ b/command_test.go
@@ -1557,6 +1557,14 @@ func TestEnableCommandSortingIsDisabled(t *testing.T) {
 	EnableCommandSorting = true
 }
 
+func TestSetOutput(t *testing.T) {
+	c := &Command{}
+	c.SetOutput(nil)
+	if out := c.OutOrStdout(); out != os.Stdout {
+		t.Errorf("Expected setting output to nil to revert back to stdout")
+	}
+}
+
 func TestSetOut(t *testing.T) {
 	c := &Command{}
 	c.SetOut(nil)

--- a/command_test.go
+++ b/command_test.go
@@ -1557,14 +1557,6 @@ func TestEnableCommandSortingIsDisabled(t *testing.T) {
 	EnableCommandSorting = true
 }
 
-func TestSetOutput(t *testing.T) {
-	c := &Command{}
-	c.SetOutput(nil)
-	if out := c.OutOrStdout(); out != os.Stdout {
-		t.Errorf("Expected setting output to nil to revert back to stdout")
-	}
-}
-
 func TestSetOut(t *testing.T) {
 	c := &Command{}
 	c.SetOut(nil)
@@ -1814,7 +1806,8 @@ func (tc *calledAsTestcase) test(t *testing.T) {
 	parent.SetArgs(tc.args)
 
 	output := new(bytes.Buffer)
-	parent.SetOutput(output)
+	parent.SetOut(output)
+	parent.SetErr(output)
 
 	parent.Execute()
 


### PR DESCRIPTION
Addresses https://github.com/spf13/cobra/issues/1071

This removes the `SetOutput` method on `*Command` as it is deprecated and replaces those methods with `SetOut` and `SetErr`. 

I didn't touch any of the `SetOutput` methods on `*FlagSet` as that appears to be apart of the `github.com/spf13/pflag` library. Do we think it's valuable to change that library as well?

If we don't want to entirely remove the function just yet, let me know!