### PR TITLE
feat(completion): add option to create default command alone

### DIFF
--- a/command.go
+++ b/command.go
@@ -927,10 +927,10 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		preExecHookFn(c)
 	}
 
-	// initialize help at the last point to allow for user overriding
-	c.InitDefaultHelpCmd()
 	// initialize completion at the last point to allow for user overriding
 	c.initDefaultCompletionCmd()
+	// initialize help at the last point to allow for user overriding
+	c.InitDefaultHelpCmd()
 
 	args := c.args
 

--- a/completions.go
+++ b/completions.go
@@ -95,6 +95,9 @@ type CompletionOptions struct {
 	DisableDescriptions bool
 	// HiddenDefaultCmd makes the default 'completion' command hidden
 	HiddenDefaultCmd bool
+	// InitDefaultEvenIfHasNoSubCommands causes the default 'completion' command to be created
+	// even if there are no other commands defined
+	InitDefaultEvenIfHasNoSubCommands bool
 }
 
 // NoFileCompletions can be used to disable file completion for commands that should
@@ -583,10 +586,10 @@ func checkIfFlagCompletion(finalCmd *Command, args []string, lastArg string) (*p
 // initDefaultCompletionCmd adds a default 'completion' command to c.
 // This function will do nothing if any of the following is true:
 // 1- the feature has been explicitly disabled by the program,
-// 2- c has no subcommands (to avoid creating one),
+// 2- c has no subcommands (to avoid creating one) and not overridden with the InitDefaultEvenIfHasNoSubCommands completion option,
 // 3- c already has a 'completion' command provided by the program.
 func (c *Command) initDefaultCompletionCmd() {
-	if c.CompletionOptions.DisableDefaultCmd || !c.HasSubCommands() {
+	if c.CompletionOptions.DisableDefaultCmd || (!c.CompletionOptions.InitDefaultEvenIfHasNoSubCommands && !c.HasSubCommands()) {
 		return
 	}
 


### PR DESCRIPTION
The current implementation of the default completion (and help) commands makes them available only when there are some other commands defined. This rules them out for apps that have no other subcommands, either by design anew, or for historical behavior, even though they would benefit from completions both in the first place, and the convenience of having the default generated.

This adds a new completion option for having the default init happen in those cases. Not that clean in the first place and the variable name is a mouthful, but the functionality would be great to have.

Untested, mainly for discussion purposes, but in absence of something better, I'd be fine with something like this.