### PR TITLE
Fix ambiguous tags: use 'viper' and remove 'useViper'

### DIFF
--- a/cobra/cmd/add_test.go
+++ b/cobra/cmd/add_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGoldenAddCmd(t *testing.T) {
-	viper.Set("useViper", true)
+	viper.Set("viper", true)
 	viper.Set("license", "apache")
 	command := &Command{
 		CmdName:   "test",

--- a/cobra/cmd/init.go
+++ b/cobra/cmd/init.go
@@ -41,7 +41,7 @@ Cobra init must be run inside of a go module (please run "go mod init <MODNAME>"
 			projectPath, err := initializeProject(args)
 			cobra.CheckErr(err)
 			cobra.CheckErr(goGet("github.com/spf13/cobra"))
-			if viper.GetBool("useViper") {
+			if viper.GetBool("viper") {
 				cobra.CheckErr(goGet("github.com/spf13/viper"))
 			}
 			fmt.Printf("Your Cobra application is ready at\n%s\n", projectPath)
@@ -68,7 +68,7 @@ func initializeProject(args []string) (string, error) {
 		PkgName:      modName,
 		Legal:        getLicense(),
 		Copyright:    copyrightLine(),
-		Viper:        viper.GetBool("useViper"),
+		Viper:        viper.GetBool("viper"),
 		AppName:      path.Base(modName),
 	}
 

--- a/cobra/cmd/init_test.go
+++ b/cobra/cmd/init_test.go
@@ -47,7 +47,7 @@ func TestGoldenInitCmd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			viper.Set("useViper", true)
+			viper.Set("viper", true)
 			viper.Set("license", "apache")
 			projectPath, err := initializeProject(tt.args)
 			defer func() {

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -48,7 +48,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "name of license for the project")
 	rootCmd.PersistentFlags().Bool("viper", false, "use Viper for configuration")
 	cobra.CheckErr(viper.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author")))
-	cobra.CheckErr(viper.BindPFlag("useViper", rootCmd.PersistentFlags().Lookup("viper")))
+	cobra.CheckErr(viper.BindPFlag("viper", rootCmd.PersistentFlags().Lookup("viper")))
 	viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
 	viper.SetDefault("license", "none")
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -107,7 +107,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "name of license for the project")
 	rootCmd.PersistentFlags().Bool("viper", true, "use Viper for configuration")
 	viper.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author"))
-	viper.BindPFlag("useViper", rootCmd.PersistentFlags().Lookup("viper"))
+	viper.BindPFlag("viper", rootCmd.PersistentFlags().Lookup("viper"))
 	viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
 	viper.SetDefault("license", "apache")
 


### PR DESCRIPTION
This approach is more appropriate than just modifying the README. Contrast: #1571