### PR TITLE
update minimum go version to go1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,6 @@ jobs:
         - ubuntu
         - macOS
         go:
-        - 15
-        - 16
         - 17
         - 18
         - 19
@@ -81,12 +79,8 @@ jobs:
 
     - run: |
         export GOBIN=$HOME/go/bin
-        case "${{ matrix.go }}" in
-          14|15) _version='';;
-          *) _version='@latest';;
-        esac
-        go install github.com/kyoh86/richgo"${_version}"
-        go install github.com/mitchellh/gox"${_version}"
+        go install github.com/kyoh86/richgo@latest
+        go install github.com/mitchellh/gox@latest
 
     - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin/:$PATH make richtest
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spf13/cobra
 
-go 1.15
+go 1.17
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2
@@ -8,3 +8,5 @@ require (
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/russross/blackfriday/v2 v2.1.0 // indirect


### PR DESCRIPTION
- relates to https://github.com/spf13/cobra/pull/1870#issuecomment-1337033791
- supersedes / closes https://github.com/spf13/cobra/pull/1866
- closes https://github.com/spf13/cobra/issues/1864


Versions of go below go1.18 have reached EOL, but some projects may be slightly behind and still on go1.17.

This patch updates the minimum Go version to go1.17, as older versions are broken in CI:

    Error: ../../../go/pkg/mod/github.com/kyoh86/richgo@v0.3.11/config/load.go:64:9: undefined: os.ReadFile
    note: module requires Go 1.17
    Error: Process completed with exit code 2.

