### PR TITLE
Add additional hook that runs before flags are parsed

### DIFF
--- a/command.go
+++ b/command.go
@@ -767,11 +767,11 @@ func (c *Command) execute(a []string) (err error) {
 	}
 
 	if c.AdditionalSetupE != nil {
-		if err := c.AdditionalSetupE(c, c.Flags().Args()); err != nil {
+		if err := c.AdditionalSetupE(c, a); err != nil {
 			return err
 		}
 	} else if c.AdditionalSetup != nil {
-		c.AdditionalSetup(c, c.flags.Args())
+		c.AdditionalSetup(c, a)
 	}
 
 	// initialize help and version flag at the last point possible to allow for user


### PR DESCRIPTION
Added an additional hook point called `AdditionalSetup` that you can attach a function to if you need to do additional command setup before the flags are parsed. We use this functionality to dynamically add additional flags.