### PR TITLE
fix: Don't complete _command on zsh

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -75,7 +75,7 @@ func genZshComp(buf io.StringWriter, name string, includeDesc bool) {
 	if !includeDesc {
 		compCmd = ShellCompNoDescRequestCmd
 	}
-	WriteStringAndCheck(buf, fmt.Sprintf(`#compdef _%[1]s %[1]s
+	WriteStringAndCheck(buf, fmt.Sprintf(`#compdef %[1]s
 
 # zsh completion for %-36[1]s -*- shell-script -*-
 


### PR DESCRIPTION
As reported by @VorpalBlade in https://github.com/twpayne/chezmoi/issues/2047:

Previously the generated zsh completion script started with the line

    #compdef _<command> <command>

where \<command\> is the command that the zsh completion script is generated for.

This enabled completions for both \<command> and _\<command>, but _\<command> is the completion function itself and should not be completed. Furthermore, attempting to autocomplete _<command> (e.g. typing "_\<command>\<Space>\<Tab>" in a zsh shell) causes zsh to hang.

This commit fixes the #compdef line to only complete \<command>, not _\<command>.

Co-authored-by: Arvid Norlander <VorpalBlade@users.noreply.github.com>