### PR TITLE
Completion: Capitalize short desc and remove extra space from long 

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -589,9 +589,8 @@ func (c *Command) initDefaultCompletionCmd() {
 
 	completionCmd := &Command{
 		Use:   compCmdName,
-		Short: "generate the autocompletion script for the specified shell",
-		Long: fmt.Sprintf(`
-Generate the autocompletion script for %[1]s for the specified shell.
+		Short: "Generate the autocompletion script for the specified shell",
+		Long: fmt.Sprintf(`Generate the autocompletion script for %[1]s for the specified shell.
 See each sub-command's help for details on how to use the generated script.
 `, c.Root().Name()),
 		Args:              NoArgs,
@@ -601,12 +600,11 @@ See each sub-command's help for details on how to use the generated script.
 
 	out := c.OutOrStdout()
 	noDesc := c.CompletionOptions.DisableDescriptions
-	shortDesc := "generate the autocompletion script for %s"
+	shortDesc := "Generate the autocompletion script for %s"
 	bash := &Command{
 		Use:   "bash",
 		Short: fmt.Sprintf(shortDesc, "bash"),
-		Long: fmt.Sprintf(`
-Generate the autocompletion script for the bash shell.
+		Long: fmt.Sprintf(`Generate the autocompletion script for the bash shell.
 
 This script depends on the 'bash-completion' package.
 If it is not installed already, you can install it via your OS's package manager.
@@ -636,8 +634,7 @@ You will need to start a new shell for this setup to take effect.
 	zsh := &Command{
 		Use:   "zsh",
 		Short: fmt.Sprintf(shortDesc, "zsh"),
-		Long: fmt.Sprintf(`
-Generate the autocompletion script for the zsh shell.
+		Long: fmt.Sprintf(`Generate the autocompletion script for the zsh shell.
 
 If shell completion is not already enabled in your environment you will need
 to enable it.  You can execute the following once:
@@ -668,8 +665,7 @@ You will need to start a new shell for this setup to take effect.
 	fish := &Command{
 		Use:   "fish",
 		Short: fmt.Sprintf(shortDesc, "fish"),
-		Long: fmt.Sprintf(`
-Generate the autocompletion script for the fish shell.
+		Long: fmt.Sprintf(`Generate the autocompletion script for the fish shell.
 
 To load completions in your current shell session:
 $ %[1]s completion fish | source
@@ -692,8 +688,7 @@ You will need to start a new shell for this setup to take effect.
 	powershell := &Command{
 		Use:   "powershell",
 		Short: fmt.Sprintf(shortDesc, "powershell"),
-		Long: fmt.Sprintf(`
-Generate the autocompletion script for powershell.
+		Long: fmt.Sprintf(`Generate the autocompletion script for powershell.
 
 To load completions in your current shell session:
 PS C:\> %[1]s completion powershell | Out-String | Invoke-Expression

--- a/completions_test.go
+++ b/completions_test.go
@@ -125,7 +125,7 @@ func TestCmdNameCompletionInGo(t *testing.T) {
 
 	expected = strings.Join([]string{
 		"aliased\tA command with aliases",
-		"completion\tgenerate the autocompletion script for the specified shell",
+		"completion\tGenerate the autocompletion script for the specified shell",
 		"firstChild\tFirst command",
 		"help\tHelp about any command",
 		"secondChild",
@@ -580,7 +580,7 @@ func TestFlagNameCompletionInGoWithDesc(t *testing.T) {
 
 	expected := strings.Join([]string{
 		"childCmd\tfirst command",
-		"completion\tgenerate the autocompletion script for the specified shell",
+		"completion\tGenerate the autocompletion script for the specified shell",
 		"help\tHelp about any command",
 		":4",
 		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")


### PR DESCRIPTION
The `help` short desc is capitalized so we should follow its lead for consistency.

Also fixes #1458.