### PR TITLE
Completion command helptext capitalization

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -599,7 +599,7 @@ func (c *Command) initDefaultCompletionCmd() {
 
 	completionCmd := &Command{
 		Use:   compCmdName,
-		Short: "generate the autocompletion script for the specified shell",
+		Short: "Generate the autocompletion script for the specified shell",
 		Long: fmt.Sprintf(`
 Generate the autocompletion script for %[1]s for the specified shell.
 See each sub-command's help for details on how to use the generated script.


### PR DESCRIPTION
The default completion command's helptext capitalization should match the default help command's helptext capitalization

Yes, this is entirely nitpicky, but it is bothering me