### PR TITLE
Skip flag completion for commands with disabled flag parsing

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -266,6 +266,11 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 		}
 	}
 
+	// Skip flag completion for commands that have disabled flag parsing
+	if finalCmd.DisableFlagParsing && flagCompletion {
+		flagCompletion = false
+	}
+
 	if flag != nil && flagCompletion {
 		// Check if we are completing a flag value subject to annotations
 		if validExts, present := flag.Annotations[BashCompFilenameExt]; present {


### PR DESCRIPTION
When a command disabled flag parsing, the shell completion for that
command should not offer flags. This allows completions for args to be
processed like normal. This behavior is particularly useful for invoking
a CLI plugin that has its own sub commands, arguments, flags, and
completion rules.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>