### PR TITLE
Adds `check-latest` for setup-go action v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.17'
+          check-latest: true
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This is needed for[ v3 of `setup-go` to check the latest patch version of Go](https://github.com/actions/setup-go#check-latest-version).

Related to https://github.com/spf13/cobra/pull/1660