### PR TITLE
chore(ci): use golangci-lint-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,20 @@ env:
 
 jobs:
 
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - uses: actions/checkout@v2
+
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: --verbose
 
   test-unix:
     strategy:
@@ -40,7 +54,6 @@ jobs:
 
     - run: |
         export GOBIN=$HOME/go/bin
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
         case "${{ matrix.go }}" in
           16|17) _version='@latest';;
           *) _version='';;
@@ -48,8 +61,7 @@ jobs:
         go install github.com/kyoh86/richgo"${_version}"
         go install github.com/mitchellh/gox"${_version}"
 
-    - run: PATH=$HOME/go/bin/:$PATH make
-
+    - run: PATH=$HOME/go/bin/:$PATH make test cobra_generator
 
   test-win:
     name: MINGW64
@@ -82,8 +94,7 @@ jobs:
 
     - run: |
         export GOBIN=$HOME/go/bin
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOBIN latest
         go install github.com/kyoh86/richgo@latest
         go install github.com/mitchellh/gox@latest
 
-    - run: PATH=$HOME/go/bin:$PATH make
+    - run: PATH=$HOME/go/bin:$PATH make test cobra_generator

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint:
 	$(info ******************** running lint tools ********************)
 	golangci-lint run -v
 
-test: install_deps lint
+test: install_deps
 	$(info ******************** running tests ********************)
 	richgo test -v ./...
 


### PR DESCRIPTION
This PR is to use golangci-lint-action instead of direct download of it's executable.
It allows also to see the tool's reviews outside of the logs in github.
I also formated and fixed the actual reviews.
Some linters were deprecated, so I used there actual versions