### PR TITLE
ci: add GitHub Actions workflow 'Test'

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.platform }}-latest
     steps:
 
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -30,6 +30,12 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.go }}-
+
     - run: |
         export GOBIN=$HOME/go/bin
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
@@ -61,6 +67,12 @@ jobs:
           mingw-w64-x86_64-go
 
     - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.go }}-
 
     - run: |
         export GOBIN=$HOME/go/bin

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,80 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  GO111MODULE: on
+
+jobs:
+
+
+  test-unix:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { icon: 🐧, os: ubuntu }
+        - { icon: 🍎, os: macOS }
+        go:
+        - 1.14.x
+        - 1.15.x
+    name: '${{ matrix.platform.icon }} ${{ matrix.go }}'
+    runs-on: ${{ matrix.platform.os }}-latest
+    steps:
+
+    - name: '⚙️ Setup go'
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '⚙️ Install deps'
+      run: |
+        export GOBIN=$HOME/go/bin
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
+        go install github.com/kyoh86/richgo
+        go install github.com/mitchellh/gox
+
+    - name: '🚧 Run tests'
+      run: PATH=$HOME/go/bin/:$PATH make
+
+
+  test-win:
+    name: '🟪 MINGW64'
+    defaults:
+      run:
+        shell: msys2 {0}
+    runs-on: windows-latest
+    steps:
+
+    - name: '⚙️ Git config'
+      shell: bash
+      run: git config --global core.autocrlf input
+
+    - name: '🟪 Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >
+          git
+          make
+          unzip
+          mingw-w64-x86_64-go
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '⚙️ Install deps'
+      run: |
+        export GOBIN=$HOME/go/bin
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
+        go install github.com/kyoh86/richgo
+        go install github.com/mitchellh/gox
+
+    - name: '🚧 Run tests'
+      run: PATH=$HOME/go/bin:$PATH make

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -15,48 +15,42 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { icon: 🐧, os: ubuntu }
-        - { icon: 🍎, os: macOS }
+        - ubuntu
+        - macOS
         go:
         - 1.14.x
         - 1.15.x
-    name: '${{ matrix.platform.icon }} ${{ matrix.go }}'
-    runs-on: ${{ matrix.platform.os }}-latest
+    name: '${{ matrix.platform }} | ${{ matrix.go }}'
+    runs-on: ${{ matrix.platform }}-latest
     steps:
 
-    - name: '⚙️ Setup go'
-      uses: actions/setup-go@v1
+    - uses: actions/setup-go@v1
       with:
         go-version: ${{ matrix.go }}
 
-    - name: '🧰 Checkout'
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-    - name: '⚙️ Install deps'
-      run: |
+    - run: |
         export GOBIN=$HOME/go/bin
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
         go install github.com/kyoh86/richgo
         go install github.com/mitchellh/gox
 
-    - name: '🚧 Run tests'
-      run: PATH=$HOME/go/bin/:$PATH make
+    - run: PATH=$HOME/go/bin/:$PATH make
 
 
   test-win:
-    name: '🟪 MINGW64'
+    name: MINGW64
     defaults:
       run:
         shell: msys2 {0}
     runs-on: windows-latest
     steps:
 
-    - name: '⚙️ Git config'
-      shell: bash
+    - shell: bash
       run: git config --global core.autocrlf input
 
-    - name: '🟪 Setup MSYS2'
-      uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
         update: true
@@ -66,15 +60,12 @@ jobs:
           unzip
           mingw-w64-x86_64-go
 
-    - name: '🧰 Checkout'
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-    - name: '⚙️ Install deps'
-      run: |
+    - run: |
         export GOBIN=$HOME/go/bin
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
         go install github.com/kyoh86/richgo
         go install github.com/mitchellh/gox
 
-    - name: '🚧 Run tests'
-      run: PATH=$HOME/go/bin:$PATH make
+    - run: PATH=$HOME/go/bin:$PATH make

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Cobra is used in many Go projects such as [Kubernetes](http://kubernetes.io/),
 [Hugo](https://gohugo.io), and [Github CLI](https://github.com/cli/cli) to
 name a few. [This list](./projects_using_cobra.md) contains a more extensive list of projects using Cobra.
 
+[![](https://img.shields.io/github/workflow/status/spf13/cobra/Test?longCache=tru&label=Test&logo=github%20actions&logoColor=fff)](https://github.com/spf13/cobra/actions?query=workflow%3ATest)
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
 [![GoDoc](https://godoc.org/github.com/spf13/cobra?status.svg)](https://godoc.org/github.com/spf13/cobra)
 [![Go Report Card](https://goreportcard.com/badge/github.com/spf13/cobra)](https://goreportcard.com/report/github.com/spf13/cobra)


### PR DESCRIPTION
Travis changed their pricing model. Free resources for open source projects were significantly reduced, and maintainers need to periodically request additional "credits". Since this projects is in spf13's namespace, I guess that only he can see the state of the credits.

In practice, most open source projects are migrating from Travis CI to somewhere else, mostly GitHub Actions.

- https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
- https://github.com/python-pillow/Pillow/issues/5028
- https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Refs: #952 #968 #1044 #1075 #1074 #1143 #1323 #1338 