### PR TITLE
API (urgent): Rename BashCompDirectives to ShellCompDirectives

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -344,7 +344,7 @@ __%[1]s_handle_word()
     __%[1]s_handle_word
 }
 
-`, name, CompRequestCmd, BashCompDirectiveError, BashCompDirectiveNoSpace, BashCompDirectiveNoFileComp))
+`, name, ShellCompRequestCmd, ShellCompDirectiveError, ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp))
 }
 
 func writePostscript(buf *bytes.Buffer, name string) {

--- a/bash_completions.md
+++ b/bash_completions.md
@@ -128,11 +128,11 @@ cmd := &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) {
 		RunGet(args[0])
 	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective) {
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
-			return nil, cobra.BashCompDirectiveNoFileComp
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		return getReleasesFromCluster(toComplete), cobra.BashCompDirectiveNoFileComp
+		return getReleasesFromCluster(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 }
 ```
@@ -143,20 +143,20 @@ Notice we put the `ValidArgsFunction` on the `status` subcommand. Let's assume t
 # helm status [tab][tab]
 harbor notary rook thanos
 ```
-You may have noticed the use of `cobra.BashCompDirective`.  These directives are bit fields allowing to control some shell completion behaviors for your particular completion.  You can combine them with the bit-or operator such as `cobra.BashCompDirectiveNoSpace | cobra.BashCompDirectiveNoFileComp`
+You may have noticed the use of `cobra.ShellCompDirective`.  These directives are bit fields allowing to control some shell completion behaviors for your particular completion.  You can combine them with the bit-or operator such as `cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp`
 ```go
 // Indicates an error occurred and completions should be ignored.
-BashCompDirectiveError
+ShellCompDirectiveError
 // Indicates that the shell should not add a space after the completion,
 // even if there is a single completion provided.
-BashCompDirectiveNoSpace
+ShellCompDirectiveNoSpace
 // Indicates that the shell should not provide file completion even when
 // no completion is provided.
 // This currently does not work for zsh or bash < 4
-BashCompDirectiveNoFileComp
+ShellCompDirectiveNoFileComp
 // Indicates that the shell will perform its default behavior after completions
-// have been provided (this implies !BashCompDirectiveNoSpace && !BashCompDirectiveNoFileComp).
-BashCompDirectiveDefault
+// have been provided (this implies !ShellCompDirectiveNoSpace && !ShellCompDirectiveNoFileComp).
+ShellCompDirectiveDefault
 ```
 
 When using the `ValidArgsFunction`, Cobra will call your registered function after having parsed all flags and arguments provided in the command-line.  You therefore don't need to do this parsing yourself.  For example, when a user calls `helm status --namespace my-rook-ns [tab][tab]`, Cobra will call your registered `ValidArgsFunction` after having parsed the `--namespace` flag, as it would have done when calling the `RunE` function.
@@ -168,7 +168,7 @@ Cobra achieves dynamic completions written in Go through the use of a hidden com
 # helm __complete status har<ENTER>
 harbor
 :4
-Completion ended with directive: BashCompDirectiveNoFileComp # This is on stderr
+Completion ended with directive: ShellCompDirectiveNoFileComp # This is on stderr
 ```
 ***Important:*** If the noun to complete is empty, you must pass an empty parameter to the `__complete` command:
 ```bash
@@ -178,7 +178,7 @@ notary
 rook
 thanos
 :4
-Completion ended with directive: BashCompDirectiveNoFileComp # This is on stderr
+Completion ended with directive: ShellCompDirectiveNoFileComp # This is on stderr
 ```
 Calling the `__complete` command directly allows you to run the Go debugger to troubleshoot your code.  You can also add printouts to your code; Cobra provides the following functions to use for printouts in Go completion code:
 ```go
@@ -307,8 +307,8 @@ To provide a Go function that Cobra will execute when it needs the list of compl
 
 ```go
 flagName := "output"
-cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.BashCompDirective) {
-	return []string{"json", "table", "yaml"}, cobra.BashCompDirectiveDefault
+cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"json", "table", "yaml"}, cobra.ShellCompDirectiveDefault
 })
 ```
 Notice that calling `RegisterFlagCompletionFunc()` is done through the `command` with which the flag is associated.  In our example this dynamic completion will give results like so:
@@ -327,7 +327,7 @@ json
 table
 yaml
 :4
-Completion ended with directive: BashCompDirectiveNoFileComp # This is on stderr
+Completion ended with directive: ShellCompDirectiveNoFileComp # This is on stderr
 ```
 ***Important:*** You should **not** leave traces that print to stdout in your completion code as they will be interpreted as completion choices by the completion script.  Instead, use the cobra-provided debugging traces functions mentioned in the above section.
 

--- a/command.go
+++ b/command.go
@@ -60,7 +60,7 @@ type Command struct {
 	// ValidArgsFunction is an optional function that provides valid non-flag arguments for bash completion.
 	// It is a dynamic version of using ValidArgs.
 	// Only one of ValidArgs and ValidArgsFunction can be used for a command.
-	ValidArgsFunction func(cmd *Command, args []string, toComplete string) ([]string, BashCompDirective)
+	ValidArgsFunction func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
 
 	// Expected arguments
 	Args PositionalArgs

--- a/custom_completions_test.go
+++ b/custom_completions_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func validArgsFunc(cmd *Command, args []string, toComplete string) ([]string, BashCompDirective) {
+func validArgsFunc(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
 	if len(args) != 0 {
-		return nil, BashCompDirectiveNoFileComp
+		return nil, ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
@@ -17,12 +17,12 @@ func validArgsFunc(cmd *Command, args []string, toComplete string) ([]string, Ba
 			completions = append(completions, comp)
 		}
 	}
-	return completions, BashCompDirectiveDefault
+	return completions, ShellCompDirectiveDefault
 }
 
-func validArgsFunc2(cmd *Command, args []string, toComplete string) ([]string, BashCompDirective) {
+func validArgsFunc2(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
 	if len(args) != 0 {
-		return nil, BashCompDirectiveNoFileComp
+		return nil, ShellCompDirectiveNoFileComp
 	}
 
 	var completions []string
@@ -31,7 +31,7 @@ func validArgsFunc2(cmd *Command, args []string, toComplete string) ([]string, B
 			completions = append(completions, comp)
 		}
 	}
-	return completions, BashCompDirectiveDefault
+	return completions, ShellCompDirectiveDefault
 }
 
 func TestValidArgsFuncSingleCmd(t *testing.T) {
@@ -42,7 +42,7 @@ func TestValidArgsFuncSingleCmd(t *testing.T) {
 	}
 
 	// Test completing an empty string
-	output, err := executeCommand(rootCmd, CompRequestCmd, "")
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -51,14 +51,14 @@ func TestValidArgsFuncSingleCmd(t *testing.T) {
 		"one",
 		"two",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Check completing with a prefix
-	output, err = executeCommand(rootCmd, CompRequestCmd, "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestValidArgsFuncSingleCmd(t *testing.T) {
 	expected = strings.Join([]string{
 		"two",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
@@ -86,14 +86,14 @@ func TestValidArgsFuncSingleCmdInvalidArg(t *testing.T) {
 	}
 
 	// Check completing with wrong number of args
-	output, err := executeCommand(rootCmd, CompRequestCmd, "unexpectedArg", "t")
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "unexpectedArg", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
 	expected := strings.Join([]string{
 		":4",
-		"Completion ended with directive: BashCompDirectiveNoFileComp", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
@@ -115,7 +115,7 @@ func TestValidArgsFuncChildCmds(t *testing.T) {
 	rootCmd.AddCommand(child1Cmd, child2Cmd)
 
 	// Test completion of first sub-command with empty argument
-	output, err := executeCommand(rootCmd, CompRequestCmd, "child1", "")
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "child1", "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -124,14 +124,14 @@ func TestValidArgsFuncChildCmds(t *testing.T) {
 		"one",
 		"two",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Test completion of first sub-command with a prefix to complete
-	output, err = executeCommand(rootCmd, CompRequestCmd, "child1", "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "child1", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -139,28 +139,28 @@ func TestValidArgsFuncChildCmds(t *testing.T) {
 	expected = strings.Join([]string{
 		"two",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Check completing with wrong number of args
-	output, err = executeCommand(rootCmd, CompRequestCmd, "child1", "unexpectedArg", "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "child1", "unexpectedArg", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
 	expected = strings.Join([]string{
 		":4",
-		"Completion ended with directive: BashCompDirectiveNoFileComp", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Test completion of second sub-command with empty argument
-	output, err = executeCommand(rootCmd, CompRequestCmd, "child2", "")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "child2", "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -169,13 +169,13 @@ func TestValidArgsFuncChildCmds(t *testing.T) {
 		"three",
 		"four",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
-	output, err = executeCommand(rootCmd, CompRequestCmd, "child2", "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "child2", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -183,21 +183,21 @@ func TestValidArgsFuncChildCmds(t *testing.T) {
 	expected = strings.Join([]string{
 		"three",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Check completing with wrong number of args
-	output, err = executeCommand(rootCmd, CompRequestCmd, "child2", "unexpectedArg", "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "child2", "unexpectedArg", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
 	expected = strings.Join([]string{
 		":4",
-		"Completion ended with directive: BashCompDirectiveNoFileComp", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
@@ -215,7 +215,7 @@ func TestValidArgsFuncAliases(t *testing.T) {
 	rootCmd.AddCommand(child)
 
 	// Test completion of first sub-command with empty argument
-	output, err := executeCommand(rootCmd, CompRequestCmd, "son", "")
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "son", "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -224,14 +224,14 @@ func TestValidArgsFuncAliases(t *testing.T) {
 		"one",
 		"two",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Test completion of first sub-command with a prefix to complete
-	output, err = executeCommand(rootCmd, CompRequestCmd, "daughter", "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "daughter", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -239,21 +239,21 @@ func TestValidArgsFuncAliases(t *testing.T) {
 	expected = strings.Join([]string{
 		"two",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Check completing with wrong number of args
-	output, err = executeCommand(rootCmd, CompRequestCmd, "son", "unexpectedArg", "t")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "son", "unexpectedArg", "t")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
 	expected = strings.Join([]string{
 		":4",
-		"Completion ended with directive: BashCompDirectiveNoFileComp", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
@@ -297,28 +297,28 @@ func TestFlagCompletionInGo(t *testing.T) {
 		Run: emptyRun,
 	}
 	rootCmd.Flags().IntP("introot", "i", -1, "help message for flag introot")
-	rootCmd.RegisterFlagCompletionFunc("introot", func(cmd *Command, args []string, toComplete string) ([]string, BashCompDirective) {
+	rootCmd.RegisterFlagCompletionFunc("introot", func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
 		completions := []string{}
 		for _, comp := range []string{"1", "2", "10"} {
 			if strings.HasPrefix(comp, toComplete) {
 				completions = append(completions, comp)
 			}
 		}
-		return completions, BashCompDirectiveDefault
+		return completions, ShellCompDirectiveDefault
 	})
 	rootCmd.Flags().String("filename", "", "Enter a filename")
-	rootCmd.RegisterFlagCompletionFunc("filename", func(cmd *Command, args []string, toComplete string) ([]string, BashCompDirective) {
+	rootCmd.RegisterFlagCompletionFunc("filename", func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
 		completions := []string{}
 		for _, comp := range []string{"file.yaml", "myfile.json", "file.xml"} {
 			if strings.HasPrefix(comp, toComplete) {
 				completions = append(completions, comp)
 			}
 		}
-		return completions, BashCompDirectiveNoSpace | BashCompDirectiveNoFileComp
+		return completions, ShellCompDirectiveNoSpace | ShellCompDirectiveNoFileComp
 	})
 
 	// Test completing an empty string
-	output, err := executeCommand(rootCmd, CompRequestCmd, "--introot", "")
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "--introot", "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -328,14 +328,14 @@ func TestFlagCompletionInGo(t *testing.T) {
 		"2",
 		"10",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Check completing with a prefix
-	output, err = executeCommand(rootCmd, CompRequestCmd, "--introot", "1")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "--introot", "1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -344,14 +344,14 @@ func TestFlagCompletionInGo(t *testing.T) {
 		"1",
 		"10",
 		":0",
-		"Completion ended with directive: BashCompDirectiveDefault", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Test completing an empty string
-	output, err = executeCommand(rootCmd, CompRequestCmd, "--filename", "")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "--filename", "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -361,14 +361,14 @@ func TestFlagCompletionInGo(t *testing.T) {
 		"myfile.json",
 		"file.xml",
 		":6",
-		"Completion ended with directive: BashCompDirectiveNoSpace, BashCompDirectiveNoFileComp", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 
 	// Check completing with a prefix
-	output, err = executeCommand(rootCmd, CompRequestCmd, "--filename", "f")
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "--filename", "f")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestFlagCompletionInGo(t *testing.T) {
 		"file.yaml",
 		"file.xml",
 		":6",
-		"Completion ended with directive: BashCompDirectiveNoSpace, BashCompDirectiveNoFileComp", ""}, "\n")
+		"Completion ended with directive: ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)


### PR DESCRIPTION
Rename `BashCompDirectives` to `ShellCompDirectives`

When answering questions in #1070 about Zsh completion, I realized that the naming for the Completion Directives could be improved.  Since those completion directives will be used for different shells, and that these names will be consumed by users, it is more appropriate not to include `bash` in the name.

If this is worth doing, it should be done right away before the old names get locked as a released API.  Assuming it is still ok to make this change.

@jharshman what do you think?
