### PR TITLE
Adds Persistent{Pre,Post}Run hook chaining

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - ineffassign
     - interfacer
     #- lll
-    - maligned
+    # - maligned
     - megacheck
     #- misspell
     #- nakedret


### PR DESCRIPTION
PersistentPreRun and PersistentPostRun are chained together so that
each child PersistentPreRun is ran, and the PersistentPostRun are ran
in reverse order. For example:

Commands: root -> subcommand-a -> subcommand-b

root - PersistentPreRun
subcommand-a - PersistentPreRun
subcommand-b - PersistentPreRun
subcommand-b - Run
subcommand-b - PersistentPostRun
subcommand-a - PersistentPostRun
root - PersistentPostRun

fixes #252