### PR TITLE
Fix command name collision on generator

### DIFF
--- a/cobra/cmd/add_test.go
+++ b/cobra/cmd/add_test.go
@@ -8,9 +8,11 @@ import (
 
 func TestGoldenAddCmd(t *testing.T) {
 	command := &Command{
-		CmdName:   "test",
-		CmdParent: parentName,
-		Project:   getProject(),
+		CmdName:     "test",
+		CmdUse:      "test",
+		CmdFileName: "test",
+		CmdParent:   parentName,
+		Project:     getProject(),
 	}
 	defer os.RemoveAll(command.AbsolutePath)
 
@@ -45,6 +47,33 @@ func TestValidateCmdName(t *testing.T) {
 		got := validateCmdName(testCase.input)
 		if testCase.expected != got {
 			t.Errorf("Expected %q, got %q", testCase.expected, got)
+		}
+	}
+}
+
+func TestGenerateCmdFileName(t *testing.T) {
+	testCases := []struct {
+		inputCmd     string
+		inputParent  string
+		expectedCmd  string
+		expectedFile string
+	}{
+		{"cmdname", "parent", "parentCmdname", "parent_cmdname"},
+		{"cmdname", "parentCmd", "parentCmdname", "parent_cmdname"},
+		{"CmdName", "ParentCmd", "parentCmdName", "parent_cmd_name"},
+		{"cmdname", "granpaParentCmd", "granpaParentCmdname", "granpa_parent_cmdname"},
+		{"test", "granpaParentCmd", "granpaParentTest", "granpa_parent_testcmd"},
+		{"cmdname", "rootCmd", "cmdname", "cmdname"},
+	}
+
+	for _, testCase := range testCases {
+		got1, got2 := generateCmdFileName(testCase.inputCmd, testCase.inputParent)
+		if testCase.expectedCmd != got1 || testCase.expectedFile != got2 {
+			t.Errorf(
+				"Expected %q and %q, got %q and %q",
+				testCase.expectedCmd, testCase.expectedFile,
+				got1, got2,
+			)
 		}
 	}
 }

--- a/cobra/cmd/project.go
+++ b/cobra/cmd/project.go
@@ -21,8 +21,10 @@ type Project struct {
 }
 
 type Command struct {
-	CmdName   string
-	CmdParent string
+	CmdName     string
+	CmdUse      string
+	CmdFileName string
+	CmdParent   string
 	*Project
 }
 
@@ -83,7 +85,7 @@ func (p *Project) createLicenseFile() error {
 }
 
 func (c *Command) Create() error {
-	cmdFile, err := os.Create(fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, c.CmdName))
+	cmdFile, err := os.Create(fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, c.CmdFileName))
 	if err != nil {
 		return err
 	}

--- a/cobra/tpl/main.go
+++ b/cobra/tpl/main.go
@@ -113,9 +113,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// {{ .CmdName }}Cmd represents the {{ .CmdName }} command
+// {{ .CmdName }}Cmd represents the {{ .CmdUse }} command
 var {{ .CmdName }}Cmd = &cobra.Command{
-	Use:   "{{ .CmdName }}",
+	Use:   "{{ .CmdUse }}",
 	Short: "A brief description of your command",
 	Long: ` + "`" + `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -124,7 +124,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.` + "`" + `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("{{ .CmdName }} called")
+		fmt.Println("{{ .CmdUse }} called")
 	},
 }
 


### PR DESCRIPTION
When creating new commands via `cobra add`, it is not possible to add
commands with the same name to different parents. They will just
overwrite each other.

With this patch, the command's object identifier is templated
`parentCommandCmd`, the `Use` field `command` and the file name
`parent_command.go`.

Fixes #1059
Fixes #1131

Signed-off-by: Carlos Marx <me@carlosmarx.com>