### PR TITLE
Allow user to add completion for powershell alias

### DIFF
--- a/powershell_completions.go
+++ b/powershell_completions.go
@@ -22,9 +22,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 func genPowerShellComp(buf io.StringWriter, name string, includeDesc bool) {
+	// Variables should not contain a '-' or ':' character
+	nameForVar := name
+	nameForVar = strings.Replace(nameForVar, "-", "_", -1)
+	nameForVar = strings.Replace(nameForVar, ":", "_", -1)
+
 	compCmd := ShellCompRequestCmd
 	if !includeDesc {
 		compCmd = ShellCompNoDescRequestCmd
@@ -41,7 +47,7 @@ filter __%[1]s_escapeStringWithSpecialChars {
 `+"    $_ -replace '\\s|#|@|\\$|;|,|''|\\{|\\}|\\(|\\)|\"|`|\\||<|>|&','`$&'"+`
 }
 
-Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock {
+[scriptblock]$__%[2]sCompleterBlock = {
     param(
             $WordToComplete,
             $CommandAst,
@@ -66,17 +72,17 @@ Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock {
     }
     __%[1]s_debug "Truncated command: $Command"
 
-    $ShellCompDirectiveError=%[3]d
-    $ShellCompDirectiveNoSpace=%[4]d
-    $ShellCompDirectiveNoFileComp=%[5]d
-    $ShellCompDirectiveFilterFileExt=%[6]d
-    $ShellCompDirectiveFilterDirs=%[7]d
+    $ShellCompDirectiveError=%[4]d
+    $ShellCompDirectiveNoSpace=%[5]d
+    $ShellCompDirectiveNoFileComp=%[6]d
+    $ShellCompDirectiveFilterFileExt=%[7]d
+    $ShellCompDirectiveFilterDirs=%[8]d
 
     # Prepare the command to request completions for the program.
     # Split the command at the first space to separate the program and arguments.
     $Program,$Arguments = $Command.Split(" ",2)
 
-    $RequestComp="$Program %[2]s $Arguments"
+    $RequestComp="$Program %[3]s $Arguments"
     __%[1]s_debug "RequestComp: $RequestComp"
 
     # we cannot use $WordToComplete because it
@@ -106,7 +112,7 @@ Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock {
 
     __%[1]s_debug "Calling $RequestComp"
     # First disable ActiveHelp which is not supported for Powershell
-    $env:%[8]s=0
+    $env:%[9]s=0
 
     #call the command store the output in $out and redirect stderr and stdout to null
     # $Out is an array contains each line per element
@@ -257,7 +263,9 @@ Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock {
 
     }
 }
-`, name, compCmd,
+
+Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock $__%[2]sCompleterBlock
+`, name, nameForVar, compCmd,
 		ShellCompDirectiveError, ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp,
 		ShellCompDirectiveFilterFileExt, ShellCompDirectiveFilterDirs, activeHelpEnvVar(name)))
 }

--- a/shell_completions.md
+++ b/shell_completions.md
@@ -535,6 +535,21 @@ search for a keyword in charts
 $ helm s[tab]
 search  show  status
 ```
+### Aliases
+
+You can also configure `powershell` aliases for your program and they will also support completions.
+
+```
+$ sal aliasname origcommand
+$ Register-ArgumentCompleter -CommandName 'aliasname' -ScriptBlock $__origcommandCompleterBlock
+
+# and now when you run `aliasname` completion will make
+# suggestions as it did for `origcommand`.
+
+$ aliasname <tab>
+completion     firstcommand   secondcommand
+```
+The name of the completer block variable is of the form `$__<programName>CompleterBlock` where every `-` and `:` in the program name have been replaced with `_`, to respect powershell naming syntax.
 
 ### Limitations
 


### PR DESCRIPTION
I ran across a possible problem with using powershell completion with aliases.  I can't recall where it was though, but the situation is pretty simple.

IIUC, when a user has an alias in powershell, she needs to register that alias for completion using:
```
PS> Register-ArgumentCompleter -CommandName 'aliasname' -ScriptBlock <completionBlock>
```
The problem is that the `<completionBlock>` is currently not accessible in our powershell script.

To address this, this commit stores the completion logic into a scriptblock variable which can easily be accessed by the
user to register aliases.

For example, if the user defines an alias for `helm` she will be able to register an alias like this:
```
PS> sal h helm
PS> Register-ArgumentCompleter -CommandName 'h' -ScriptBlock $__helmCompleterBlock
```

@Luap99 does this make sense to you?  I may be misunderstanding something fundamental about aliases and powershell...