### PR TITLE
env variable available for git outh key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,15 @@ matrix:
       go: 1.13.x
       script: make cobra_generator
 
-script: 
- - make test
+script:
+  - make test
+
+deploy:
+  provider: releases
+  api_key:
+    secure: $YOUR_API_KEY_ENCRYPTED
+  file_glob: true
+  file: ./bin/*
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
Hey!

Auto deploy configuration for Travis complete 🖖 

There will be a little bit of setup necessary in to use a github oauth token. I'll link the docs below. The setup should all be here though. It will only deploy automagically on tags, which seem to be deliberately used in the repo so it should be muy bien.

https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token