### PR TITLE
Handle requiredFlags errors in the same way as errors originating from parsing flags.

### DIFF
--- a/command.go
+++ b/command.go
@@ -850,7 +850,7 @@ func (c *Command) execute(a []string) (err error) {
 	}
 
 	if err := c.validateRequiredFlags(); err != nil {
-		return err
+		return c.FlagErrorFunc()(c, err)
 	}
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {


### PR DESCRIPTION
At the moment there is a difference between the error messages + output when a required argument is not filled in compared to when an unexisting flag is passed.

I validate this by passing in a custom flagErrorFunc which prints both the error and the usage.
This error function is correctly used when the flag parsing fails, but it is not taken into account when validating required arguments fails.

