### PR TITLE
Fix unexpected executing subcommand

### DIFF
--- a/command.go
+++ b/command.go
@@ -585,11 +585,12 @@ Loop:
 		case strings.HasPrefix(s, "-") && !strings.Contains(s, "=") && len(s) == 2 && !shortHasNoOptDefVal(s[1:], flags):
 			// If '-f arg' then
 			// delete 'arg' from args or break the loop if len(args) <= 1.
-			if len(args) <= 1 {
+			if len(args) == 0 {
 				break Loop
-			} else {
+			}
+			// Only delete 'arg' when it is not starts with '-'
+			if !strings.HasPrefix(args[0], "-") {
 				args = args[1:]
-				continue
 			}
 		case s != "" && !strings.HasPrefix(s, "-"):
 			commands = append(commands, s)

--- a/command_test.go
+++ b/command_test.go
@@ -2058,3 +2058,93 @@ func TestFParseErrWhitelistSiblingCommand(t *testing.T) {
 	}
 	checkStringContains(t, output, "unknown flag: --unknown")
 }
+
+func TestFCommandFindSubCommand(t *testing.T) {
+	root := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+	type testOpts struct {
+		a bool
+		b bool
+	}
+	var opt testOpts
+	child := &Command{
+		Use: "child",
+		RunE: func(cmd *Command, args []string) error {
+			fmt.Printf("Done! a=%v b=%v\n", opt.a, opt.b)
+			return nil
+		},
+	}
+	child.Flags().BoolVar(&opt.a, "a", false, "a")
+	child.Flags().BoolVar(&opt.b, "b", false, "b")
+	flag := child.Flags().Lookup("a")
+	if flag != nil {
+		if flag.NoOptDefVal != "true" {
+			t.Errorf("ffff %v", flag.NoOptDefVal)
+		}
+	}
+	root.AddCommand(child)
+
+	argsToTest := [][]string{
+		{"--a", "--b", "child"},
+		{"child", "--a"},
+		{"child", "--b"},
+		{"--a=false", "child"},
+		{"--a=true", "child"},
+		{"--a", "child"},
+		{"--b", "child"},
+	}
+	for _, args := range argsToTest {
+		cmdFound, _, err := root.Find(args)
+		if err != nil {
+			t.Errorf("Unexpected error: %v with args: %v", err, args)
+		}
+		if cmdFound.Name() != "child" {
+			t.Errorf("expected found 'child' command with args: %v", args)
+		}
+	}
+}
+
+func TestFFindSubCommand(t *testing.T) {
+	root := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+	type testOpts struct {
+		a bool
+		b bool
+	}
+	var opt testOpts
+	child := &Command{
+		Use: "child",
+		RunE: func(cmd *Command, args []string) error {
+			fmt.Printf("Done! a=%v b=%v\n", opt.a, opt.b)
+			return nil
+		},
+	}
+	child.Flags().BoolVar(&opt.a, "a", false, "a")
+	child.Flags().BoolVar(&opt.b, "b", false, "b")
+	root.AddCommand(child)
+
+	// ok
+	output, err := executeCommand(root, "--a", "child")
+	if err == nil {
+		t.Error("expected unknown flag error")
+	}
+	checkStringContains(t, output, "unknown flag: --a")
+
+	// ok
+	output, err = executeCommand(root, "--b", "child")
+	if err == nil {
+		t.Error("expected unknown flag error")
+	}
+	checkStringContains(t, output, "unknown flag: --b")
+
+	// fail?
+	output, err = executeCommand(root, "--a", "--b", "child")
+	if err == nil {
+		t.Error("expected unknown flag error")
+	}
+	checkStringContains(t, output, "unknown flag: --a")
+}


### PR DESCRIPTION
I've defined a subcommand with two boolean arguments and found it unexpectedly run into the subcommand.
In specific, a subcommand naming "sub" with two boolean arguments "a" and "b". If I parse the command with arguments " --a sub" or "--b sub", it returns an error "unknown argument" as expected. But when I parse the command with arguments "--a --b sub", it runs into the "sub" command with those two boolean arguments set.

I trace down the codes in cobra and find that `stripFlags` always assume `'--flag arg'` or `-f arg`, ignoring the pattern of boolean flag. So I file a PR trying to fix this unexpected behavior.
