### PR TITLE
Fix Makefile install instructions and improve CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ If you have questions regarding Cobra, feel free to ask it in the community
 
 ### Quick steps to contribute
 
+You'll need [golangci-lint] and [richgo] installed in order to run linting and unit tests
+
 1. Fork the project.
 1. Download your fork to your PC (`git clone https://github.com/your_username/cobra && cd cobra`)
 1. Create your feature branch (`git checkout -b my-new-feature`)
@@ -48,3 +50,5 @@ If you have questions regarding Cobra, feel free to ask it in the community
 
 <!-- Links -->
 [cobra-slack]: https://gophers.slack.com/archives/CD3LP1199
+[golangci-lint]: https://golangci-lint.run
+[richgo]: https://github.com/kyoh86/richgo

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 BIN="./bin"
 SRC=$(shell find . -name "*.go")
-GOPATH=$(shell go env GOPATH)
 
 ifeq (, $(shell which golangci-lint))
-$(warning "could not find golangci-lint in PATH, run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.50.0")
+$(warning "could not find golangci-lint in PATH, see here for installation details: https://golangci-lint.run/usage/install/")
 endif
 
 ifeq (, $(shell which richgo))

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 BIN="./bin"
 SRC=$(shell find . -name "*.go")
+GOPATH=$(shell go env GOPATH)
 
 ifeq (, $(shell which golangci-lint))
-$(warning "could not find golangci-lint in $(PATH), run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh")
+$(warning "could not find golangci-lint in PATH, run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.50.0")
 endif
 
 ifeq (, $(shell which richgo))
-$(warning "could not find richgo in $(PATH), run: go install github.com/kyoh86/richgo@latest")
+$(warning "could not find richgo in PATH, run: go install github.com/kyoh86/richgo@latest")
 endif
 
 .PHONY: fmt lint test install_deps clean


### PR DESCRIPTION
Closes #1820 

This PR addresses the concerns raised in the linked issue above re. Makefile printing entire `$PATH` variable and incorrect instructions for installing golangci-lint.

I've also added a line in `CONTRIBUTING.md` linking to the two dev tools required.

On running linting there was a few warnings about deprecated and/or abandoned linters so I've fixed them up:

```shell
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
```

I've made the suggested replacements (most were replaced by `unused`)
