### PR TITLE
Use github actions as test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: "Build and test"
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.14', '1.15' ]
+    name: Go ${{ matrix.go }}
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.go }}-
+      - name: Install deps
+        run: |
+          go get -u github.com/kyoh86/richgo
+          go get -u github.com/mitchellh/gox
+
+      - name: Diff
+        run: |
+          make fmt
+
+      - name: Generator
+        run: |
+          make cobra_generator
+
+      - name: Test
+        run: |
+          make test
+


### PR DESCRIPTION
This PR includes a workflow for Github Actions which is comparable to the current Travis CI testing pipeline.

This workflow only uses official Github supported Actions (found in their `actions` org)

You can see this being run on [my fork here](https://github.com/jpmcb/cobra/runs/1856008364) and it only takes 51 seconds to complete. It also uses a cache for the go mod, so we shouldn't have alot of downloads for each run.

