### PR TITLE
Use consistent layout for Usage template

### DIFF
--- a/command.go
+++ b/command.go
@@ -508,7 +508,7 @@ Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}


### PR DESCRIPTION
Other sections like Usage, Aliases, Available Commands, Flags and
Additional help topics have two spaces indent.