### PR TITLE
perf(bash-v2): speed up filtering menu-complete descriptions

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -156,11 +156,11 @@ __%[1]s_handle_completion_types() {
         # https://github.com/spf13/cobra/issues/1508
         local tab=$'\t' comp
         while IFS='' read -r comp; do
+            [[ -z $comp ]] && continue
             # Strip any description
             comp=${comp%%%%$tab*}
             # Only consider the completions that match
-            comp=$(compgen -W "$comp" -- "$cur")
-            if [ -n "$comp" ]; then
+            if [[ $comp == "$cur"* ]]; then
                 COMPREPLY+=("$comp")
             fi
         done < <(printf "%%s\n" "${out}")


### PR DESCRIPTION
Similarly as fb8031162c2ffab270774f13c6904bb04cbba5a7 (+ the empty entry fix in https://github.com/spf13/cobra/pull/1691) did for the "regular", non-menu completion cases.

I have no numbers on this, but I'm assuming the speedups seen elsewhere are here too, and didn't notice anything breaking in casual manual tests.

Could be useful to add some perf numbers for the menu-complete code path too to [marckhouzam/cobra-completion-testing](https://github.com/marckhouzam/cobra-completion-testing/) (maybe as well as other tests, haven't checked if there are any).