### PR TITLE
Clarify SetContext documentation

### DIFF
--- a/command.go
+++ b/command.go
@@ -236,8 +236,8 @@ func (c *Command) Context() context.Context {
 	return c.ctx
 }
 
-// SetContext sets context for the command. It is set to context.Background by default and will be overwritten by
-// Command.ExecuteContext or Command.ExecuteContextC
+// SetContext sets context for the command. This context will be overwritten by
+// Command.ExecuteContext or Command.ExecuteContextC.
 func (c *Command) SetContext(ctx context.Context) {
 	c.ctx = ctx
 }


### PR DESCRIPTION
Documentation of Context() was fixed in #1639, especially the fact that the underlying ctx is set to context.Background when Execute() is called (otherwise returns nil). 

The documentation of SetContext() states that the ctx is set to context.Background "by default", which is a bit imprecise (and confused some coworker of mine). I think the Context() method provides the needed information when exactly the context is set to Background. I don't see a need to also document this behavior in the comment of SetContext(), as it is only interesting for a caller of Context().

