### PR TITLE
Add Polygon Edge as a project using Cobra

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -37,6 +37,7 @@
 - [Ory Hydra](https://github.com/ory/hydra)
 - [Ory Kratos](https://github.com/ory/kratos)
 - [Pixie](https://github.com/pixie-io/pixie)
+- [Polygon Edge](https://github.com/0xPolygon/polygon-edge)
 - [Pouch](https://github.com/alibaba/pouch)
 - [ProjectAtomic (enterprise)](http://www.projectatomic.io/)
 - [Prototool](https://github.com/uber/prototool)


### PR DESCRIPTION
# Description

This PR adds Polygon Edge to the list of projects using Cobra CLI.

We've added support for Cobra a while back:
https://github.com/0xPolygon/polygon-edge/pull/410