### PR TITLE
Improving the "required flag(s) "%s" not set" error message by not printing "(s)" if a single required flag is missing

### DIFF
--- a/command.go
+++ b/command.go
@@ -1004,7 +1004,10 @@ func (c *Command) validateRequiredFlags() error {
 	})
 
 	if len(missingFlagNames) > 0 {
-		return fmt.Errorf(`required flag(s) "%s" not set`, strings.Join(missingFlagNames, `", "`))
+		return fmt.Errorf(`required %s "%s" not set`,
+			pluralize("flag", len(missingFlagNames)),
+			strings.Join(missingFlagNames, `", "`),
+		)
 	}
 	return nil
 }
@@ -1661,4 +1664,12 @@ func (c *Command) updateParentsPflags() {
 	c.VisitParents(func(parent *Command) {
 		c.parentsPflags.AddFlagSet(parent.PersistentFlags())
 	})
+}
+
+func pluralize(name string, length int) string {
+	if length == 1 {
+		return name
+	}
+
+	return name + "s"
 }

--- a/command_test.go
+++ b/command_test.go
@@ -742,6 +742,21 @@ func TestPersistentFlagsOnChild(t *testing.T) {
 	}
 }
 
+func TestRequiredFlag(t *testing.T) {
+	c := &Command{Use: "c", Run: emptyRun}
+	c.Flags().String("foo1", "", "")
+	c.MarkFlagRequired("foo1")
+
+	expected := fmt.Sprintf("required flag %q not set", "foo1")
+
+	_, err := executeCommand(c)
+	got := err.Error()
+
+	if got != expected {
+		t.Errorf("Expected error: %q, got: %q", expected, got)
+	}
+}
+
 func TestRequiredFlags(t *testing.T) {
 	c := &Command{Use: "c", Run: emptyRun}
 	c.Flags().String("foo1", "", "")
@@ -750,7 +765,7 @@ func TestRequiredFlags(t *testing.T) {
 	c.MarkFlagRequired("foo2")
 	c.Flags().String("bar", "", "")
 
-	expected := fmt.Sprintf("required flag(s) %q, %q not set", "foo1", "foo2")
+	expected := fmt.Sprintf("required flags %q, %q not set", "foo1", "foo2")
 
 	_, err := executeCommand(c)
 	got := err.Error()
@@ -777,7 +792,7 @@ func TestPersistentRequiredFlags(t *testing.T) {
 
 	parent.AddCommand(child)
 
-	expected := fmt.Sprintf("required flag(s) %q, %q, %q, %q not set", "bar1", "bar2", "foo1", "foo2")
+	expected := fmt.Sprintf("required flags %q, %q, %q, %q not set", "bar1", "bar2", "foo1", "foo2")
 
 	_, err := executeCommand(parent, "child")
 	if err.Error() != expected {


### PR DESCRIPTION
Improving the "required flag(s) "%s" not set" error message by not printing "(s)" if a single required flag is missing.

If a single flag is missing, the error message is of the form "required flag "%s" not set". 

Otherwise, the error message remains unchanged.