### PR TITLE
Uppercase first char in short desc of generate command

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -589,7 +589,7 @@ func (c *Command) initDefaultCompletionCmd() {
 
 	completionCmd := &Command{
 		Use:   compCmdName,
-		Short: "generate the autocompletion script for the specified shell",
+		Short: "Generate the autocompletion script for the specified shell",
 		Long: fmt.Sprintf(`
 Generate the autocompletion script for %[1]s for the specified shell.
 See each sub-command's help for details on how to use the generated script.
@@ -601,7 +601,7 @@ See each sub-command's help for details on how to use the generated script.
 
 	out := c.OutOrStdout()
 	noDesc := c.CompletionOptions.DisableDescriptions
-	shortDesc := "generate the autocompletion script for %s"
+	shortDesc := "Generate the autocompletion script for %s"
 	bash := &Command{
 		Use:   "bash",
 		Short: fmt.Sprintf(shortDesc, "bash"),

--- a/completions_test.go
+++ b/completions_test.go
@@ -125,7 +125,7 @@ func TestCmdNameCompletionInGo(t *testing.T) {
 
 	expected = strings.Join([]string{
 		"aliased\tA command with aliases",
-		"completion\tgenerate the autocompletion script for the specified shell",
+		"completion\tGenerate the autocompletion script for the specified shell",
 		"firstChild\tFirst command",
 		"help\tHelp about any command",
 		"secondChild",
@@ -580,7 +580,7 @@ func TestFlagNameCompletionInGoWithDesc(t *testing.T) {
 
 	expected := strings.Join([]string{
 		"childCmd\tfirst command",
-		"completion\tgenerate the autocompletion script for the specified shell",
+		"completion\tGenerate the autocompletion script for the specified shell",
 		"help\tHelp about any command",
 		":4",
 		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")


### PR DESCRIPTION
This commit provides consistency of the letter casing in the short
description between commands. Both the short description as well as
documented examples have the first character in the short description in
uppercase. The generate command was the exception by having the first
character of the short description in lowercase, creating an
inconsistent help menu for the user:

``` sh
Available Commands:
  add              Add a command to a Cobra Application
  completion       generate the autocompletion script for the specified shell
  help             Help about any command
  init             Initialize a Cobra Application
```

* User Guide Example: https://github.com/spf13/cobra/blob/v1.2.1/user_guide.md#example
* Help command: https://github.com/spf13/cobra/blob/master/command.go#L1080