### PR TITLE
Implement SetContext() for passing values between hooks

### DIFF
--- a/command.go
+++ b/command.go
@@ -949,9 +949,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 
 	// We have to pass global context to children command
 	// if context is present on the parent command.
-	if cmd.ctx == nil {
-		cmd.ctx = c.ctx
-	}
+	cmd.ctx = c.ctx
 
 	err = cmd.execute(flags)
 	if err != nil {

--- a/command.go
+++ b/command.go
@@ -216,6 +216,12 @@ func (c *Command) Context() context.Context {
 	return c.ctx
 }
 
+// SetContext replaces the underlying command context so that parent
+// commands can pass down values to their subcommands.
+func (c *Command) SetContext(ctx context.Context) {
+	c.ctx = ctx
+}
+
 // SetArgs sets arguments for the command. It is set to os.Args[1:] by default, if desired, can be overridden
 // particularly useful when testing.
 func (c *Command) SetArgs(a []string) {


### PR DESCRIPTION
- Implement SetContext() function for passing context between hooks, as proposed by @flimzy  on issue #563. A test routine was too implemented, and validates that by using the newly introduced function together with persistent hooks, it is possible to pass values between hooks, and between parent and child commands.

- Remove condition for passing down context to child command, as pointed out in issue #1109.
