### PR TITLE
Extend Persistent*Run behavior to allow multiple hooks throughout the execution chain

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -39,6 +39,9 @@ var templateFuncs = template.FuncMap{
 
 var initializers []func()
 
+// EnablePersistentRunOverride ensures Persistent*Run* functions in childs override their parents
+var EnablePersistentRunOverride = true
+
 // EnablePrefixMatching allows to set automatic prefix matching. Automatic prefix matching can be a dangerous thing
 // to automatically enable in CLI tools.
 // Set this to true to enable it.

--- a/command.go
+++ b/command.go
@@ -833,28 +833,28 @@ func (c *Command) execute(a []string) (err error) {
 	postRunHooks := c.postRunHooks
 	var persistentPostRunHooks []func(cmd *Command, args []string) error
 
-	// Merge the PreRun functions into the preRunHooks slice
+	// Merge the PreRun* functions into the preRunHooks array
 	if c.PreRunE != nil {
 		preRunHooks = append(preRunHooks, c.PreRunE)
 	} else if c.PreRun != nil {
 		preRunHooks = append(preRunHooks, wrapVoidHook(c.PreRun))
 	}
 
-	// Merge the Run functions into the runHooks slice
+	// Merge the Run* functions into the runHooks array
 	if c.RunE != nil {
 		runHooks = append(runHooks, c.RunE)
 	} else if c.Run != nil {
 		runHooks = append(runHooks, wrapVoidHook(c.Run))
 	}
 
-	// Merge the PostRun functions into the runHooks slice
+	// Merge the PostRun* functions into the runHooks array
 	if c.PostRunE != nil {
 		postRunHooks = append(postRunHooks, c.PostRunE)
 	} else if c.PostRun != nil {
 		postRunHooks = append(postRunHooks, wrapVoidHook(c.PostRun))
 	}
 
-	// Find and merge the Persistent*Run functions into the persistent*Run slices.
+	// Find and merge the Persistent*Run functions into the persistent*Run array.
 	// If EnablePersistentRunOverride is set Persistent*Run from childs will override their parents.
 	// Any hooks registered through OnPersistent*Run will always be executed and cannot be overriden.
 	hasPersistentPreRunFromStruct := false
@@ -912,7 +912,7 @@ func (c *Command) preRun() {
 	}
 }
 
-// executeHooks executes a slice of hooks
+// executeHooks executes the hooks
 func (c *Command) executeHooks(hooks *[]func(cmd *Command, args []string) error, args []string) error {
 	for _, x := range *hooks {
 		if err := x(c, args); err != nil {
@@ -922,11 +922,12 @@ func (c *Command) executeHooks(hooks *[]func(cmd *Command, args []string) error,
 	return nil
 }
 
-// prepend a hook onto the slice of hooks
+// prependHook prepends a hook onto the array of hooks
 func prependHook(hooks *[]func(cmd *Command, args []string) error, hook ...func(cmd *Command, args []string) error) []func(cmd *Command, args []string) error {
 	return append(hook, *hooks...)
 }
 
+// wrapVoidHook wraps a void hook into a function having the return error signature
 func wrapVoidHook(hook func(cmd *Command, args []string)) func(cmd *Command, args []string) error {
 	return func(cmd *Command, args []string) error {
 		hook(cmd, args)

--- a/command_test.go
+++ b/command_test.go
@@ -1484,13 +1484,13 @@ func TestPersistentHooks(t *testing.T) {
 		t.Errorf("Expected persParentPersPreArgs %q, got %q", "one two", persParentPersPreArgs)
 	}
 	if persParentPreArgs != "" {
-		t.Errorf("Expected persParentPreArgs %q, got %q", "one two", persParentPreArgs)
+		t.Errorf("Expected blank persParentPreArgs, got %q", persParentPreArgs)
 	}
 	if persParentRunArgs != "" {
-		t.Errorf("Expected persParentRunArgs %q, got %q", "one two", persParentRunArgs)
+		t.Errorf("Expected blank persParentRunArgs, got %q", persParentRunArgs)
 	}
 	if persParentPostArgs != "" {
-		t.Errorf("Expected persParentPostArgs %q, got %q", "one two", persParentPostArgs)
+		t.Errorf("Expected blank persParentPostArg, got %q", persParentPostArgs)
 	}
 	if persParentPersPostArgs != "one two" {
 		t.Errorf("Expected persParentPersPostArgs %q, got %q", "one two", persParentPersPostArgs)


### PR DESCRIPTION
Supersedes: PR #1123 
Resolves: #252, #219
Related PR's: #714, #220

* Introduces On*Run() methods to register hooks
* Introduces OnPersistent*Run() methods to register hooks that are always executed (childs not overriding parents).
* Allows to register multiple *Run hooks
* Keeps current Persistent*Run behavior unaffected (childs still override parents when set as a property)
* Introduces EnablePersistentRunOverride option to control if child Persistent*Run hooks should override their parent's hooks