### PR TITLE
Remove duplicate main.go example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,20 +131,6 @@ application will follow the following organizational structure:
       main.go
 ```
 
-In a Cobra app, typically the main.go file is very bare. It serves one purpose: initializing Cobra.
-
-```go
-package main
-
-import (
-  "{pathToYourApp}/cmd"
-)
-
-func main() {
-  cmd.Execute()
-}
-```
-
 ## Using the Cobra Generator
 
 Cobra provides its own program that will create your application and add any


### PR DESCRIPTION
There was a duplicate `main.go` example on `README.md`. I removed the first one, since the second seems to make more sense. 

![Screen Shot 2020-08-15 at 12 34 20 PM](https://user-images.githubusercontent.com/22722936/90315795-93b94300-def4-11ea-9d61-0e70ba92e7ef.png)
