### PR TITLE
Bugfix: Requesting help in case of an error needs exit code > 0

### DIFF
--- a/command.go
+++ b/command.go
@@ -961,7 +961,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		// effect
 		if err == flag.ErrHelp {
 			cmd.HelpFunc()(cmd, args)
-			return cmd, nil
+			return cmd, err
 		}
 
 		// If root command has SilenceErrors flagged,


### PR DESCRIPTION
Returning nil, when flag.ErrHelp is returned, should really not exit with '0'.

Thanks for merging.