### PR TITLE
Capitalize first letter of default `completion` command short description

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -599,7 +599,7 @@ func (c *Command) initDefaultCompletionCmd() {
 
 	completionCmd := &Command{
 		Use:   compCmdName,
-		Short: "generate the autocompletion script for the specified shell",
+		Short: "Generate the autocompletion script for the specified shell",
 		Long: fmt.Sprintf(`
 Generate the autocompletion script for %[1]s for the specified shell.
 See each sub-command's help for details on how to use the generated script.
@@ -611,7 +611,7 @@ See each sub-command's help for details on how to use the generated script.
 
 	out := c.OutOrStdout()
 	noDesc := c.CompletionOptions.DisableDescriptions
-	shortDesc := "generate the autocompletion script for %s"
+	shortDesc := "Generate the autocompletion script for %s"
 	bash := &Command{
 		Use:   "bash",
 		Short: fmt.Sprintf(shortDesc, "bash"),


### PR DESCRIPTION
Currently, the default `completion` command has the following short description: `generate the autocompletion script for the specified shell`. Note that `generate` is not capitalized.

Meanwhile, the again default `help` command has the following short description: `Help about any command`. Note that `Help` is capitalized.

This mean that a default project will have the following Help message:

```
Available Commands:
  completion  generate the autocompletion script for the specified shell
  help        Help about any command
```

This is kinda inconsistent and is more noticeable in real life scenario, such as the [Hugo](https://gohugo.io/) CLI here:

![screenshot_2021-11-22-155724_761x280_selection](https://user-images.githubusercontent.com/4584397/142885705-c2b2182b-f977-4aa8-beb1-6a82fa9d0d47.png)

Yes, this is definitely very minor but you know... OCD and stuff :sweat_smile: 