### PR TITLE
Changed branch name in the cobra generator link to 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ It can be installed by running:
 go install github.com/spf13/cobra-cli@latest
 ```
 
-For complete details on using the Cobra-CLI generator, please read [The Cobra Generator README](https://github.com/spf13/cobra-cli/blob/master/README.md)
+For complete details on using the Cobra-CLI generator, please read [The Cobra Generator README](https://github.com/spf13/cobra-cli/blob/main/README.md)
 
 For complete details on using the Cobra library, please read the [The Cobra User Guide](user_guide.md).
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -32,7 +32,7 @@ func main() {
 Cobra-CLI is its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
-For complete details on using the Cobra generator, please refer to [The Cobra-CLI Generator README](https://github.com/spf13/cobra-cli/blob/master/README.md)
+For complete details on using the Cobra generator, please refer to [The Cobra-CLI Generator README](https://github.com/spf13/cobra-cli/blob/main/README.md)
 
 ## Using the Cobra Library
 


### PR DESCRIPTION
I was going through the ```README.md``` file and noticed at the very end when I clicked on ```The COBRA Generator README``` link, it opened the webpage properly but shows a ```Branch not found, redirected to default branch.``` message every time that kind of feels annoying 🙂 

<img width="772" alt="image" src="https://user-images.githubusercontent.com/5323192/159793082-56db86d5-9c99-4c87-b01a-6c35850c8308.png">

Have updated the link in the ```README.md``` with the correct branch name as a ```good first issue``` contribution to this repo 🙂  