### PR TITLE
github: add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Close #907

Dependabot was an external service for keeping dependencies up to date. It was bought by GitHub, and it's now a built-in service which integrates with security updates. See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically.

In April, GitHub announced that the external service (*Dependabot Preview*) is to be shut down in August: https://github.blog/2021-04-29-goodbye-dependabot-preview-hello-dependabot/.

This PR adds a dependabot configuration file for checking go dependencies weekly.

Note that this features does NOT auto-merge. It will open PRs, but maintainers will need to merge them, or bump the dependencies otherwise.

Refs: #1420 #1406 #1404 #1364