### PR TITLE
remove unneeded error from printOption method

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
+func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
@@ -42,7 +42,6 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 		parentFlags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}
-	return nil
 }
 
 // GenMarkdown creates markdown output.
@@ -74,9 +73,8 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.Example))
 	}
 
-	if err := printOptions(buf, cmd, name); err != nil {
-		return err
-	}
+	printOptions(buf, cmd, name)
+
 	if hasSeeAlso(cmd) {
 		buf.WriteString("### SEE ALSO\n\n")
 		if cmd.HasParent() {


### PR DESCRIPTION
The code below doesn't really need the `error` as return type, so I remove it

```go
func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
	flags := cmd.NonInheritedFlags()
	flags.SetOutput(buf)
	if flags.HasAvailableFlags() {
		parentFlags.PrintDefaults()
		buf.WriteString("```\n\n")
	}
	return nil
}
```