### PR TITLE
perf(bash-v2): short-circuit descriptionless candidate lists

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -176,6 +176,14 @@ __%[1]s_handle_completion_types() {
 __%[1]s_handle_standard_completion_case() {
     local tab=$'\t' comp
 
+    # Short circuit to optimize if we don't have descriptions
+    if [[ $out != *$tab* ]]; then
+        while IFS='' read -r comp; do
+            COMPREPLY+=("$comp")
+        done < <(IFS=$'\n' compgen -W "$out" -- "$cur")
+        return 0
+    fi
+
     local longest=0
     # Look for the longest completion so that we can format things nicely
     while IFS='' read -r comp; do


### PR DESCRIPTION
If the list of candidates has no descriptions, short circuit all the description processing logic, basically just do a `compgen -W` for the whole list and be done with it.

We could conceivably do some optimizations like this and more when generating the completions with `--no-descriptions` in Go code, by omitting some parts we know won't be needed, or doing some things differently. But doing it this way in bash, the improvements are available also to completions generated with descriptions enabled when they are invoked for completion cases that produce no descriptions. The result after this for descriptionless entries seems fast enough so it seems there's no immediate need to look into doing that.

This alone pretty much eliminates all the slowness related to my specific use case in #1680, bringing it down to ~0.07s (yes, there _is_ a zero on the right of the period), so for the time being I'm not inclined to look into further optimizations at least for the code path where there are no descriptions. Related to #1683, but I suggest merging both as they affect different scenarios.

Same caveat as in #1683 about testing and the way the change was made applies here.