### PR TITLE
Add UnknownCommandErrorFunc API to override default unknown command behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,19 @@ Did you mean this?
 Run 'kubectl help' for usage.
 ```
 
+If you wish to customize the error message which is shown for unknown commands, you can set a custom error handler:
+
+```go
+cmd.SuggestionsMinimumDistance = 2 // this won't automatically be set if you override the default function
+cmd.SetUnknownCommandErrorFunc(func(c *cobra.Command, arg string) error {
+  suggestionsString := ""
+  if suggestions := c.SuggestionsFor(arg); len(suggestions) > 0 {
+    suggestionsString += fmt.Sprintf(" Did you mean %q?", suggestions[0])
+  }
+  return fmt.Errorf("Unknown command %q.%s", arg, suggestionsString)
+})
+```
+
 ## Generating documentation for your command
 
 Cobra can generate documentation based on subcommands, flags, etc. Read more about it in the [docs generation documentation](doc/README.md).

--- a/args.go
+++ b/args.go
@@ -19,7 +19,7 @@ func legacyArgs(cmd *Command, args []string) error {
 
 	// root command with subcommands, do subcommand checking.
 	if !cmd.HasParent() && len(args) > 0 {
-		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
+		return cmd.UnknownCommandErrorFunc()(cmd, args[0])
 	}
 	return nil
 }

--- a/command.go
+++ b/command.go
@@ -266,8 +266,7 @@ func (c *Command) SetFlagErrorFunc(f func(*Command, error) error) {
 	c.flagErrorFunc = f
 }
 
-// SetUnknownCommandErrorFunc sets a function to generate an error when flag parsing
-// fails.
+// SetUnknownCommandErrorFunc sets a function to generate an error when flag parsing fails.
 func (c *Command) SetUnknownCommandErrorFunc(f func(*Command, string) error) {
 	c.unknownCommandErrorFunc = f
 }
@@ -444,8 +443,7 @@ func (c *Command) FlagErrorFunc() (f func(*Command, error) error) {
 }
 
 // UnknownCommandErrorFunc returns either the function set by SetUnknownCommandErrorFunc for this
-// command or a parent, or it returns a function which returns the original
-// error.
+// command or a parent, or it returns a function which returns the original error.
 func (c *Command) UnknownCommandErrorFunc() (f func(*Command, string) error) {
 	if c.unknownCommandErrorFunc != nil {
 		return c.unknownCommandErrorFunc

--- a/command.go
+++ b/command.go
@@ -443,7 +443,7 @@ func (c *Command) FlagErrorFunc() (f func(*Command, error) error) {
 }
 
 // UnknownCommandErrorFunc returns either the function set by SetUnknownCommandErrorFunc for this
-// command or a parent, or it returns a function which returns the original error.
+// command or a parent, or it returns a function which returns the default implementation.
 func (c *Command) UnknownCommandErrorFunc() (f func(*Command, string) error) {
 	if c.unknownCommandErrorFunc != nil {
 		return c.unknownCommandErrorFunc

--- a/command_test.go
+++ b/command_test.go
@@ -1653,6 +1653,28 @@ func TestFlagErrorFunc(t *testing.T) {
 	}
 }
 
+func TestUnknownCommandErrorFunc(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	subCmd := &Command{
+		Use: "type",
+		Run: emptyRun,
+	}
+	rootCmd.AddCommand(subCmd)
+
+	expectedFmt := "unknown command: %v"
+	rootCmd.SetUnknownCommandErrorFunc(func(_ *Command, arg string) error {
+		return fmt.Errorf(expectedFmt, arg)
+	})
+
+	_, err := executeCommand(rootCmd, "typo")
+
+	got := err.Error()
+	expected := "unknown command: typo"
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+}
+
 // TestSortedFlags checks,
 // if cmd.LocalFlags() is unsorted when cmd.Flags().SortFlags set to false.
 // Related to https://github.com/spf13/cobra/issues/404.


### PR DESCRIPTION
I wanted to customize the appearance of the unknown command output, but that didn't seem possible (unless I missed something?) so this PR provides a way to override it.