### PR TITLE
Makefile: add target richtest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
         go install github.com/kyoh86/richgo"${_version}"
         go install github.com/mitchellh/gox"${_version}"
 
-    - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin/:$PATH make test
+    - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin/:$PATH make richtest
 
 
   test-win:
@@ -125,4 +125,4 @@ jobs:
         go install github.com/kyoh86/richgo@latest
         go install github.com/mitchellh/gox@latest
 
-    - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin:$PATH make test
+    - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin:$PATH make richtest

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@ ifeq (, $(shell which golangci-lint))
 $(warning "could not find golangci-lint in $(PATH), run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh")
 endif
 
-ifeq (, $(shell which richgo))
-$(warning "could not find richgo in $(PATH), run: go install github.com/kyoh86/richgo@latest")
-endif
-
 .PHONY: fmt lint test install_deps clean
 
 default: all
@@ -25,6 +21,10 @@ lint:
 
 test: install_deps
 	$(info ******************** running tests ********************)
+	go test -v ./...
+
+richtest: install_deps
+	$(info ******************** running tests with kyoh86/richgo ********************)
 	richgo test -v ./...
 
 install_deps:


### PR DESCRIPTION
Reduce the barrier to entry by making makefile target `test` use `go test` and adding target `richtest` to be used in CI.