### PR TITLE
Fix fish completion for programs that output trailing empty lines

### DIFF
--- a/fish_completions.go
+++ b/fish_completions.go
@@ -53,6 +53,19 @@ function __%[1]s_perform_completion
     __%[1]s_debug "Calling $requestComp"
 
     set results (eval $requestComp 2> /dev/null)
+
+    # Some programs may output extra empty lines after the directive.
+    # Let's ignore them or else it will break completion.
+    # Ref: https://github.com/spf13/cobra/issues/1279
+    for line in $results[-1..1]
+        if test (string trim -- $line) = ""
+            # Found an empty line, remove it
+            set results $results[1..-2]
+        else
+            # Found non-empty line, we have our proper output
+            break
+        end
+    end
     set comps $results[1..-2]
     set directiveLine $results[-1]
 


### PR DESCRIPTION
Fixes #1279 

Some programs output extra empty lines at the end of their output, which affects the output of the `__complete` command.
`goreleaser` is such an case:
https://github.com/goreleaser/goreleaser/blob/f35534d9d7cbc2d69fcbd4edb78a5d668357fa60/cmd/root.go#L23

Those lines must be ignored for `fish` shell completion to work.
`zsh` and `bash` are not impacted.

To test this fix use the following commands for the program that follows.
```
$ go build -o testprog testprog.go
$ fish
$ ./testprog completion fish | source
$ ./testprog <TAB>

# Without this fix the completion directive :4 will be shown as a valid completion
```
**Test program which adds extra empty lines to the output**:
```
package main

import (
	"fmt"
	"os"

	"github.com/spf13/cobra"
)

var completionNoDesc = false

var completionCmd = &cobra.Command{
	Use:   "completion [bashzsh|fish|powershell]",
	Short: "Generate completion script",
	Long: `To load completions:

Bash:

$ source <(testprog completion bash)

# To load completions for each session, execute once:
Linux:
  $ testprog completion bash > /etc/bash_completion.d/testprog
MacOS:
  $ testprog completion bash > /usr/local/etc/bash_completion.d/testprog

Zsh:

$ source <(testprog completion zsh)
$ compdef _testprog testprog

# To load completions for each session, execute once:
$ testprog completion zsh > "${fpath[1]}/_testprog"

Fish:

$ testprog completion fish | source

# To load completions for each session, execute once:
$ testprog completion fish > ~/.config/fish/completions/testprog.fish

PowerShell:

PS C:\> testprog completion powershell | Out-String | Invoke-Expression

To load completions for every new session, add the output of the above command
to your powershell profile.
`,
	DisableFlagsInUseLine: true,
	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
		return []string{"bash\tBash completion", "zsh", "fish", "powershell"}, cobra.ShellCompDirectiveNoFileComp
	},
	Args: cobra.ExactValidArgs(1),
	Run: func(cmd *cobra.Command, args []string) {
		switch args[0] {
		case "bash":
			cmd.Root().GenBashCompletion(os.Stdout)
		case "zsh":
			if !completionNoDesc {
				cmd.Root().GenZshCompletion(os.Stdout)
			} else {
				cmd.Root().GenZshCompletionNoDesc(os.Stdout)
			}
		case "fish":
			cmd.Root().GenFishCompletion(os.Stdout, !completionNoDesc)
		}
	},
}

var rootCmd = &cobra.Command{
	Use: "testprog",
	Run: func(cmd *cobra.Command, args []string) {
		fmt.Println("rootCmd called")
	},
}

func setFlags() {
	rootCmd.PersistentFlags().String("theme", "", "theme to use (located in /themes/THEMENAME/)")
}

func main() {
	completionCmd.Flags().BoolVar(
		&completionNoDesc,
		"no-descriptions", false,
		"disable completion description for shells that support it")
	rootCmd.AddCommand(completionCmd)

	setFlags()

	fmt.Println("")
	fmt.Println("")
	rootCmd.Execute()
	fmt.Println("     ")
	fmt.Println("")
}
```
