### PR TITLE
Add Command.SetContext

### DIFF
--- a/command.go
+++ b/command.go
@@ -230,6 +230,12 @@ func (c *Command) Context() context.Context {
 	return c.ctx
 }
 
+// SetContext sets context for the command. It is set to context.Background by default and will be overwritten by
+// Command.ExecuteContext or Command.ExecuteContextC
+func (c *Command) SetContext(ctx context.Context) {
+	c.ctx = ctx
+}
+
 // SetArgs sets arguments for the command. It is set to os.Args[1:] by default, if desired, can be overridden
 // particularly useful when testing.
 func (c *Command) SetArgs(a []string) {

--- a/command_test.go
+++ b/command_test.go
@@ -2061,7 +2061,7 @@ func TestFParseErrWhitelistSiblingCommand(t *testing.T) {
 
 func TestSetContext(t *testing.T) {
 	type key struct{}
-	val := "val"
+	val := "foobar"
 	root := &Command{
 		Use: "root",
 		Run: func(cmd *Command, args []string) {
@@ -2076,7 +2076,7 @@ func TestSetContext(t *testing.T) {
 		},
 	}
 
-	ctx := context.WithValue(context.Background(), key{},  val)
+	ctx := context.WithValue(context.Background(), key{}, val)
 	root.SetContext(ctx)
 	err := root.Execute()
 	if err != nil {
@@ -2086,7 +2086,7 @@ func TestSetContext(t *testing.T) {
 
 func TestSetContextPreRun(t *testing.T) {
 	type key struct{}
-	val := "bar"
+	val := "barr"
 	root := &Command{
 		Use: "root",
 		PreRun: func(cmd *Command, args []string) {
@@ -2112,7 +2112,7 @@ func TestSetContextPreRun(t *testing.T) {
 
 func TestSetContextPreRunOverwrite(t *testing.T) {
 	type key struct{}
-	val := "bar"
+	val := "blah"
 	root := &Command{
 		Use: "root",
 		Run: func(cmd *Command, args []string) {
@@ -2133,7 +2133,7 @@ func TestSetContextPreRunOverwrite(t *testing.T) {
 
 func TestSetContextPersistentPreRun(t *testing.T) {
 	type key struct{}
-	val := "bar"
+	val := "barbar"
 	root := &Command{
 		Use: "root",
 		PersistentPreRun: func(cmd *Command, args []string) {

--- a/command_test.go
+++ b/command_test.go
@@ -2060,11 +2060,12 @@ func TestFParseErrWhitelistSiblingCommand(t *testing.T) {
 }
 
 func TestSetContext(t *testing.T) {
-	key, val := "foo", "bar"
+	type key struct{}
+	val := "val"
 	root := &Command{
 		Use: "root",
 		Run: func(cmd *Command, args []string) {
-			key := cmd.Context().Value(key)
+			key := cmd.Context().Value(key{})
 			got, ok := key.(string)
 			if !ok {
 				t.Error("key not found in context")
@@ -2074,7 +2075,8 @@ func TestSetContext(t *testing.T) {
 			}
 		},
 	}
-	ctx := context.WithValue(context.Background(), key, val)
+
+	ctx := context.WithValue(context.Background(), key{},  val)
 	root.SetContext(ctx)
 	err := root.Execute()
 	if err != nil {
@@ -2083,16 +2085,17 @@ func TestSetContext(t *testing.T) {
 }
 
 func TestSetContextPreRun(t *testing.T) {
-	key, val := "foo", "bar"
+	type key struct{}
+	val := "bar"
 	root := &Command{
 		Use: "root",
 		PreRun: func(cmd *Command, args []string) {
-			ctx := context.WithValue(cmd.Context(), key, val)
+			ctx := context.WithValue(cmd.Context(), key{}, val)
 			cmd.SetContext(ctx)
 		},
 		Run: func(cmd *Command, args []string) {
-			key := cmd.Context().Value(key)
-			got, ok := key.(string)
+			val := cmd.Context().Value(key{})
+			got, ok := val.(string)
 			if !ok {
 				t.Error("key not found in context")
 			}
@@ -2108,18 +2111,19 @@ func TestSetContextPreRun(t *testing.T) {
 }
 
 func TestSetContextPreRunOverwrite(t *testing.T) {
-	key, val := "foo", "bar"
+	type key struct{}
+	val := "bar"
 	root := &Command{
 		Use: "root",
 		Run: func(cmd *Command, args []string) {
-			key := cmd.Context().Value(key)
+			key := cmd.Context().Value(key{})
 			_, ok := key.(string)
 			if ok {
 				t.Error("key found in context when not expected")
 			}
 		},
 	}
-	ctx := context.WithValue(context.Background(), key, val)
+	ctx := context.WithValue(context.Background(), key{}, val)
 	root.SetContext(ctx)
 	err := root.ExecuteContext(context.Background())
 	if err != nil {
@@ -2128,18 +2132,19 @@ func TestSetContextPreRunOverwrite(t *testing.T) {
 }
 
 func TestSetContextPersistentPreRun(t *testing.T) {
-	key, val := "foo", "bar"
+	type key struct{}
+	val := "bar"
 	root := &Command{
 		Use: "root",
 		PersistentPreRun: func(cmd *Command, args []string) {
-			ctx := context.WithValue(cmd.Context(), key, val)
+			ctx := context.WithValue(cmd.Context(), key{}, val)
 			cmd.SetContext(ctx)
 		},
 	}
 	child := &Command{
 		Use: "child",
 		Run: func(cmd *Command, args []string) {
-			key := cmd.Context().Value(key)
+			key := cmd.Context().Value(key{})
 			got, ok := key.(string)
 			if !ok {
 				t.Error("key not found in context")


### PR DESCRIPTION
Basically the same as https://github.com/spf13/cobra/pull/1517 but uses the `Set<field>` naming convention instead of `WithContext` 

Context setting without execution is important because it means that more design patterns can be achieved.

Currently I am using functional options in a project and I can add behaviour through functional options as such:
```go
type GrptlOption func(*cobra.Command) error

func WithFileDescriptors(descriptors ...protoreflect.FileDescriptor) GrptlOption {
	return func(cmd *cobra.Command) error {
		err := CommandFromFileDescriptors(cmd, descriptors...)
		if err != nil {
			return err
		}
		return nil
	}
}
```

I've got a lot more options and this pattern allows me to have nice abstracted pieces of logic that interact with the cobra command. 

This Pattern also allows for adding extra information to a call through `PreRun` functions:

```go

cmd := &cobra.Command{
		Use: "Foobar",
		PersistentPreRun: func(cmd *cobra.Command, args []string) {
			err :=cmd.SetContext(metadata.AppendToOutgoingContext(context.Background(), "pre", "run"))
		},
	}
```

This is a veer nice abstraction and allows for these functions to be very modular

The issue I'm facing at the moment is that I can't write a nifty option (something like `WithAuthentication`) because that needs access to reading and setting the context. Currently I can only read the context.

Needing to use `ExecuteContext` breaks this abstraction because I need to run it right at the end.


