### PR TITLE
Provide usefull errors when using invalid sub command

### DIFF
--- a/args.go
+++ b/args.go
@@ -38,6 +38,23 @@ func legacyArgs(cmd *Command, args []string) error {
 	return nil
 }
 
+// Legacy sub command arg validation has the following behaviour:
+// - commands with no subcommands can take arbitrary arguments
+// - commands with subcommands will do subcommand validity checking
+// - subcommands will always accept arbitrary arguments
+func legacySubCommandArgs(cmd *Command, args []string) error {
+	// no subcommand, always take args
+	if !cmd.HasSubCommands() {
+		return nil
+	}
+
+	// command with subcommands, do subcommand checking.
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
+	}
+	return nil
+}
+
 // NoArgs returns an error if any args are included.
 func NoArgs(cmd *Command, args []string) error {
 	if len(args) > 0 {

--- a/command.go
+++ b/command.go
@@ -769,7 +769,7 @@ func (c *Command) Traverse(args []string) (*Command, []string, error) {
 			if c.Runnable() {
 				return c, args, nil
 			}
-			return c, args, legacyArgs(c, args)
+			return c, args, legacySubCommandArgs(c, args)
 		}
 
 		if err := c.ParseFlags(flags); err != nil {


### PR DESCRIPTION
If the *TraverseChildren* mode is active, the *Traverse* function returns the last accepted command along the requested sub command chain. This command is then used to parse the arguments. This will for sure fail, if the traversing was aborted because an invalid sub command was given. As a result, cobra complains about invalid flags instead of an invalid sub command.

This behaviour might be useful, if the intermediate command is *Runnable()*, but it for sure makes no sense, if it isn't.

This PR fixes this by providing a *legacyArgs()* error in case of not runnable intermediate commands.

---
*Remark:* It solves the obvious problematic behaviour, but basically the general scenario is more complex.
If the intermediate command is *Runnable()* in addition to providing additional sub commands, then it should be possible to forward the control about the error message to the command to be a able to distinguish between these two cases according to its needs. This is basically already possible by declaring a *FlagErrorFunc()*. But unfortunately it only gets the command and error as arguments, but not the actual set of arguments. Therefore it has no chance to detect the actual problem and provide appropriate error feedback.

Solving this is more invasive, because it would require, either to change the interface, or add another more general error handler option.

