### PR TITLE
fix manpage building with new go-md2man

### DIFF
--- a/doc/man_docs.go
+++ b/doc/man_docs.go
@@ -145,9 +145,7 @@ func manPreamble(buf *bytes.Buffer, header *GenManHeader, cmd *cobra.Command, da
 		description = cmd.Short
 	}
 
-	buf.WriteString(fmt.Sprintf(`%% %s(%s)%s
-%% %s
-%% %s
+	buf.WriteString(fmt.Sprintf(`%% "%s" "%s" "%s" "%s" "%s"
 # NAME
 `, header.Title, header.Section, header.date, header.Source, header.Manual))
 	buf.WriteString(fmt.Sprintf("%s \\- %s\n\n", dashedName, cmd.Short))


### PR DESCRIPTION
This addresses #1049 by changing the format of the generated Markdown input.