### PR TITLE
[RFC] Redirect bash completion v1 to v2 when possible

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -684,11 +684,19 @@ func gen(buf io.StringWriter, cmd *Command) {
 
 // GenBashCompletion generates bash completion file and writes to the passed writer.
 func (c *Command) GenBashCompletion(w io.Writer) error {
+	if len(c.BashCompletionFunction) == 0 {
+		// If the program does not define any legacy custom completion (which is not
+		// supported by bash completion V2), use bash completion V2 which is the version
+		// that is maintained.  However, we keep descriptions off to behave as much as v1
+		// as possible to avoid changing things unexpectedly for projects
+		return c.GenBashCompletionV2(w, false)
+	}
+
 	buf := new(bytes.Buffer)
 	writePreamble(buf, c.Name())
-	if len(c.BashCompletionFunction) > 0 {
-		buf.WriteString(c.BashCompletionFunction + "\n")
-	}
+
+	buf.WriteString(c.BashCompletionFunction + "\n")
+
 	gen(buf, c)
 	writePostscript(buf, c.Name())
 

--- a/completions_test.go
+++ b/completions_test.go
@@ -1506,11 +1506,19 @@ func TestValidArgsFuncAliases(t *testing.T) {
 }
 
 func TestValidArgsFuncInBashScript(t *testing.T) {
-	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
+	rootCmd := &Command{
+		Use:  "root",
+		Args: NoArgs,
+		// Set the legacy BashCompletionFunction to force the
+		// use of bash completion V1
+		BashCompletionFunction: bashCompletionFunc,
+		Run:                    emptyRun,
+	}
 	child := &Command{
-		Use:               "child",
-		ValidArgsFunction: validArgsFunc,
-		Run:               emptyRun,
+		Use:                    "child",
+		ValidArgsFunction:      validArgsFunc,
+		BashCompletionFunction: bashCompletionFunc,
+		Run:                    emptyRun,
 	}
 	rootCmd.AddCommand(child)
 
@@ -1522,7 +1530,14 @@ func TestValidArgsFuncInBashScript(t *testing.T) {
 }
 
 func TestNoValidArgsFuncInBashScript(t *testing.T) {
-	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
+	rootCmd := &Command{
+		Use:  "root",
+		Args: NoArgs,
+		// Set the legacy BashCompletionFunction to force the
+		// use of bash completion V1
+		BashCompletionFunction: bashCompletionFunc,
+		Run:                    emptyRun,
+	}
 	child := &Command{
 		Use: "child",
 		Run: emptyRun,

--- a/shell_completions.md
+++ b/shell_completions.md
@@ -75,7 +75,7 @@ PowerShell:
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			cmd.Root().GenBashCompletionV2(os.Stdout, true)
 		case "zsh":
 			cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":
@@ -412,20 +412,21 @@ Please refer to [Bash Completions](bash_completions.md) for details.
 
 ### Bash completion V2
 
-Cobra provides two versions for bash completion.  The original bash completion (which started it all!) can be used by calling
-`GenBashCompletion()` or `GenBashCompletionFile()`.
+Cobra provides two versions for bash completion.  The original bash completion (which started it all!) that is no longer
+evolving and a new V2 version which is aligned with the completion solution for other shells supported by Cobra.  We
+recommend you use bash completion V2.
 
-A new V2 bash completion version is also available.  This version can be used by calling `GenBashCompletionV2()` or
-`GenBashCompletionFileV2()`.  The V2 version does **not** support the legacy dynamic completion
-(see [Bash Completions](bash_completions.md)) but instead works only with the Go dynamic completion
-solution described in this document.
-Unless your program already uses the legacy dynamic completion solution, it is recommended that you use the bash
-completion V2 solution which provides the following extra features:
+Note that the V2 version does **not** support the legacy dynamic completion solution (see [Bash Completions](bash_completions.md)) 
+but instead works only with the Go dynamic completion solution described in this document.
+Unless your program already uses the legacy dynamic completion solution (meaning that your program defines a
+`BashCompletionFunction` variable), it is recommended that you use the bash completion V2 solution which beyond being
+actively maintained, provides the following extra features:
 - Supports completion descriptions (like the other shells)
-- Small completion script of less than 300 lines (v1 generates scripts of thousands of lines; `kubectl` for example has a bash v1 completion script of over 13K lines)
-- Streamlined user experience thanks to a completion behavior aligned with the other shells 
+- Small completion script of less than 350 lines (v1 generates scripts of thousands of lines; `kubectl` for example has a bash v1 completion script of over 13K lines)
+- Streamlined user experience thanks to a completion behavior aligned with the other shells
 
-`Bash` completion V2 supports descriptions for completions. When calling `GenBashCompletionV2()` or `GenBashCompletionFileV2()`
+`Bash` completion V2 can be used by calling `GenBashCompletionV2()` or `GenBashCompletionFileV2()`. 
+As it supports descriptions for completions, when calling `GenBashCompletionV2()` or `GenBashCompletionFileV2()`
 you must provide these functions with a parameter indicating if the completions should be annotated with a description; Cobra
 will provide the description automatically based on usage information.  You can choose to make this option configurable by
 your users.
@@ -440,7 +441,8 @@ show    (show information of a chart)
 $ helm s[tab][tab]
 search  show  status
 ```
-**Note**: Cobra's default `completion` command uses bash completion V2.  If for some reason you need to use bash completion V1, you will need to implement your own `completion` command. 
+**Note**: Cobra's default `completion` command uses bash completion V2.  If for some reason you need to use bash completion V1, you will need to implement your own `completion` command.
+ 
 ## Zsh completions
 
 Cobra supports native zsh completion generated from the root `cobra.Command`.


### PR DESCRIPTION
We are no longer actively maintaining bash completion v1 in favor of its more rich v2 version.  Previously, using bash completion v2 required projects to be aware of its existence and to explicitly call `GenBashCompletionV2()`.

With this commit, any projects calling `GenBashCompletion()` will automatically be redirected to using the v2 version.
One exception is if the project uses the legacy custom completion logic which is not supported in v2.  We can detect that by looking for the use of the field `BashCompletionFunction` on the root command.

If we ignore the tests and doc, this is a 2 line change in `bash_completions.go`

Note that descriptions are kept off when calling `GenBashCompletion()`. This means that to enable completion descriptions for bash, a project must still explicitly call `GenBashCompletionV2()`.  I chose this approach because I was hesitant to enable descriptions without getting projects to make the decision themselves. 

cc @jpmcb @scop @Luap99  