### PR TITLE
Add OnFinalize method

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -38,6 +38,7 @@ var templateFuncs = template.FuncMap{
 }
 
 var initializers []func()
+var finalizers []func()
 
 // EnablePrefixMatching allows to set automatic prefix matching. Automatic prefix matching can be a dangerous thing
 // to automatically enable in CLI tools.
@@ -81,6 +82,12 @@ func AddTemplateFuncs(tmplFuncs template.FuncMap) {
 // Execute method is called.
 func OnInitialize(y ...func()) {
 	initializers = append(initializers, y...)
+}
+
+// OnFinalize sets the passed functions to be run when each command's
+// Execute method is terminated.
+func OnFinalize(y ...func()) {
+	finalizers = append(finalizers, y...)
 }
 
 // FIXME Gt is unused by cobra and should be removed in a version 2. It exists only for compatibility with users of cobra.

--- a/command.go
+++ b/command.go
@@ -807,6 +807,8 @@ func (c *Command) execute(a []string) (err error) {
 
 	c.preRun()
 
+	defer c.postRun()
+
 	argWoFlags := c.Flags().Args()
 	if c.DisableFlagParsing {
 		argWoFlags = a
@@ -869,6 +871,12 @@ func (c *Command) execute(a []string) (err error) {
 
 func (c *Command) preRun() {
 	for _, x := range initializers {
+		x()
+	}
+}
+
+func (c *Command) postRun() {
+	for _, x := range finalizers {
 		x()
 	}
 }


### PR DESCRIPTION
This method is the OnInitialize counterpart. Like OnInitialize which allows
loading the configuration before each command is executed, OnFinalize allows
saving the configuration after each command has been executed.