### PR TITLE
Add PR labeler with pull_request_target

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,16 @@
-# changes to documentation
-"area/documentation": doc/**/*
+# changes to documentation generation
+"area/doc-gen": doc/**/*
 
-# changes to the core lib package
+# changes to the core Go cobra lib package
 "area/lib": ./*.go
 
-# changes to the shell completion
+# changes to the Cobra CLI
+"area/cli": cobra/**/*
+
+# changes to Github workflows
+"area/github": .github/**/*
+
+# changes to shell completions
 "area/*sh completion":
   - ./*completions*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,10 +4,7 @@
 # changes to the core lib package
 "area/lib": ./*.go
 
-# changes to the zsh completion
+# changes to the shell completion
 "area/*sh completion":
-  - ./zsh_*
-  - ./shell_*
-  - ./powershell_*
-  - ./bash_*
+  - ./*completions*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+# changes to documentation
+"area/documentation": doc/**/*
+
+# changes to the core lib package
+"area/lib": ./*.go
+
+# changes to the zsh completion
+"area/*sh completion":
+  - ./zsh_*
+  - ./shell_*
+  - ./powershell_*
+  - ./bash_*
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ github.token }}"
 


### PR DESCRIPTION
The github [actions/labeler](https://github.com/actions/labeler) workflow now supports the `pull_request_target` trigger which will enable us to have labels on incoming PRs that originated from forks.

This was originally a permissions issue with action/labeler since they did not support actions being run directly from forks. This was documented [in this issue](https://github.com/actions/labeler/issues/12). This new feature has been documented [here](https://github.com/actions/labeler/blob/main/README.md)

And since this is supported directly by Github, I anticipate this will be a much better collaborator experience vs the periodic-labeler tried in #1112

Closes #1092

Let me know if this needs anything else!