### PR TITLE
Added power support for the travis.yml file with ppc64le and  Disabled  GO:  1.12.x for amd64 ,  ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     - stage: build
       go: 1.13.x
       script: make cobra_generator
+      script:  
+    - make test
       
 # power support 
     - stage: diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch: 
+ - amd64
+ - ppc64le
 stages:
   - diff
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ stages:
   - build
 
 go:
-  - 1.12.x
+# - 1.12.x
   - 1.13.x
   - tip
 
@@ -36,10 +36,5 @@ matrix:
       go: 1.13.x
       arch: ppc64le
       script: make cobra_generator
-# Disable version Go 1.12.x
-jobs:
-  exclude:
-    - arch: ppc64le
-     go: 1.12.x
 script: 
  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,7 @@ matrix:
       script: make fmt
     - stage: build
       go: 1.13.x
-      script: make cobra_generator
-      script:  
-    - make test
-      
+      script: make cobra_generator  
 # power support 
     - stage: diff
       go: 1.13.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     - stage: build
       go: 1.13.x
       script: make cobra_generator
+      script: 
+ - make test
 # power support 
     - stage: diff
       go: 1.13.x
@@ -35,6 +37,12 @@ matrix:
       go: 1.13.x
       arch: ppc64le
       script: make cobra_generator
-
+      script: 
+ - make test
+# Disable version Go 1.12.x
+jobs:
+  exclude:
+    - arch: ppc64le
+     go: 1.12.x
 script: 
  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,15 @@ matrix:
     - stage: build
       go: 1.13.x
       script: make cobra_generator
+# power support 
+    - stage: diff
+      go: 1.13.x
+      arch : ppc64le
+      script: make fmt
+    - stage: build
+      go: 1.13.x
+      arch: ppc64le
+      script: make cobra_generator
 
 script: 
  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ matrix:
     - stage: build
       go: 1.13.x
       script: make cobra_generator
-      script: 
- - make test
+      
 # power support 
     - stage: diff
       go: 1.13.x
@@ -37,8 +36,6 @@ matrix:
       go: 1.13.x
       arch: ppc64le
       script: make cobra_generator
-      script: 
- - make test
 # Disable version Go 1.12.x
 jobs:
   exclude:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.
Disabled  GO :  1.12.x for amd64,  ppc64le