### PR TITLE
perf(bash-v2): speed up filtering entries with descriptions

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -183,8 +183,7 @@ __%[1]s_handle_standard_completion_case() {
         # Strip any description before checking the length
         comp=${compline%%%%$tab*}
         # Only consider the completions that match
-        comp=$(compgen -W "$comp" -- "$cur")
-        [[ -z $comp ]] && continue
+        [[ $comp == "$cur"* ]] || continue
         COMPREPLY+=("$compline")
         if ((${#comp}>longest)); then
             longest=${#comp}


### PR DESCRIPTION
Use simple prefix match instead of single word `compgen -W` command substitution for each candidate match.

It's a bit late, but I can't think of a case where this replacement wouldn't be ok this late at night. Performancewise this improves the cases with descriptions quite a bit, with current https://github.com/marckhouzam/cobra-completion-testing/pull/15 on my box, the v2 numbers look like the following (I've stripped the v1 numbers from each list below).

Before (current master, #1686 not merged yet):
```
Processing 1000 completions took 0.492 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.600 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.455 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.578 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.424 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.570 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.502 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.585 seconds which is less than the 2.0 seconds limit
```
After (also without #1686):
```
Processing 1000 completions took 0.070 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.165 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.072 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.181 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.089 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.254 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.058 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.122 seconds which is less than the 2.0 seconds limit
```

For curiosity, even though this improves the descriptionless case quite a bit too, #1686 is still relevant, with it applied on top of this one: 
```
Processing 1000 completions took 0.036 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.165 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.047 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.183 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.051 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.264 seconds which is less than the 2.0 seconds limit
Processing 1000 completions took 0.036 seconds which is less than the 1.0 seconds limit
Processing 1000 completions took 0.122 seconds which is less than the 2.0 seconds limit
```