### PR TITLE
fix: replace viper with useViper in cobra/README.md' example .cobra.yaml

### DIFF
--- a/cobra/README.md
+++ b/cobra/README.md
@@ -135,7 +135,7 @@ An example ~/.cobra.yaml file:
 ```yaml
 author: Steve Francia <spf@spf13.com>
 license: MIT
-viper: true
+useViper: true
 ```
 
 You can also use built-in licenses. For example, **GPLv2**, **GPLv3**, **LGPL**,


### PR DESCRIPTION
I found the example .cobra.yaml's config "viper" is not working; I think it is useViper after I have read the source code.