### PR TITLE
Fix zsh completion not working on the first time in a shell session

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -229,6 +229,11 @@ _%[1]s()
         _describe "completions" completions $(echo $flagPrefix)
     fi
 }
+
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_%[1]s" ]; then
+	_%[1]s
+fi
 `, name, compCmd,
 		ShellCompDirectiveError, ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp,
 		ShellCompDirectiveFilterFileExt, ShellCompDirectiveFilterDirs))


### PR DESCRIPTION
The zsh completion script output by cobra is a stub completion function which replaces itself with the actual completion function. This technique enables cobra to define helper functions without splitting the completion script into multiple files.  However, the current implementation forgets to call the actual completion function at the end of the stub function, meaning that completion won't work the first time it's invoked in a shell session. This PR is a fix for this problem.