### PR TITLE
Get MINGW64 action running

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -76,8 +76,8 @@ jobs:
 
     - run: |
         export GOBIN=$HOME/go/bin
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
         go get github.com/kyoh86/richgo
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
         go install github.com/mitchellh/gox
 
     - run: PATH=$HOME/go/bin:$PATH make

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -77,7 +77,7 @@ jobs:
     - run: |
         export GOBIN=$HOME/go/bin
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
-        go install github.com/kyoh86/richgo
+        go get github.com/kyoh86/richgo
         go install github.com/mitchellh/gox
 
     - run: PATH=$HOME/go/bin:$PATH make

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -77,7 +77,7 @@ jobs:
     - run: |
         export GOBIN=$HOME/go/bin
         go get github.com/kyoh86/richgo
+        go get github.com/mitchellh/gox
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
-        go install github.com/mitchellh/gox
 
     - run: PATH=$HOME/go/bin:$PATH make


### PR DESCRIPTION
The `gets` need to be before `golangci-lint` is fetched,  so move them earlier to prevent the action from failing because of missing dependancies