### PR TITLE
Fix handling of descriptions for bash v3

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -219,7 +219,7 @@ __%[1]s_handle_standard_completion_case() {
     local tab=$'\t' comp
 
     # Short circuit to optimize if we don't have descriptions
-    if [[ ${completions[*]} != *$tab* ]]; then
+    if [[ "${completions[*]}" != *$tab* ]]; then
         IFS=$'\n' read -ra COMPREPLY -d '' < <(compgen -W "${completions[*]}" -- "$cur")
         return 0
     fi


### PR DESCRIPTION
Fixes #1734

Tab characters that introduce completion descriptions weren't properly being handled with bash v3.  This change fixes that.

This PR fixes the detection of tab characters in the list of completion choices when using bash v3.

See #1734 for details.

Test failures could be seen when running the bash completion tests of https://github.com/marckhouzam/cobra-completion-testing