### PR TITLE
Include EnablePersistentHookOverride option to control Persistent*Run override behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,9 @@ It is possible to run functions before or after the main `Run` function of your 
 - `PostRun`
 - `PersistentPostRun`
 
-An example of two commands which use all of these features is below.  When the subcommand is executed, it will run the root command's `PersistentPreRun` but not the root command's `PersistentPostRun`:
+By default `Persistent*Run` functions declared within children will override their parents.  Setting `cobra.EnablePersistentHookOverride` to false changes this behavior to also run the parent `Persistent*Run` functions.
+
+An example of two commands is below.  When the subcommand is executed, it will run the root command's `PersistentPreRun` but not the root command's `PersistentPostRun`:
 
 ```go
 package main

--- a/cobra.go
+++ b/cobra.go
@@ -48,6 +48,10 @@ var EnablePrefixMatching = false
 // To disable sorting, set it to false.
 var EnableCommandSorting = true
 
+// EnablePersistentHookOverride controls if PersistentPreRun* and PersistentPostRun* hooks
+// should override their parents. When set to true only the final hooks are executed (default).
+var EnablePersistentHookOverride = true
+
 // MousetrapHelpText enables an information splash screen on Windows
 // if the CLI is started from explorer.exe.
 // To disable the mousetrap, just set this variable to blank string ("").

--- a/command_test.go
+++ b/command_test.go
@@ -1379,11 +1379,10 @@ func TestPersistentHooks(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	// TODO: currently PersistenPreRun* defined in parent does not
-	// run if the matchin child subcommand has PersistenPreRun.
-	// If the behavior changes (https://github.com/spf13/cobra/issues/252)
-	// this test must be fixed.
-	if parentPersPreArgs != "" {
+	if !EnablePersistentHookOverride && parentPersPreArgs != "one two" {
+		t.Errorf("Expected parentPersPreArgs %q, got %q", "one two", parentPersPreArgs)
+	}
+	if EnablePersistentHookOverride && parentPersPreArgs != "" {
 		t.Errorf("Expected blank parentPersPreArgs, got %q", parentPersPreArgs)
 	}
 	if parentPreArgs != "" {
@@ -1395,14 +1394,12 @@ func TestPersistentHooks(t *testing.T) {
 	if parentPostArgs != "" {
 		t.Errorf("Expected blank parentPostArgs, got %q", parentPostArgs)
 	}
-	// TODO: currently PersistenPostRun* defined in parent does not
-	// run if the matchin child subcommand has PersistenPostRun.
-	// If the behavior changes (https://github.com/spf13/cobra/issues/252)
-	// this test must be fixed.
-	if parentPersPostArgs != "" {
+	if !EnablePersistentHookOverride && parentPersPostArgs != "one two" {
+		t.Errorf("Expected parentPersPostArgs %q, got %q", "one two", parentPersPostArgs)
+	}
+	if EnablePersistentHookOverride && parentPersPostArgs != "" {
 		t.Errorf("Expected blank parentPersPostArgs, got %q", parentPersPostArgs)
 	}
-
 	if childPersPreArgs != "one two" {
 		t.Errorf("Expected childPersPreArgs %q, got %q", "one two", childPersPreArgs)
 	}
@@ -1418,6 +1415,12 @@ func TestPersistentHooks(t *testing.T) {
 	if childPersPostArgs != "one two" {
 		t.Errorf("Expected childPersPostArgs %q, got %q", "one two", childPersPostArgs)
 	}
+}
+
+func TestPersistentHooksNotOverriding(t *testing.T) {
+	EnablePersistentHookOverride = false
+	TestPersistentHooks(t)
+	EnablePersistentHookOverride = true
 }
 
 // Related to https://github.com/spf13/cobra/issues/521.


### PR DESCRIPTION
Currently Cobra will only run the last Persistent*Run functions that are defined within the command chain. This introduces an EnablePersistentHookOverride option which allows to run all the functions throughout the command chain.

Resolves: #252, #219
Related PR's: #714, #220