### PR TITLE
Check if a command is 'hidden' before adding length to usage

### DIFF
--- a/command.go
+++ b/command.go
@@ -1162,18 +1162,20 @@ func (c *Command) AddCommand(cmds ...*Command) {
 			panic("Command can't be a child of itself")
 		}
 		cmds[i].parent = c
-		// update max lengths
-		usageLen := len(x.Use)
-		if usageLen > c.commandsMaxUseLen {
-			c.commandsMaxUseLen = usageLen
-		}
-		commandPathLen := len(x.CommandPath())
-		if commandPathLen > c.commandsMaxCommandPathLen {
-			c.commandsMaxCommandPathLen = commandPathLen
-		}
-		nameLen := len(x.Name())
-		if nameLen > c.commandsMaxNameLen {
-			c.commandsMaxNameLen = nameLen
+		if !cmds[i].Hidden {
+			// update max lengths
+			usageLen := len(x.Use)
+			if usageLen > c.commandsMaxUseLen {
+				c.commandsMaxUseLen = usageLen
+			}
+			commandPathLen := len(x.CommandPath())
+			if commandPathLen > c.commandsMaxCommandPathLen {
+				c.commandsMaxCommandPathLen = commandPathLen
+			}
+			nameLen := len(x.Name())
+			if nameLen > c.commandsMaxNameLen {
+				c.commandsMaxNameLen = nameLen
+			}
 		}
 		// If global normalization function exists, update all children
 		if c.globNormFunc != nil {
@@ -1203,17 +1205,19 @@ main:
 	c.commandsMaxCommandPathLen = 0
 	c.commandsMaxNameLen = 0
 	for _, command := range c.commands {
-		usageLen := len(command.Use)
-		if usageLen > c.commandsMaxUseLen {
-			c.commandsMaxUseLen = usageLen
-		}
-		commandPathLen := len(command.CommandPath())
-		if commandPathLen > c.commandsMaxCommandPathLen {
-			c.commandsMaxCommandPathLen = commandPathLen
-		}
-		nameLen := len(command.Name())
-		if nameLen > c.commandsMaxNameLen {
-			c.commandsMaxNameLen = nameLen
+		if !command.Hidden {
+			usageLen := len(command.Use)
+			if usageLen > c.commandsMaxUseLen {
+				c.commandsMaxUseLen = usageLen
+			}
+			commandPathLen := len(command.CommandPath())
+			if commandPathLen > c.commandsMaxCommandPathLen {
+				c.commandsMaxCommandPathLen = commandPathLen
+			}
+			nameLen := len(command.Name())
+			if nameLen > c.commandsMaxNameLen {
+				c.commandsMaxNameLen = nameLen
+			}
 		}
 	}
 }

--- a/command_test.go
+++ b/command_test.go
@@ -2161,3 +2161,23 @@ func TestSetContextPersistentPreRun(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestCommandsLengthWithoutHiddenCommands(t *testing.T) {
+	rootCmd := &Command{Use: "root", TraverseChildren: true}
+	rootCmd.Flags().String("foo", "", "foo things")
+	// add a normal command
+	childCmd := &Command{Use: "child"}
+	childCmd.Flags().String("str", "", "")
+	rootCmd.AddCommand(childCmd)
+	//add a hidden command
+	child2Cmd := &Command{Use: "reallyLongCommand"}
+	child2Cmd.Flags().String("str", "", "")
+	child2Cmd.Hidden = true
+	rootCmd.AddCommand(child2Cmd)
+	//hidden commands should not be taken into account for usage length
+	expectedmaxLen := 5
+	fmt.Println(rootCmd.commandsMaxUseLen)
+	if rootCmd.commandsMaxUseLen != expectedmaxLen {
+		t.Errorf("Expected value: \n %v\nGot:\n %v\n", expectedmaxLen, rootCmd.commandsMaxUseLen)
+	}
+}


### PR DESCRIPTION
This PR is related to issue #1272. When adding or removing a command, only take into account commands that are not hidden when calculating length for the usage.