### PR TITLE
If the file exists, it should be forbidden to regenerate

### DIFF
--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -83,6 +83,11 @@ func (p *Project) createLicenseFile() error {
 }
 
 func (c *Command) Create() error {
+	// check if Command exists
+	if _, err := os.Stat(fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, c.CmdName)); os.IsExist(err) {
+		return err
+	}
+
 	cmdFile, err := os.Create(fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, c.CmdName))
 	if err != nil {
 		return err


### PR DESCRIPTION
When there are multiple commands in the cmd directory, we cannot clearly see which names have been used. 
Because this will overwrite the original code.This is not safe.
So the best way is to prohibit the creation of existing files.