### PR TITLE
Add slack badge to point to cobra slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ name a few. [This list](./projects_using_cobra.md) contains a more extensive lis
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
 [![GoDoc](https://godoc.org/github.com/spf13/cobra?status.svg)](https://godoc.org/github.com/spf13/cobra)
 [![Go Report Card](https://goreportcard.com/badge/github.com/spf13/cobra)](https://goreportcard.com/report/github.com/spf13/cobra)
+[![Slack](https://img.shields.io/badge/Slack-cobra-brightgreen)](https://gophers.slack.com/archives/CD3LP1199)
 
 # Table of Contents
 


### PR DESCRIPTION
Pointing slack badge to our [#cobra slack channel](https://gophers.slack.com/archives/CD3LP1199) in the gophers slack. 