### PR TITLE
Add completion for help command

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -389,7 +389,7 @@ fi
 func writeCommands(buf *bytes.Buffer, cmd *Command) {
 	buf.WriteString("    commands=()\n")
 	for _, c := range cmd.Commands() {
-		if !c.IsAvailableCommand() || c == cmd.helpCommand {
+		if !c.IsAvailableCommand() && c != cmd.helpCommand {
 			continue
 		}
 		buf.WriteString(fmt.Sprintf("    commands+=(%q)\n", c.Name()))
@@ -582,7 +582,7 @@ func writeArgAliases(buf *bytes.Buffer, cmd *Command) {
 
 func gen(buf *bytes.Buffer, cmd *Command) {
 	for _, c := range cmd.Commands() {
-		if !c.IsAvailableCommand() || c == cmd.helpCommand {
+		if !c.IsAvailableCommand() && c != cmd.helpCommand {
 			continue
 		}
 		gen(buf, c)

--- a/command.go
+++ b/command.go
@@ -1056,7 +1056,25 @@ func (c *Command) InitDefaultHelpCmd() {
 			Short: "Help about any command",
 			Long: `Help provides help for any command in the application.
 Simply type ` + c.Name() + ` help [path to command] for full details.`,
-
+			ValidArgsFunction: func(c *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+				var completions []string
+				cmd, _, e := c.Root().Find(args)
+				if e != nil {
+					return nil, ShellCompDirectiveNoFileComp
+				}
+				if cmd == nil {
+					// Root help command.
+					cmd = c.Root()
+				}
+				for _, subCmd := range cmd.Commands() {
+					if subCmd.IsAvailableCommand() || subCmd == cmd.helpCommand {
+						if strings.HasPrefix(subCmd.Name(), toComplete) {
+							completions = append(completions, fmt.Sprintf("%s\t%s", subCmd.Name(), subCmd.Short))
+						}
+					}
+				}
+				return completions, ShellCompDirectiveNoFileComp
+			},
 			Run: func(c *Command, args []string) {
 				cmd, _, e := c.Root().Find(args)
 				if cmd == nil || e != nil {

--- a/custom_completions.go
+++ b/custom_completions.go
@@ -183,10 +183,12 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 	}
 
 	if flag == nil {
-		// Complete subcommand names
+		// Complete subcommand names, including the help command
 		for _, subCmd := range finalCmd.Commands() {
-			if subCmd.IsAvailableCommand() && strings.HasPrefix(subCmd.Name(), toComplete) {
-				completions = append(completions, fmt.Sprintf("%s\t%s", subCmd.Name(), subCmd.Short))
+			if subCmd.IsAvailableCommand() || subCmd == finalCmd.helpCommand {
+				if strings.HasPrefix(subCmd.Name(), toComplete) {
+					completions = append(completions, fmt.Sprintf("%s\t%s", subCmd.Name(), subCmd.Short))
+				}
 			}
 		}
 


### PR DESCRIPTION
Supersedes #1065.
Fixes #1000 

This PR does two things:
 
1) adds completion *of* the `help` command so that
```
<program> [tab][tab]
```
will include `help` in the completion choices.  This is done by the first commit provided by @voithos taken from #1065.

2) adds completion *for* the `help` command using `ValidArgsFunction` so that  
```
<program> help [tab][tab]
```
will show all sub-commands (including `help` since `<program> help help` is a valid command), and
```
<program> help <subCmd1> [tab][tab]
```
will show all sub-commands of `<subCmd1>`.  And so forth down the command tree.