### PR TITLE
Rename `SuggestionsMinimumDistance` to `SuggestionsMaximumDistance`

### DIFF
--- a/command.go
+++ b/command.go
@@ -219,9 +219,9 @@ type Command struct {
 	// that go along with 'unknown command' messages.
 	DisableSuggestions bool
 
-	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
+	// SuggestionsMaximumDistance defines maximum levenshtein distance to display suggestions.
 	// Must be > 0.
-	SuggestionsMinimumDistance int
+	SuggestionsMaximumDistance int
 }
 
 // Context returns underlying command context. If command was executed
@@ -659,8 +659,8 @@ func (c *Command) findSuggestions(arg string) string {
 	if c.DisableSuggestions {
 		return ""
 	}
-	if c.SuggestionsMinimumDistance <= 0 {
-		c.SuggestionsMinimumDistance = 2
+	if c.SuggestionsMaximumDistance <= 0 {
+		c.SuggestionsMaximumDistance = 2
 	}
 	suggestionsString := ""
 	if suggestions := c.SuggestionsFor(arg); len(suggestions) > 0 {
@@ -740,7 +740,7 @@ func (c *Command) SuggestionsFor(typedName string) []string {
 	for _, cmd := range c.commands {
 		if cmd.IsAvailableCommand() {
 			levenshteinDistance := ld(typedName, cmd.Name(), true)
-			suggestByLevenshtein := levenshteinDistance <= c.SuggestionsMinimumDistance
+			suggestByLevenshtein := levenshteinDistance <= c.SuggestionsMaximumDistance
 			suggestByPrefix := strings.HasPrefix(strings.ToLower(cmd.Name()), strings.ToLower(typedName))
 			if suggestByLevenshtein || suggestByPrefix {
 				suggestions = append(suggestions, cmd.Name())

--- a/user_guide.md
+++ b/user_guide.md
@@ -627,7 +627,7 @@ Did you mean this?
 Run 'hugo --help' for usage.
 ```
 
-Suggestions are automatic based on every subcommand registered and use an implementation of [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). Every registered command that matches a minimum distance of 2 (ignoring case) will be displayed as a suggestion.
+Suggestions are automatic based on every subcommand registered and use an implementation of [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). Every registered command that matches a maximum distance of 2 (ignoring case) will be displayed as a suggestion.
 
 If you need to disable suggestions or tweak the string distance in your command, use:
 
@@ -638,7 +638,7 @@ command.DisableSuggestions = true
 or
 
 ```go
-command.SuggestionsMinimumDistance = 1
+command.SuggestionsMaximumDistance = 1
 ```
 
 You can also explicitly set names for which a given command will be suggested using the `SuggestFor` attribute. This allows suggestions for strings that are not close in terms of string distance, but makes sense in your set of commands and for some which you don't want aliases. Example:


### PR DESCRIPTION
Since Cobra will provide suggestions that are less than or equal to this value, it is a maximum, not a minimum.

I just noticed this and the cognitive dissonance was bugging me, but I understand if changing the public API without providing a new feature isn't worth it.