### PR TITLE
Support subcommands checking for suggestions

### DIFF
--- a/args.go
+++ b/args.go
@@ -8,8 +8,8 @@ import (
 type PositionalArgs func(cmd *Command, args []string) error
 
 // Legacy arg validation has the following behaviour:
-// - root commands with no subcommands can take arbitrary arguments
-// - root commands with subcommands will do subcommand validity checking
+// - commands with no subcommands can take arbitrary arguments
+// - commands with subcommands will do subcommand validity checking
 // - subcommands will always accept arbitrary arguments
 func legacyArgs(cmd *Command, args []string) error {
 	// no subcommand, always take args
@@ -17,8 +17,8 @@ func legacyArgs(cmd *Command, args []string) error {
 		return nil
 	}
 
-	// root command with subcommands, do subcommand checking.
-	if !cmd.HasParent() && len(args) > 0 {
+	// do subcommand checking
+	if len(args) > 0 {
 		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
 	}
 	return nil


### PR DESCRIPTION
Resolves #636
Resolves #834
Resolves https://github.com/alexellis/arkade/issues/525

Till now, only the root command looked for suggestions.
Now `findSuggestions` works for nested commands as well.

For example

```
Error: unknown command "rewin" for "root times"

Did you mean this?
	rewind

Run 'root times --help' for usage.
```
