### PR TITLE
Remove indentation causing RST errors

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -616,9 +616,9 @@ $ source <(%[1]s completion bash)
 
 To load completions for every new session, execute once:
 Linux:
-  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
+$ %[1]s completion bash > /etc/bash_completion.d/%[1]s
 MacOS:
-  $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
+$ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
 
 You will need to start a new shell for this setup to take effect.
   `, c.Root().Name()),


### PR DESCRIPTION
We generate our docs in RST from Cobra. I removed the indentations causing an error in the generated RST. This also makes the long descriptions consistent.