### PR TITLE
completions: do not detect arguments with dash as 2nd char as flag

### DIFF
--- a/command.go
+++ b/command.go
@@ -692,7 +692,7 @@ Loop:
 }
 
 func isFlagArg(arg string) bool {
-	return ((len(arg) >= 3 && arg[1] == '-') ||
+	return ((len(arg) >= 3 && arg[0:2] == "--") ||
 		(len(arg) >= 2 && arg[0] == '-' && arg[1] != '-'))
 }
 


### PR DESCRIPTION
Previously, arguments with a dash as the second character (e.g., 1-ff00:0:1) were detected as a flag by mistake.
This resulted in auto completion misbehaving if such an argument was last in the argument list during invocation.

Fixes #1816