### PR TITLE
Handle linebreaks in custom completions.

### DIFF
--- a/custom_completions.go
+++ b/custom_completions.go
@@ -132,6 +132,12 @@ func (c *Command) initCompleteCmd(args []string) {
 					comp = strings.Split(comp, "\t")[0]
 				}
 
+				// Make sure we only write the first line to the output.
+				// This is needed if a description contains a linebreak.
+				// Otherwise the shell scripts will interpret the other lines as new flags
+				// and could therefore provide a wrong completion.
+				comp = strings.Split(comp, "\n")[0]
+
 				// Finally trim the completion.  This is especially important to get rid
 				// of a trailing tab when there are no description following it.
 				// For example, a sub-command without a description should not be completed

--- a/custom_completions_test.go
+++ b/custom_completions_test.go
@@ -501,7 +501,7 @@ func TestFlagNameCompletionInGoWithDesc(t *testing.T) {
 	}
 	rootCmd.AddCommand(childCmd)
 
-	rootCmd.Flags().IntP("first", "f", -1, "first flag")
+	rootCmd.Flags().IntP("first", "f", -1, "first flag\nlonger description for flag")
 	rootCmd.PersistentFlags().BoolP("second", "s", false, "second flag")
 	childCmd.Flags().String("subFlag", "", "sub flag")
 


### PR DESCRIPTION
If a command/flag description contains a linebreak than the shell completion script will interpret this as new command/flag.

To fix this we should only use the first line from the description in the output.

e.g. `cmd.Flags().String("flag", "", "Description for flag\nlonger description")`