### PR TITLE
Check if command already exists before attempting to create

### DIFF
--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -83,7 +83,14 @@ func (p *Project) createLicenseFile() error {
 }
 
 func (c *Command) Create() error {
-	cmdFile, err := os.Create(fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, c.CmdName))
+	fileName := fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, c.CmdName)
+
+	// check if Command exists
+	if _, err := os.Stat(fileName); err == nil {
+		return fmt.Errorf("command '%s' already exists", c.CmdName)
+	}
+
+	cmdFile, err := os.Create(fileName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These changes makes sure a command doesn't exist before attempting to create it, if it does the user gets a `command already exists` message.

I lost a lot of uncommited work in a project of mine because i mistakenly ran `$ cobra add ..`, this pull request aims to fix that.
