### PR TITLE
Update stale-bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,38 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is being marked as stale due to a long period of inactivity'
-        stale-pr-message: 'This PR is being marked as stale due to a long period of inactivity'
-        stale-issue-label: 'kind/stale'
-        stale-pr-label: 'kind/stale'
-        exempt-issue-label: 'kind/stale'
-        exempt-pr-label: 'kind/stale'
+        stale-issue-message: "The Cobra project currently lacks enough contributors to adequately respond to all issues.
+          This bot triages issues and PRs according to the following rules:
+
+          - After 60d of inactivity, lifecycle/stale is applied.
+          - After 30d of inactivity since lifecycle/stale was applied, lifecycle/rotten is applied and the issue is closed.
+
+          You can:
+
+          - Make a comment to remove the stale label and show your support. The 60 days reset.
+          - If an issue has lifecycle/rotten and is closed, comment and ask maintainers if they'd be interseted in reopening"
+
+        stale-pr-message: "The Cobra project currently lacks enough contributors to adequately respond to all PRs.
+          This bot triages issues and PRs according to the following rules:
+
+          - After 60d of inactivity, lifecycle/stale is applied.
+          - After 30d of inactivity since lifecycle/stale was applied, lifecycle/rotten is applied and the PR is closed.
+
+          You can:
+
+          - Make a comment to remove the stale label and show your support. The 60 days reset.
+          - If a PR has lifecycle/rotten and is closed, comment and ask maintainers if they'd be interseted in reopening."
+
+        days-before-stale: 60
+        days-before-close: 30
+        stale-issue-label: 'lifecycle/stale'
+        stale-pr-label: 'lifecycle/stale'
+        exempt-issue-label: 'lifecycle/frozen'
+        exempt-pr-label: 'lifecycle/frozen'
+        close-issue-label: 'lifecycle/rotten'
+        close-pr-label: 'lifecycle/rotten'
+
+        # Since cobra has so many legacy issues and PRs that need to be triaged,
+        # only label new PRs and issues.
+        start-date: '2022-02-01T00:00:00Z'
+


### PR DESCRIPTION
- Update to `v4` of stale-bot
- Only label issues after feb 01, 2022
- Apply `lifecycle/stale` after 60 days
- Close issue and apply `lifecycle/rotten` after another 30 days

Since cobra has so many legacy issues and PRs that need to be triaged by maintainers, we are only going to apply this new stalebot configuration to _new_ issues and PRs.

Closes https://github.com/spf13/cobra/pull/1560
Closes https://github.com/spf13/cobra/issues/1598

Inspiration for the issue / pr messages from the Kubernetes org