### PR TITLE
Add Meroxa CLI

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -21,6 +21,7 @@
 - [Kubernetes](http://kubernetes.io/)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)
+- [Meroxa CLI](https://github.com/meroxa/cli)
 - [Metal Stack CLI](https://github.com/metal-stack/metalctl)
 - [Moby (former Docker)](https://github.com/moby/moby)
 - [Nanobox](https://github.com/nanobox-io/nanobox)/[Nanopack](https://github.com/nanopack)


### PR DESCRIPTION
👋,

I'm reaching out in behalf of [Meroxa](https://meroxa.com/) as one of its developers. We've been using [Cobra](https://github.com/spf13/cobra) since our first [initial commit](https://github.com/meroxa/cli/commit/a3301a0199df4c77a9cabf1662f7858110d387e5) back from January 2020, and we recently [launched our Platform](https://techcrunch.com/2021/04/13/meroxa-raises-15m-series-a-for-its-real-time-data-platform/) to the public.

We continue considering using Cobra as our CLI framework and are [actively](https://github.com/meroxa/cli/releases) working on it, and it'd be really nice to be featured as one of the projects using Cobra in the wild.

Thank you!