### PR TITLE
perf(bash-v2): read directly to COMPREPLY on descriptionless short circuit

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -178,9 +178,7 @@ __%[1]s_handle_standard_completion_case() {
 
     # Short circuit to optimize if we don't have descriptions
     if [[ $out != *$tab* ]]; then
-        while IFS='' read -r comp; do
-            COMPREPLY+=("$comp")
-        done < <(IFS=$'\n' compgen -W "$out" -- "$cur")
+        IFS=$'\n' read -ra COMPREPLY -d '' < <(IFS=$'\n' compgen -W "$out" -- "$cur")
         return 0
     fi
 


### PR DESCRIPTION
Not that it'd really matter that much performancewise given the level we are at for this case, but this change makes the short circuit roughly twice as fast on my box as it was for the 1000 rounds done in marckhouzam/cobra-completion-testing.

Perhaps more importantly, this makes the code arguably slightly cleaner.

Before:
```
...
<= TIMING => no descriptions: 1000 completions took 0.039 seconds < 0.2 seconds limit
...
<= TIMING => no descriptions: 1000 completions took 0.046 seconds < 0.2 seconds limit
...
```

After:
```
...
<= TIMING => no descriptions: 1000 completions took 0.022 seconds < 0.2 seconds limit
...
<= TIMING => no descriptions: 1000 completions took 0.024 seconds < 0.2 seconds limit
...
```
