### PR TITLE
fix: typo in {bash,zsh}_completions.go

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -134,7 +134,7 @@ __%[1]s_handle_go_custom_completion()
         $filteringCmd
     elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
         # File completion for directories only
-        local subDir
+        local subdir
         # Use printf to strip any trailing newline
         subdir=$(printf "%%s" "${out[0]}")
         if [ -n "$subdir" ]; then

--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -202,7 +202,7 @@ _%[1]s()
         _arguments '*:filename:'"$filteringCmd"
     elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
         # File completion for directories only
-        local subDir
+        local subdir
         subdir="${completions[1]}"
         if [ -n "$subdir" ]; then
             __%[1]s_debug "Listing directories in $subdir"


### PR DESCRIPTION
`subDir` seems to be a typo. It is deep inside `bash_completions.go` used to generate bash completion scripts. I am not sure how to write a test for this.