### PR TITLE
Command.Context() returns nil instead of context.Background()

### DIFF
--- a/command.go
+++ b/command.go
@@ -227,6 +227,9 @@ type Command struct {
 // Context returns underlying command context. If command wasn't
 // executed with ExecuteContext Context returns Background context.
 func (c *Command) Context() context.Context {
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
 	return c.ctx
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -2058,3 +2058,10 @@ func TestFParseErrWhitelistSiblingCommand(t *testing.T) {
 	}
 	checkStringContains(t, output, "unknown flag: --unknown")
 }
+
+func TestContext(t *testing.T) {
+	root := &Command{}
+	if root.Context() == nil {
+		t.Error("expected root.Context() != nil")
+	}
+}


### PR DESCRIPTION
Closes #1578