### PR TITLE
fix RegisterFlagCompletionFunc concurrent map writes error

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -512,7 +512,7 @@ func writeLocalNonPersistentFlag(buf io.StringWriter, flag *pflag.Flag) {
 
 // Setup annotations for go completions for registered flags
 func prepareCustomAnnotationsForFlags(cmd *Command) {
-	for flag := range flagCompletionFunctions {
+	for flag := range cmd.Root().flagCompletionFunctions {
 		// Make sure the completion script calls the __*_go_custom_completion function for
 		// every registered flag.  We need to do this here (and not when the flag was registered
 		// for completion) so that we can know the root command name for the prefix

--- a/command.go
+++ b/command.go
@@ -88,6 +88,9 @@ type Command struct {
 	// group commands.
 	Annotations map[string]string
 
+	//flagCompletionFunctions is map of flag completion functions.
+	flagCompletionFunctions map[*flag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
+
 	// Version defines the version for this command. If this value is non-empty and the command does not
 	// define a "version" flag, a "version" boolean flag will be added to the command and, if specified,
 	// will print content of the "Version" variable. A shorthand "v" flag will also be added if the

--- a/command.go
+++ b/command.go
@@ -88,9 +88,6 @@ type Command struct {
 	// group commands.
 	Annotations map[string]string
 
-	//flagCompletionFunctions is map of flag completion functions.
-	flagCompletionFunctions map[*flag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
-
 	// Version defines the version for this command. If this value is non-empty and the command does not
 	// define a "version" flag, a "version" boolean flag will be added to the command and, if specified,
 	// will print content of the "Version" variable. A shorthand "v" flag will also be added if the
@@ -143,6 +140,9 @@ type Command struct {
 	// globNormFunc is the global normalization function
 	// that we can use on every pflag set and children commands
 	globNormFunc func(f *flag.FlagSet, name string) flag.NormalizedName
+
+	//flagCompletionFunctions is map of flag completion functions.
+	flagCompletionFunctions map[*flag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
 
 	// usageFunc is usage func defined by user.
 	usageFunc func(*Command) error

--- a/completions.go
+++ b/completions.go
@@ -17,9 +17,6 @@ const (
 	ShellCompNoDescRequestCmd = "__completeNoDesc"
 )
 
-// Global map of flag completion functions.
-var flagCompletionFunctions = map[*pflag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective){}
-
 // ShellCompDirective is a bit map representing the different behaviors the shell
 // can be instructed to have once completions have been provided.
 type ShellCompDirective int
@@ -95,10 +92,14 @@ func (c *Command) RegisterFlagCompletionFunc(flagName string, f func(cmd *Comman
 	if flag == nil {
 		return fmt.Errorf("RegisterFlagCompletionFunc: flag '%s' does not exist", flagName)
 	}
-	if _, exists := flagCompletionFunctions[flag]; exists {
+
+	if _, exists := c.Root().flagCompletionFunctions[flag]; exists {
 		return fmt.Errorf("RegisterFlagCompletionFunc: flag '%s' already registered", flagName)
 	}
-	flagCompletionFunctions[flag] = f
+	if c.Root().flagCompletionFunctions == nil {
+		c.Root().flagCompletionFunctions = map[*pflag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective){}
+	}
+	c.Root().flagCompletionFunctions[flag] = f
 	return nil
 }
 
@@ -375,7 +376,7 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 	// Find the completion function for the flag or command
 	var completionFn func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
 	if flag != nil {
-		completionFn = flagCompletionFunctions[flag]
+		completionFn = c.Root().flagCompletionFunctions[flag]
 	} else {
 		completionFn = finalCmd.ValidArgsFunction
 	}

--- a/completions.go
+++ b/completions.go
@@ -93,13 +93,14 @@ func (c *Command) RegisterFlagCompletionFunc(flagName string, f func(cmd *Comman
 		return fmt.Errorf("RegisterFlagCompletionFunc: flag '%s' does not exist", flagName)
 	}
 
-	if _, exists := c.Root().flagCompletionFunctions[flag]; exists {
+	root := c.Root()
+	if _, exists := root.flagCompletionFunctions[flag]; exists {
 		return fmt.Errorf("RegisterFlagCompletionFunc: flag '%s' already registered", flagName)
 	}
-	if c.Root().flagCompletionFunctions == nil {
-		c.Root().flagCompletionFunctions = map[*pflag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective){}
+	if root.flagCompletionFunctions == nil {
+		root.flagCompletionFunctions = map[*pflag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective){}
 	}
-	c.Root().flagCompletionFunctions[flag] = f
+	root.flagCompletionFunctions[flag] = f
 	return nil
 }
 


### PR DESCRIPTION
Some CI system(like istio) will call package of istioctl in parallel, if cobra use `flagCompletionFunctions` as a global var, will generate `fatal error: concurrent map writes`.
So it is better to store those functions to `flagCompletionFunctions` as a map of root command(thread-safe), instead of a global var.

ref #1320 (this PR will not fix it, as we only get thread-safe, but no lock for multi threads)
