### PR TITLE
Wrap printf tab with quotes

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -171,7 +171,7 @@ _%[1]s()
             # We first need to escape any : as part of the completion itself.
             comp=${comp//:/\\:}
 
-            local tab=$(printf '\t')
+            local tab="$(printf '\t')"
             comp=${comp//$tab/:}
 
             __%[1]s_debug "Adding completion: ${comp}"


### PR DESCRIPTION
Without this, slightly older versions of zsh fail to correctly parse the output of the __complete
command. Tested that with zsh 5.0.2 and zsh 5.8. Since this is just correctly quoting the output of
a command, it shouldn't cause any compatibility issues.