### PR TITLE
Add install instructions for zsh on Mac OS

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -608,7 +608,10 @@ to enable it.  You can execute the following once:
 $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
 To load completions for every new session, execute once:
+# Linux:
 $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+# macOS:
+$ %[1]s completion zsh > /usr/local/share/zsh/site-functions/_%[1]s
 
 You will need to start a new shell for this setup to take effect.
 `, c.Root().Name()),


### PR DESCRIPTION
zsh is now the default on Mac OS, but the $_fpath version of the installation instructions are likely to put the completion in a strange location that the user might not expect (e.g. an oh-my-zsh plugin's function directory).  So, since Mac OS seems to (as far as I can tell) provide a stable location, this PR recommends using that path instead.