### PR TITLE
'go get' to 'go install'

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -5,7 +5,7 @@ commands you want. It's the easiest way to incorporate Cobra into your applicati
 
 In order to use the cobra command, compile it using the following command:
 
-    go get github.com/spf13/cobra/cobra
+    go install github.com/spf13/cobra/cobra@latest
 
 This will create the cobra executable under your `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Installing using `go get -u` is depricated. So, updated it in cobra/README to `go install`