### PR TITLE
Fix invalid shell completion when used with ~/.cobra.yaml

### DIFF
--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -74,6 +74,6 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 }


### PR DESCRIPTION
`cobra completion` outputs invalid output "Using config file:" at the top of the completion script. when ~/.cobra.yaml exists.