### PR TITLE
Fix error message for NoArgs

### DIFF
--- a/args.go
+++ b/args.go
@@ -27,7 +27,7 @@ func legacyArgs(cmd *Command, args []string) error {
 // NoArgs returns an error if any args are included.
 func NoArgs(cmd *Command, args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+		return fmt.Errorf("unknown argument %q for %q", args[0], cmd.CommandPath())
 	}
 	return nil
 }


### PR DESCRIPTION

If this is about arguments and if this is not a legacy argument validation function, maybe using the word `argument` instead of the word `command` makes more sense, in the error message for `NoArgs` ?