### PR TITLE
Replace deprecated ExactValidArgs with MatchAll in user_guide and shell_completions example

### DIFF
--- a/shell_completions.md
+++ b/shell_completions.md
@@ -71,7 +71,7 @@ PowerShell:
 `,cmd.Root().Name()),
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-	Args:                  cobra.ExactValidArgs(1),
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":

--- a/user_guide.md
+++ b/user_guide.md
@@ -349,7 +349,7 @@ shown below:
 ```go
 var cmd = &cobra.Command{
   Short: "hello",
-  Args: MatchAll(ExactArgs(2), OnlyValidArgs),
+  Args: cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
   Run: func(cmd *cobra.Command, args []string) {
     fmt.Println("Hello, World!")
   },


### PR DESCRIPTION
Update the example from `shell_completions` by replacing `ExactValidArgs` which is deprecated from the documentation by `MatchAll(ExactArgs(1), OnlyValidArgs)`.