### PR TITLE
bugfix/cli: Temporary fix for go get on cobra cli

### DIFF
--- a/cobra/go.mod
+++ b/cobra/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/spf13/cobra v0.0.0
+	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
 )
 


### PR DESCRIPTION
PR #1139 introduced a complexity that will have to be taken into account
as we figure out our release pipeline. This fix pins to cobrav1.0.0 as a
temporary workaround.

fixes #1191