### PR TITLE
Add qrcp to list of projects using cobra

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -30,6 +30,7 @@
 - [Pouch](https://github.com/alibaba/pouch)
 - [ProjectAtomic (enterprise)](http://www.projectatomic.io/)
 - [Prototool](https://github.com/uber/prototool)
+- [QRcp](https://github.com/claudiodangelis/qrcp)
 - [Random](https://github.com/erdaltsksn/random)
 - [Rclone](https://rclone.org/)
 - [Skaffold](https://skaffold.dev/)


### PR DESCRIPTION
Hello! I'm the author of [qrcp](https://github.com/claudiodangelis/qrcp), a popular file transfer utility for the command line which works by scanning a QR code printed inside the terminal (qrcp = QR copy).
Thought it would be nice to have it on the list of projects using cobra :)

Cheers, and thanks for your work,
Claudio