### PR TITLE
Add Kubescape to projects

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -22,6 +22,7 @@
 - [Istio](https://istio.io)
 - [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](http://kubernetes.io/)
+- [Kubescape](https://github.com/armosec/kubescape)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)
 - [Mercure](https://mercure.rocks/)


### PR DESCRIPTION
[Kubescape](https://github.com/armosec/kubescape) is a Kubernetes security tool with over 5.4k stars on GitHub. Adding it to the list of projects using cobra