### PR TITLE
feat(completion): support no space format of short flags

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -480,7 +480,7 @@ func getFlagNameCompletions(flag *pflag.Flag, toComplete string) []string {
 	}
 
 	flagName = "-" + flag.Shorthand
-	if len(flag.Shorthand) > 0 && strings.HasPrefix(flagName, toComplete) {
+	if len(flag.Shorthand) > 0 && (strings.HasPrefix(flagName, toComplete) || strings.HasPrefix(toComplete, flagName)) {
 		completions = append(completions, fmt.Sprintf("%s\t%s", flagName, flag.Usage))
 	}
 

--- a/completions_test.go
+++ b/completions_test.go
@@ -495,19 +495,48 @@ func TestShorthandFlagCompletionInGoWithDesc(t *testing.T) {
 		return completions, ShellCompDirectiveDefault
 	})
 
-	// Test that flag names are completed
+	// Test completion for flag with "no space" value and with defined completion function
 	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "-ftest")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-
 	expected := strings.Join([]string{
 		"test1\tThe first",
 		"test2\tThe second",
 		"test10\tThe tenth",
 		":0",
 		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
 
+	// Test completion for flag without value but with defined completion function
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "-f")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+
+	// Test completion for flag with value and with defined completion function
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "-f", "test")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+
+	// Test completion for flag without completion function
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "-d")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected = strings.Join([]string{
+		"-d\tsecond flag",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
 	}
@@ -2321,7 +2350,7 @@ func removeCompCmd(rootCmd *Command) {
 	}
 }
 
-func xTestDefaultCompletionCmd(t *testing.T) {
+func TestDefaultCompletionCmd(t *testing.T) {
 	rootCmd := &Command{
 		Use:  "root",
 		Args: NoArgs,

--- a/completions_test.go
+++ b/completions_test.go
@@ -473,6 +473,32 @@ func TestValidArgsFuncAndCmdCompletionInGo(t *testing.T) {
 	}
 }
 
+func TestShorthandFlagCompletionInGoWithDesc(t *testing.T) {
+	rootCmd := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+
+	rootCmd.Flags().StringP("first", "f", "", "first flag")
+	rootCmd.Flags().StringP("second", "d", "", "second flag")
+
+	// Test that flag names are completed
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "-ftest")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"-f\tfirst flag",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+
+}
+
 func TestFlagNameCompletionInGo(t *testing.T) {
 	rootCmd := &Command{
 		Use: "root",

--- a/completions_test.go
+++ b/completions_test.go
@@ -481,6 +481,19 @@ func TestShorthandFlagCompletionInGoWithDesc(t *testing.T) {
 
 	rootCmd.Flags().StringP("first", "f", "", "first flag")
 	rootCmd.Flags().StringP("second", "d", "", "second flag")
+	_ = rootCmd.RegisterFlagCompletionFunc("first", func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+		var completions []string
+		for _, comp := range []string{
+			"test1\tThe first",
+			"test2\tThe second",
+			"test10\tThe tenth",
+		} {
+			if strings.HasPrefix(comp, toComplete) {
+				completions = append(completions, comp)
+			}
+		}
+		return completions, ShellCompDirectiveDefault
+	})
 
 	// Test that flag names are completed
 	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "-ftest")
@@ -489,9 +502,11 @@ func TestShorthandFlagCompletionInGoWithDesc(t *testing.T) {
 	}
 
 	expected := strings.Join([]string{
-		"-f\tfirst flag",
-		":4",
-		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+		"test1\tThe first",
+		"test2\tThe second",
+		"test10\tThe tenth",
+		":0",
+		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
 
 	if output != expected {
 		t.Errorf("expected: %q, got: %q", expected, output)
@@ -2306,7 +2321,7 @@ func removeCompCmd(rootCmd *Command) {
 	}
 }
 
-func TestDefaultCompletionCmd(t *testing.T) {
+func xTestDefaultCompletionCmd(t *testing.T) {
 	rootCmd := &Command{
 		Use:  "root",
 		Args: NoArgs,


### PR DESCRIPTION
Cobra supports a "no space" format for short flags but doesn't support auto complete for this case.
 
Related to issue https://github.com/spf13/cobra/issues/1629