### PR TITLE
Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,13 @@
+maintainers:
+- spf13
+- johnSchnake
+- jpmcb
+- marckhouzam
+inactive:
+- anthonyfok
+- bep
+- bogem
+- broady
+- eparis
+- jharshman
+- wfernandes


### PR DESCRIPTION
This PR suggests adding a MAINTAINERS file to help the community know who they can turn to, but also give credit to the maintainers for all their hard work.

That being said, I've only included maintainers that I can remember merged something in the last few years, but there must be more.
I also added an emeritus section that is currently empty and I don't know if it even applies.

If there is interest such a change, please let me know the list of maintainers and I'll update the PR.

