### PR TITLE
add arduino-cli to projects using cobra

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -1,6 +1,6 @@
 ## Projects using Cobra
 
-- [arduino-cli](https://github.com/arduino/arduino-cli)
+- [Arduino CLI](https://github.com/arduino/arduino-cli)
 - [Bleve](http://www.blevesearch.com/)
 - [CockroachDB](http://www.cockroachlabs.com/)
 - [Delve](https://github.com/derekparker/delve)

--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -1,5 +1,6 @@
 ## Projects using Cobra
 
+- [arduino-cli](https://github.com/arduino/arduino-cli)
 - [Bleve](http://www.blevesearch.com/)
 - [CockroachDB](http://www.cockroachlabs.com/)
 - [Delve](https://github.com/derekparker/delve)


### PR DESCRIPTION
arduino-cli has been using cobra for [almost a year](https://github.com/arduino/arduino-cli/commit/6a2d8de4f3ff7011f29637eac658b07fcbf8f5b3#diff-37aff102a57d3d7b797f152915a6dc16).
I'm also working in [adding shell completion](https://github.com/arduino/arduino-cli/pull/663) using the latest features of cobra 1.0.0