### PR TITLE
Fix error messages of unbound variables in completions with `set -u`

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -24,7 +24,7 @@ func writePreamble(buf io.StringWriter, name string) {
 	WriteStringAndCheck(buf, fmt.Sprintf(`
 __%[1]s_debug()
 {
-    if [[ -n ${BASH_COMP_DEBUG_FILE} ]]; then
+    if [[ -n ${BASH_COMP_DEBUG_FILE-} ]]; then
         echo "$*" >> "${BASH_COMP_DEBUG_FILE}"
     fi
 }

--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -81,7 +81,7 @@ func genZshComp(buf io.StringWriter, name string, includeDesc bool) {
 
 __%[1]s_debug()
 {
-    local file="$BASH_COMP_DEBUG_FILE"
+    local file="${BASH_COMP_DEBUG_FILE-}"
     if [[ -n ${file} ]]; then
         echo "$*" >> "${file}"
     fi


### PR DESCRIPTION
This fixes the issue reported at https://github.com/scop/bash-completion/issues/551
