### PR TITLE
Use correct stale action `exempt-*` yaml keys

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,8 +39,8 @@ jobs:
         days-before-close: 30
         stale-issue-label: 'lifecycle/stale'
         stale-pr-label: 'lifecycle/stale'
-        exempt-issue-label: 'lifecycle/frozen'
-        exempt-pr-label: 'lifecycle/frozen'
+        exempt-issue-labels: 'lifecycle/frozen'
+        exempt-pr-labels: 'lifecycle/frozen'
         close-issue-label: 'lifecycle/rotten'
         close-pr-label: 'lifecycle/rotten'
 


### PR DESCRIPTION
Somehow we had the wrong `exempt-` keys in our stale action yaml (or maybe they changed it) causing the stale action to label some `lifecycle/frozen` issues and PR as stale.

This should fix that and make `lifecycle/frozen` labeling do the right thing 