### PR TITLE
docs: update kubescape org

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -26,7 +26,7 @@
 - [Istio](https://istio.io)
 - [Kool](https://github.com/kool-dev/kool)
 - [Kubernetes](https://kubernetes.io/)
-- [Kubescape](https://github.com/armosec/kubescape)
+- [Kubescape](https://github.com/kubescape/kubescape)
 - [KubeVirt](https://github.com/kubevirt/kubevirt)
 - [Linkerd](https://linkerd.io/)
 - [Mattermost-server](https://github.com/mattermost/mattermost-server)


### PR DESCRIPTION
Signed-off-by: David Wertenteil <dwertent@armosec.io>

The Kubscape project has been moved from the [armosec](https://github.com/armosec) org to the [kubescape](https://github.com/kubescape) org.