### PR TITLE
Add KubeVirt as a project using cobra

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -23,6 +23,7 @@
 - [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](https://kubernetes.io/)
 - [Kubescape](https://github.com/armosec/kubescape)
+- [KubeVirt](https://github.com/kubevirt/kubevirt)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)
 - [Mercure](https://mercure.rocks/)


### PR DESCRIPTION
Reaching out on behalf of KubeVirt, an add-on for Kubernetes, enabling
users to run Virtual Machines on Kubernetes pods.
