### PR TITLE
Required flag with a default value should not return an error

### DIFF
--- a/command.go
+++ b/command.go
@@ -998,7 +998,7 @@ func (c *Command) validateRequiredFlags() error {
 		if !found {
 			return
 		}
-		if (requiredAnnotation[0] == "true") && !pflag.Changed {
+		if (requiredAnnotation[0] == "true") && !pflag.Changed && pflag.DefValue == "" {
 			missingFlagNames = append(missingFlagNames, pflag.Name)
 		}
 	})

--- a/command_test.go
+++ b/command_test.go
@@ -749,6 +749,10 @@ func TestRequiredFlags(t *testing.T) {
 	c.MarkFlagRequired("foo1")
 	c.Flags().String("foo2", "", "")
 	c.MarkFlagRequired("foo2")
+	c.Flags().String("foo3", "default", "")
+	c.MarkFlagRequired("foo3")
+	c.Flags().Int("foo4", 28, "")
+	c.MarkFlagRequired("foo4")
 	c.Flags().String("bar", "", "")
 
 	expected := fmt.Sprintf("required flag(s) %q, %q not set", "foo1", "foo2")


### PR DESCRIPTION
Fix a bug that required flag with a default value should not return an error.