### PR TITLE
fix(bash-v2): skip empty completions when filtering descriptions

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -188,6 +188,7 @@ __%[1]s_handle_standard_completion_case() {
     local compline
     # Look for the longest completion so that we can format things nicely
     while IFS='' read -r compline; do
+        [[ -z $compline ]] && continue
         # Strip any description before checking the length
         comp=${compline%%%%$tab*}
         # Only consider the completions that match


### PR DESCRIPTION
`read` gives a last null value following a trailing newline.

Regression from fb8031162c2ffab270774f13c6904bb04cbba5a7.

We could drop the `\n` from the feeding `printf` to accomplish the same end result, but I'm planning to submit some related cleanups a bit later that wouldn't play well with that approach, so I went with explicit filtering here.