### PR TITLE
ci/MSYS2: go install @latest

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -77,7 +77,7 @@ jobs:
     - run: |
         export GOBIN=$HOME/go/bin
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
-        go install github.com/kyoh86/richgo
-        go install github.com/mitchellh/gox
+        go install github.com/kyoh86/richgo@latest
+        go install github.com/mitchellh/gox@latest
 
     - run: PATH=$HOME/go/bin:$PATH make


### PR DESCRIPTION
Close #1365
Ref #1360 #1363

The behaviour of modules, get and install changed in golang 1.16: https://blog.golang.org/go116-module-changes. This PR fixes the problem on MSYS2 when trying to install richgo and gox.

