### PR TITLE
Fix zsh completion handling of nospace and file completion

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -175,10 +175,6 @@ func (c *Command) initCompleteCmd(args []string) {
 				fmt.Fprintln(finalCmd.OutOrStdout(), comp)
 			}
 
-			if directive >= shellCompDirectiveMaxValue {
-				directive = ShellCompDirectiveDefault
-			}
-
 			// As the last printout, print the completion directive for the completion script to parse.
 			// The directive integer must be that last character following a single colon (:).
 			// The completion script expects :<directive>


### PR DESCRIPTION
Fixes #1211
Fixes #1212

This PR improves the zsh completion script to allow it to properly handle `ShellDirectiveCompletionNoSpace` and file completion all the time.  Specifically, there was an issue where when `ValidArgsFunction` would always return completions even if they don't match what the user types, the script would not behave right.  Please refer to #1211 and #1212 for specific details.

So this PR no longer counts the number of completions it receives, but instead relies on the zsh `_describe` function and its return code to handle things cleanly.