### PR TITLE
Adding Kool to list of projects using cobra

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -15,6 +15,7 @@
 - [Helm](https://helm.sh)
 - [Hugo](https://gohugo.io)
 - [Istio](https://istio.io)
+- [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](http://kubernetes.io/)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)


### PR DESCRIPTION
Adding Kool Dev (https://github.com/kool-dev/kool) to the list of projects using Cobra.

BTW thanks a lot and keep up the great job everyone here!