### PR TITLE
Fish does not accept dash or colon in vars

### DIFF
--- a/custom_completions_test.go
+++ b/custom_completions_test.go
@@ -1407,39 +1407,6 @@ func TestCompleteCmdInBashScript(t *testing.T) {
 	check(t, output, ShellCompNoDescRequestCmd)
 }
 
-func TestCompleteNoDesCmdInFishScript(t *testing.T) {
-	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
-	child := &Command{
-		Use:               "child",
-		ValidArgsFunction: validArgsFunc,
-		Run:               emptyRun,
-	}
-	rootCmd.AddCommand(child)
-
-	buf := new(bytes.Buffer)
-	rootCmd.GenFishCompletion(buf, false)
-	output := buf.String()
-
-	check(t, output, ShellCompNoDescRequestCmd)
-}
-
-func TestCompleteCmdInFishScript(t *testing.T) {
-	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
-	child := &Command{
-		Use:               "child",
-		ValidArgsFunction: validArgsFunc,
-		Run:               emptyRun,
-	}
-	rootCmd.AddCommand(child)
-
-	buf := new(bytes.Buffer)
-	rootCmd.GenFishCompletion(buf, true)
-	output := buf.String()
-
-	check(t, output, ShellCompRequestCmd)
-	checkOmit(t, output, ShellCompNoDescRequestCmd)
-}
-
 func TestCompleteNoDesCmdInZshScript(t *testing.T) {
 	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
 	child := &Command{

--- a/fish_completions_test.go
+++ b/fish_completions_test.go
@@ -1,0 +1,69 @@
+package cobra
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCompleteNoDesCmdInFishScript(t *testing.T) {
+	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
+	child := &Command{
+		Use:               "child",
+		ValidArgsFunction: validArgsFunc,
+		Run:               emptyRun,
+	}
+	rootCmd.AddCommand(child)
+
+	buf := new(bytes.Buffer)
+	rootCmd.GenFishCompletion(buf, false)
+	output := buf.String()
+
+	check(t, output, ShellCompNoDescRequestCmd)
+}
+
+func TestCompleteCmdInFishScript(t *testing.T) {
+	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
+	child := &Command{
+		Use:               "child",
+		ValidArgsFunction: validArgsFunc,
+		Run:               emptyRun,
+	}
+	rootCmd.AddCommand(child)
+
+	buf := new(bytes.Buffer)
+	rootCmd.GenFishCompletion(buf, true)
+	output := buf.String()
+
+	check(t, output, ShellCompRequestCmd)
+	checkOmit(t, output, ShellCompNoDescRequestCmd)
+}
+
+func TestProgWithDash(t *testing.T) {
+	rootCmd := &Command{Use: "root-dash", Args: NoArgs, Run: emptyRun}
+	buf := new(bytes.Buffer)
+	rootCmd.GenFishCompletion(buf, false)
+	output := buf.String()
+
+	// Functions name should have replace the '-'
+	check(t, output, "__root_dash_perform_completion")
+	checkOmit(t, output, "__root-dash_perform_completion")
+
+	// The command name should not have replaced the '-'
+	check(t, output, "-c root-dash")
+	checkOmit(t, output, "-c root_dash")
+}
+
+func TestProgWithColon(t *testing.T) {
+	rootCmd := &Command{Use: "root:colon", Args: NoArgs, Run: emptyRun}
+	buf := new(bytes.Buffer)
+	rootCmd.GenFishCompletion(buf, false)
+	output := buf.String()
+
+	// Functions name should have replace the ':'
+	check(t, output, "__root_colon_perform_completion")
+	checkOmit(t, output, "__root:colon_perform_completion")
+
+	// The command name should not have replaced the ':'
+	check(t, output, "-c root:colon")
+	checkOmit(t, output, "-c root_colon")
+}


### PR DESCRIPTION
Fixes #1121.

This is for programs that may contain a `:` or `-` in their name.

Those characters are not accepted in variables for fish, so it was breaking fish completion.
This PR replaces `-` and `:` with a `_` in the fish completions script.
