### PR TITLE
Make bash completion provide sub-command names even if ValidArgs present

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -181,10 +181,9 @@ __%[1]s_handle_reply()
     local completions
     completions=("${commands[@]}")
     if [[ ${#must_have_one_noun[@]} -ne 0 ]]; then
-        completions=("${must_have_one_noun[@]}")
+        completions+=("${must_have_one_noun[@]}")
     elif [[ -n "${has_completion_function}" ]]; then
         # if a go completion function is provided, defer to that function
-        completions=()
         __%[1]s_handle_go_custom_completion
     fi
     if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then


### PR DESCRIPTION
Fixes #1076 

This PR makes bash completion also provide sub-command names when `ValidArgs` or `ValidArgsFunction` are specified.

Here are details about the completions given:

Cobra's **Bash** completion:
Original (before custom Go completions of PR #1035):
- `ValidArgs` XOR `sub-commands` (which means it gives `ValidArgs` and if there are none, then it gives `sub-commands`)

Current:
- `ValidArgs` XOR `ValidArgsFunction` XOR `sub-commands`

With this PR:
- (`ValidArgs` AND  `sub-commands`) XOR (`ValidArgsFunction` AND `sub-commands`)

For info, Cobra's **Zsh** completion does it yet another way:
- `sub-commands` XOR `ValidArgs`

Which which should align eventually.
