### PR TITLE
fix: show flags that shadow parent persistent flag in child help

### DIFF
--- a/command.go
+++ b/command.go
@@ -1505,7 +1505,8 @@ func (c *Command) LocalFlags() *flag.FlagSet {
 	}
 
 	addToLocal := func(f *flag.Flag) {
-		if c.lflags.Lookup(f.Name) == nil && c.parentsPflags.Lookup(f.Name) == nil {
+		// Add the flag if it is not a parent PFlag, or it shadows a parent PFlag
+		if c.lflags.Lookup(f.Name) == nil && f != c.parentsPflags.Lookup(f.Name) {
 			c.lflags.AddFlag(f)
 		}
 	}


### PR DESCRIPTION
This fixes a bug where a child flag that shadows (has the same name as) a parent persistent flag would not be shown in the child command's help output and the parent flag would be shown instead under the global flags section.

This change makes the help output consistent with the observed behavior during execution, where the child flag is the one that is actually used.

This change also allows a previously skipped/failing test to be unskipped because it passes now: `TestOverwrittenFlag`

Fixes #1651 