### PR TITLE
Use FlagErrorFunc for required flag validation error

### DIFF
--- a/command.go
+++ b/command.go
@@ -836,7 +836,7 @@ func (c *Command) execute(a []string) (err error) {
 	}
 
 	if err := c.validateRequiredFlags(); err != nil {
-		return err
+		return c.FlagErrorFunc()(c, err)
 	}
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {


### PR DESCRIPTION
There is no way at the moment to set SilenceUsage for a command but also output usage when validation of required flags fail.

At the moment, if a user sees a required flag error, they need to run another command like `--help` to see the usage message. By using FlagErrorFunc for this, it allows developers to handle this error.