### PR TITLE
Ignore required flags when DisableFlagParsing is true

### DIFF
--- a/command.go
+++ b/command.go
@@ -979,6 +979,10 @@ func (c *Command) ValidateArgs(args []string) error {
 }
 
 func (c *Command) validateRequiredFlags() error {
+	if c.DisableFlagParsing {
+		return nil
+	}
+
 	flags := c.Flags()
 	missingFlagNames := []string{}
 	flags.VisitAll(func(pflag *flag.Flag) {


### PR DESCRIPTION
Fixes #1093

When a command requests to DisableFlagParsing, it should not fail due to a missing required flag. 
In fact, such a check would always fail since flags weren't parsed!

To reproduce the problem, one can use this program:
```
package main

import (
	"fmt"

	"github.com/spf13/cobra"
)

var rootCmd = &cobra.Command{
	Use: "testprog",
	Run: func(cmd *cobra.Command, args []string) {
		fmt.Println("rootCmd called")
	},
}
var childCmd = &cobra.Command{
	Use:                "child",
	DisableFlagParsing: true,
	Run: func(cmd *cobra.Command, args []string) {
		fmt.Println("childCmd2 called")
	},
}

func main() {
	rootCmd.PersistentFlags().Bool("flag", false, "required persistent")
	// Setting a persistent flag as a required flag
	// breaks sub-commands that set DisableFlagParsing==true
	rootCmd.MarkPersistentFlagRequired("flag")

	rootCmd.AddCommand(childCmd)
	rootCmd.Execute()
}
```
and then test as follows:
```
$ ./testprog child --flag
Error: required flag(s) "flag" not set
```
As shown, even when the flag is specified, the command fails because flag parsing is disabled.

I've added a test to make sure this does not break again.