### PR TITLE
With go 1.18, we must use go install for a binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ $(warning "could not find golangci-lint in $(PATH), run: curl -sfL https://insta
 endif
 
 ifeq (, $(shell which richgo))
-$(warning "could not find richgo in $(PATH), run: go get github.com/kyoh86/richgo")
+$(warning "could not find richgo in $(PATH), run: go install github.com/kyoh86/richgo@latest")
 endif
 
 .PHONY: fmt lint test install_deps clean


### PR DESCRIPTION
When using go 1.18, the format "go install github.com/kyoh86/richgo@latest" is needed (go get no longer works).

This PR simply updates the warning printed by the Makefile to use "go install" instead of "go get".

Note that "go install github.com/kyoh86/richgo@latest" works with go 1.16 and higher but does not work with go 1.15.  However, since installing "richgo" is only required for people who want to run the go tests for the Cobra project itself, I feel it is ok to focus on go 1.16 or higher in this case.

@umarcor you setup richgo, what do you say?
