### PR TITLE
Fix hidden commands changing padding in usage template

### DIFF
--- a/command.go
+++ b/command.go
@@ -1158,18 +1158,20 @@ func (c *Command) AddCommand(cmds ...*Command) {
 			panic("Command can't be a child of itself")
 		}
 		cmds[i].parent = c
-		// update max lengths
-		usageLen := len(x.Use)
-		if usageLen > c.commandsMaxUseLen {
-			c.commandsMaxUseLen = usageLen
-		}
-		commandPathLen := len(x.CommandPath())
-		if commandPathLen > c.commandsMaxCommandPathLen {
-			c.commandsMaxCommandPathLen = commandPathLen
-		}
-		nameLen := len(x.Name())
-		if nameLen > c.commandsMaxNameLen {
-			c.commandsMaxNameLen = nameLen
+		if len(x.Deprecated) == 0 && !x.Hidden {
+			// update max lengths
+			usageLen := len(x.Use)
+			if usageLen > c.commandsMaxUseLen {
+				c.commandsMaxUseLen = usageLen
+			}
+			commandPathLen := len(x.CommandPath())
+			if commandPathLen > c.commandsMaxCommandPathLen {
+				c.commandsMaxCommandPathLen = commandPathLen
+			}
+			nameLen := len(x.Name())
+			if nameLen > c.commandsMaxNameLen {
+				c.commandsMaxNameLen = nameLen
+			}
 		}
 		// If global normalization function exists, update all children
 		if c.globNormFunc != nil {
@@ -1199,6 +1201,9 @@ main:
 	c.commandsMaxCommandPathLen = 0
 	c.commandsMaxNameLen = 0
 	for _, command := range c.commands {
+		if len(command.Deprecated) != 0 || command.Hidden {
+			continue
+		}
 		usageLen := len(command.Use)
 		if usageLen > c.commandsMaxUseLen {
 			c.commandsMaxUseLen = usageLen

--- a/command_test.go
+++ b/command_test.go
@@ -2161,3 +2161,42 @@ func TestSetContextPersistentPreRun(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestPadding(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	childCmd := &Command{Use: "child", Run: emptyRun}
+	longChildCmd := &Command{Use: "long-name-child-abcdefghijklmnopqrstuvwxyz", Run: emptyRun}
+	// For this test to be useful the hiddenChildCmd and deprecatedChildCmd commands need to have a longer `Use` field than the other commands.
+	hiddenChildCmd := &Command{Use: longChildCmd.Use + "-hidden", Hidden: true, Run: emptyRun}
+	deprecatedChildCmd := &Command{Use: longChildCmd.Use + "-deprecated", Deprecated: "deprecated", Run: emptyRun}
+
+	rootCmd.AddCommand(childCmd)
+	rootCmd.AddCommand(longChildCmd)
+	rootCmd.AddCommand(hiddenChildCmd)
+	rootCmd.AddCommand(deprecatedChildCmd)
+
+	expectedUsePad := len(longChildCmd.Use)
+	expectedPathPad := len(longChildCmd.CommandPath())
+	expectedNamePad := len(longChildCmd.Name())
+
+	if childCmd.UsagePadding() != expectedUsePad {
+		t.Errorf("Expected usage padding '%d', got '%d'", expectedUsePad, childCmd.UsagePadding())
+	}
+	if longChildCmd.UsagePadding() != expectedUsePad {
+		t.Errorf("Expected usage padding '%d', got '%d'", expectedUsePad, longChildCmd.UsagePadding())
+	}
+
+	if childCmd.CommandPathPadding() != expectedPathPad {
+		t.Errorf("Expected command path padding '%d', got '%d'", expectedPathPad, childCmd.CommandPathPadding())
+	}
+	if longChildCmd.CommandPathPadding() != expectedPathPad {
+		t.Errorf("Expected command path padding '%d', got '%d'", expectedPathPad, longChildCmd.CommandPathPadding())
+	}
+
+	if childCmd.NamePadding() != expectedNamePad {
+		t.Errorf("Expected name padding '%d', got '%d'", expectedNamePad, childCmd.NamePadding())
+	}
+	if longChildCmd.NamePadding() != expectedNamePad {
+		t.Errorf("Expected name padding '%d', got '%d'", expectedNamePad, longChildCmd.NamePadding())
+	}
+}


### PR DESCRIPTION
We added a `fig-autocomplete` hidden subcommand to Infracost and it increased the padding in the usage text (https://github.com/infracost/infracost/pull/1457#discussion_r827182625), which was unexpected. This fixes any hidden commands affecting the padding:

Fixes #1272

Example before:

```
AVAILABLE COMMANDS
  breakdown        Show full breakdown of costs
  comment          Post an Infracost comment to GitHub, GitLab, Azure Repos or Bitbucket
  completion       Generate shell completion script
```

Example with fix:

```
AVAILABLE COMMANDS
  breakdown   Show full breakdown of costs
  comment     Post an Infracost comment to GitHub, GitLab, Azure Repos or Bitbucket
  completion  Generate shell completion script
```

I wasn't sure where to add tests for this since I couldn't find any existing ones for this functionality, but if you point me in the right direction I can do.