### PR TITLE
Adding werf to projects using cobra

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -24,3 +24,4 @@
 - [Prototool](https://github.com/uber/prototool)
 - [Rclone](https://rclone.org/)
 - [Skaffold](https://skaffold.dev/)
+- [Werf](https://werf.io/)


### PR DESCRIPTION
werf is a CI/CD & GitOps tool. Cobra is used in [werf's CLI](https://github.com/werf/werf/blob/master/cmd/werf/main.go).