### PR TITLE
Add example for making persistent flags required

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ rootCmd.Flags().StringVarP(&Region, "region", "r", "", "AWS region (required)")
 rootCmd.MarkFlagRequired("region")
 ```
 
+Or, for persistent flags:
+```go
+rootCmd.PersistentFlags().StringVarP(&Region, "region", "r", "", "AWS region (required)")
+rootCmd.MarkPersistentFlagRequired("region")
+```
+
 ## Positional and Custom Arguments
 
 Validation of positional arguments can be specified using the `Args` field


### PR DESCRIPTION
I just started using Cobra, and was confused as to why MarkFlagRequired didn't seem to be working. It was because I was using a persistent flag, and called MarkFlagRequired instead of MarkPersistentFlagRequired. I think this change makes this more clear.