### PR TITLE
Document option to hide the default completion cmd

### DIFF
--- a/shell_completions.md
+++ b/shell_completions.md
@@ -99,6 +99,11 @@ To tell Cobra *not* to provide the default `completion` command:
 rootCmd.CompletionOptions.DisableDefaultCmd = true
 ```
 
+To tell Cobra to mark the default `completion` command as *hidden*:
+```
+rootCmd.CompletionOptions.HiddenDefaultCmd = true
+```
+
 To tell Cobra *not* to provide the user with the `--no-descriptions` flag to the completion sub-commands:
 ```
 rootCmd.CompletionOptions.DisableNoDescFlag = true


### PR DESCRIPTION
When adding the option to hide the default `completion` command in #1541, I forgot to document it!

This PR simply adds that option to the documentation.