### PR TITLE
Provide option to hide default 'completion' cmd

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -93,6 +93,8 @@ type CompletionOptions struct {
 	// DisableDescriptions turns off all completion descriptions for shells
 	// that support them
 	DisableDescriptions bool
+	// HiddenDefaultCmd makes the default 'completion' command hidden
+	HiddenDefaultCmd bool
 }
 
 // NoFileCompletions can be used to disable file completion for commands that should
@@ -606,6 +608,7 @@ See each sub-command's help for details on how to use the generated script.
 `, c.Root().Name()),
 		Args:              NoArgs,
 		ValidArgsFunction: NoFileCompletions,
+		Hidden:            c.CompletionOptions.HiddenDefaultCmd,
 	}
 	c.AddCommand(completionCmd)
 

--- a/completions_test.go
+++ b/completions_test.go
@@ -2398,6 +2398,21 @@ func TestDefaultCompletionCmd(t *testing.T) {
 	rootCmd.CompletionOptions.DisableDescriptions = false
 	// Remove completion command for the next test
 	removeCompCmd(rootCmd)
+
+	// Test that the 'completion' command can be hidden
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+	assertNoErr(t, rootCmd.Execute())
+	compCmd, _, err = rootCmd.Find([]string{compCmdName})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if compCmd.Hidden == false {
+		t.Error("Default 'completion' command should be hidden but it is not")
+	}
+	// Re-enable for next test
+	rootCmd.CompletionOptions.HiddenDefaultCmd = false
+	// Remove completion command for the next test
+	removeCompCmd(rootCmd)
 }
 
 func TestCompleteCompletion(t *testing.T) {


### PR DESCRIPTION
Fixes #1507 as requested by @jpmcb

This very simple change adds a user option to allow hiding the default completion command.
So, to tell Cobra to make the default `completion` command *hidden*:
```
rootCmd.CompletionOptions.HiddenDefaultCmd = true
```
It replace #1523 which was more flexible but much more complicated.