### PR TITLE
Deprecate Go < 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - build
 
 go:
-  - 1.12.x
-  - 1.13.x
+  - 1.14.x
+  - 1.15.x
   - tip
 
 before_install:
@@ -19,10 +19,10 @@ matrix:
     - go: tip
   include:
     - stage: diff
-      go: 1.13.x
+      go: 1.14.x
       script: make fmt
     - stage: build
-      go: 1.13.x
+      go: 1.14.x
       script: make cobra_generator
 
 script: 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spf13/cobra
 
-go 1.12
+go 1.14
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0


### PR DESCRIPTION
In accordance with our adopted best practices, the main branch and the
next major release of Cobra will deprecate older and un-maintained
versions of Golang.

fix #1322
