### PR TITLE
🍒 Cherry-pick `v1.6.x` - Check for group presence after full initialization (#1839)

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1862,6 +1862,84 @@ func TestAddGroup(t *testing.T) {
 	checkStringContains(t, output, "\nTest group\n  cmd")
 }
 
+func TestWrongGroupFirstLevel(t *testing.T) {
+	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
+
+	rootCmd.AddGroup(&Group{ID: "group", Title: "Test group"})
+	// Use the wrong group ID
+	rootCmd.AddCommand(&Command{Use: "cmd", GroupID: "wrong", Run: emptyRun})
+
+	defer func() {
+		if recover() == nil {
+			t.Errorf("The code should have panicked due to a missing group")
+		}
+	}()
+	_, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestWrongGroupNestedLevel(t *testing.T) {
+	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
+	var childCmd = &Command{Use: "child", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+
+	childCmd.AddGroup(&Group{ID: "group", Title: "Test group"})
+	// Use the wrong group ID
+	childCmd.AddCommand(&Command{Use: "cmd", GroupID: "wrong", Run: emptyRun})
+
+	defer func() {
+		if recover() == nil {
+			t.Errorf("The code should have panicked due to a missing group")
+		}
+	}()
+	_, err := executeCommand(rootCmd, "child", "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestWrongGroupForHelp(t *testing.T) {
+	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
+	var childCmd = &Command{Use: "child", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+
+	rootCmd.AddGroup(&Group{ID: "group", Title: "Test group"})
+	// Use the wrong group ID
+	rootCmd.SetHelpCommandGroupID("wrong")
+
+	defer func() {
+		if recover() == nil {
+			t.Errorf("The code should have panicked due to a missing group")
+		}
+	}()
+	_, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestWrongGroupForCompletion(t *testing.T) {
+	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
+	var childCmd = &Command{Use: "child", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+
+	rootCmd.AddGroup(&Group{ID: "group", Title: "Test group"})
+	// Use the wrong group ID
+	rootCmd.SetCompletionCommandGroupID("wrong")
+
+	defer func() {
+		if recover() == nil {
+			t.Errorf("The code should have panicked due to a missing group")
+		}
+	}()
+	_, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
 func TestSetOutput(t *testing.T) {
 	c := &Command{}
 	c.SetOutput(nil)

--- a/user_guide.md
+++ b/user_guide.md
@@ -492,10 +492,11 @@ around it. In fact, you can provide your own if you want.
 
 ### Grouping commands in help
 
-Cobra supports grouping of available commands. Groups must be explicitly defined by `AddGroup` and set by
-the `GroupId` element of a subcommand. The groups will appear in the same order as they are defined.
-If you use the generated `help` or `completion` commands, you can set the group ids by `SetHelpCommandGroupId`
-and `SetCompletionCommandGroupId`, respectively.
+Cobra supports grouping of available commands in the help output.  To group commands, each group must be explicitly
+defined using `AddGroup()` on the parent command.  Then a subcommand can be added to a group using the `GroupID` element
+of that subcommand. The groups will appear in the help output in the same order as they are defined using different
+calls to `AddGroup()`.  If you use the generated `help` or `completion` commands, you can set their group ids using
+`SetHelpCommandGroupId()` and `SetCompletionCommandGroupId()` on the root command, respectively.
 
 ### Defining your own help
 


### PR DESCRIPTION
```
Fixes #1831

By moving the check for help group existence to "ExecuteC()" we no longer need groups to be added before AddCommand() is called.  This provides more flexibility to developers and works better with the use of "init()" for command creation.

Signed-off-by: Marc Khouzam <marc.khouzam@gmail.com>
```