### PR TITLE
Remove __complete cmd for programs without subcmds

### DIFF
--- a/completions_test.go
+++ b/completions_test.go
@@ -2619,3 +2619,48 @@ func TestCompleteWithDisableFlagParsing(t *testing.T) {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
 }
+
+func TestCompleteWithRootAndLegacyArgs(t *testing.T) {
+	// Test a lonely root command which uses legacyArgs().  In such a case, the root
+	// command should accept any number of arguments and completion should behave accordingly.
+	rootCmd := &Command{
+		Use:  "root",
+		Args: nil, // Args must be nil to trigger the legacyArgs() function
+		Run:  emptyRun,
+		ValidArgsFunction: func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+			return []string{"arg1", "arg2"}, ShellCompDirectiveNoFileComp
+		},
+	}
+
+	// Make sure the first arg is completed
+	output, err := executeCommand(rootCmd, ShellCompNoDescRequestCmd, "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"arg1",
+		"arg2",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+
+	// Make sure the completion of arguments continues
+	output, err = executeCommand(rootCmd, ShellCompNoDescRequestCmd, "arg1", "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected = strings.Join([]string{
+		"arg1",
+		"arg2",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+}


### PR DESCRIPTION
Fixes #1562

Programs that don't have sub-commands can accept any number of args.
However, when doing shell completion for such programs, within the `__complete` command code this very `__complete` command makes it that the program suddenly has a sub-command, and the call to `Find() -> legacyArgs()` will then return an error if there are more than one argument on the command-line being completed.

To avoid this, we first remove the `__complete` command in such a case so as to get back to having no sub-commands.

A go test has been added.

See #1562 for program to reproduce the issue.
