### PR TITLE
expose ValidateRequiredFlags and ValidateFlagGroups

### DIFF
--- a/command.go
+++ b/command.go
@@ -861,10 +861,10 @@ func (c *Command) execute(a []string) (err error) {
 		c.PreRun(c, argWoFlags)
 	}
 
-	if err := c.validateRequiredFlags(); err != nil {
+	if err := c.ValidateRequiredFlags(); err != nil {
 		return err
 	}
-	if err := c.validateFlagGroups(); err != nil {
+	if err := c.ValidateFlagGroups(); err != nil {
 		return err
 	}
 
@@ -1018,7 +1018,8 @@ func (c *Command) ValidateArgs(args []string) error {
 	return c.Args(c, args)
 }
 
-func (c *Command) validateRequiredFlags() error {
+// ValidateRequiredFlags validates all required flags are present and returns an error otherwise
+func (c *Command) ValidateRequiredFlags() error {
 	if c.DisableFlagParsing {
 		return nil
 	}

--- a/flag_groups.go
+++ b/flag_groups.go
@@ -58,9 +58,9 @@ func (c *Command) MarkFlagsMutuallyExclusive(flagNames ...string) {
 	}
 }
 
-// validateFlagGroups validates the mutuallyExclusive/requiredAsGroup logic and returns the
+// ValidateFlagGroups validates the mutuallyExclusive/requiredAsGroup logic and returns the
 // first error encountered.
-func (c *Command) validateFlagGroups() error {
+func (c *Command) ValidateFlagGroups() error {
 	if c.DisableFlagParsing {
 		return nil
 	}


### PR DESCRIPTION
Hi, dear reviewers,

In my project, there is one complex command with a lot of flags, we need to set part of them as required, and other flags are optional, all optional flags were defined from an API server. I have implemented this feature to add dynamic flags in issue #1758.
as talked with @marckhouzam in the last issue, it looks like my method is on the right way.

In the next work, I add some flags in `init()` function and call `MarkFlagRequired` to mark them as required flags. but, because I have set `DisableFlagParsing` as `true`, and need to call `func (c *Command) ParseFlags(args []string) error` to parse all flags manually, the function which validates the required flag will not be called. 

for now, I have to set up a map and store all required flags, then check if exist in arguments one bye one before `ParseFlags()`. It works but looks not graceful.

I went through the source code of Cobra, and it looks like I need to call `validateRequiredFlags()` and `validateFlagGroups()` manually after `ParseFlags(args []string)`,  and function `validateRequiredFlags()` was called by `Execute()`, so I created this PR to expose these two functions.

Thx for reviewing this PR.

B&R,
Skeet



