### PR TITLE
Bug fix: includes `os` package import in root command generation

### DIFF
--- a/cobra/tpl/main.go
+++ b/cobra/tpl/main.go
@@ -37,9 +37,9 @@ package cmd
 
 import (
 {{- if .Viper }}
-	"fmt"
+	"fmt"{{ end }}
 	"os"
-{{ end }}
+
 	"github.com/spf13/cobra"
 {{- if .Viper }}
 	"github.com/spf13/viper"{{ end }}


### PR DESCRIPTION
There was a missing `os` import in the root command generation after https://github.com/spf13/cobra/commit/1beb476da9b46aef65cc176d683f4278cb944085 was merged. This prevented the default boilerplate from being buildable

Closes: https://github.com/spf13/cobra/issues/1556