### PR TITLE
fix: func name in doc strings

### DIFF
--- a/args.go
+++ b/args.go
@@ -21,7 +21,7 @@ import (
 
 type PositionalArgs func(cmd *Command, args []string) error
 
-// Legacy arg validation has the following behaviour:
+// legacyArgs validation has the following behaviour:
 // - root commands with no subcommands can take arbitrary arguments
 // - root commands with subcommands will do subcommand validity checking
 // - subcommands will always accept arbitrary arguments

--- a/bash_completions.go
+++ b/bash_completions.go
@@ -532,7 +532,7 @@ func writeLocalNonPersistentFlag(buf io.StringWriter, flag *pflag.Flag) {
 	}
 }
 
-// Setup annotations for go completions for registered flags
+// prepareCustomAnnotationsForFlags setup annotations for go completions for registered flags
 func prepareCustomAnnotationsForFlags(cmd *Command) {
 	flagCompletionMutex.RLock()
 	defer flagCompletionMutex.RUnlock()

--- a/command.go
+++ b/command.go
@@ -35,7 +35,7 @@ const FlagSetByCobraAnnotation = "cobra_annotation_flag_set_by_cobra"
 // FParseErrWhitelist configures Flag parse errors to be ignored
 type FParseErrWhitelist flag.ParseErrorsWhitelist
 
-// Structure to manage groups for commands
+// Group Structure to manage groups for commands
 type Group struct {
 	ID    string
 	Title string
@@ -47,7 +47,7 @@ type Group struct {
 // definition to ensure usability.
 type Command struct {
 	// Use is the one-line usage message.
-	// Recommended syntax is as follow:
+	// Recommended syntax is as follows:
 	//   [ ] identifies an optional argument. Arguments that are not enclosed in brackets are required.
 	//   ... indicates that you can specify multiple values for the previous argument.
 	//   |   indicates mutually exclusive information. You can use the argument to the left of the separator or the
@@ -321,7 +321,7 @@ func (c *Command) SetHelpCommand(cmd *Command) {
 	c.helpCommand = cmd
 }
 
-// SetHelpCommandGroup sets the group id of the help command.
+// SetHelpCommandGroupID sets the group id of the help command.
 func (c *Command) SetHelpCommandGroupID(groupID string) {
 	if c.helpCommand != nil {
 		c.helpCommand.GroupID = groupID
@@ -330,7 +330,7 @@ func (c *Command) SetHelpCommandGroupID(groupID string) {
 	c.helpCommandGroupID = groupID
 }
 
-// SetCompletionCommandGroup sets the group id of the completion command.
+// SetCompletionCommandGroupID sets the group id of the completion command.
 func (c *Command) SetCompletionCommandGroupID(groupID string) {
 	// completionCommandGroupID is used if no completion command is defined by the user
 	c.Root().completionCommandGroupID = groupID
@@ -1296,7 +1296,7 @@ func (c *Command) AllChildCommandsHaveGroup() bool {
 	return true
 }
 
-// ContainGroups return if groupID exists in the list of command groups.
+// ContainsGroup return if groupID exists in the list of command groups.
 func (c *Command) ContainsGroup(groupID string) bool {
 	for _, x := range c.commandgroups {
 		if x.ID == groupID {

--- a/completions.go
+++ b/completions.go
@@ -169,7 +169,7 @@ func (d ShellCompDirective) string() string {
 	return strings.Join(directives, ", ")
 }
 
-// Adds a special hidden command that can be used to request custom completions.
+// initCompleteCmd adds a special hidden command that can be used to request custom completions.
 func (c *Command) initCompleteCmd(args []string) {
 	completeCmd := &Command{
 		Use:                   fmt.Sprintf("%s [command-line]", ShellCompRequestCmd),

--- a/doc/rest_docs.go
+++ b/doc/rest_docs.go
@@ -48,7 +48,7 @@ func printOptionsReST(buf *bytes.Buffer, cmd *cobra.Command, name string) error 
 	return nil
 }
 
-// linkHandler for default ReST hyperlink markup
+// defaultLinkHandler for default ReST hyperlink markup
 func defaultLinkHandler(name, ref string) string {
 	return fmt.Sprintf("`%s <%s.rst>`_", name, ref)
 }
@@ -169,7 +169,7 @@ func GenReSTTreeCustom(cmd *cobra.Command, dir string, filePrepender func(string
 	return nil
 }
 
-// adapted from: https://github.com/kr/text/blob/main/indent.go
+// indentString adapted from: https://github.com/kr/text/blob/main/indent.go
 func indentString(s, p string) string {
 	var res []byte
 	b := []byte(s)


### PR DESCRIPTION
Corrected the function name at the start of doc strings, as per the convention
outlined in official go documentation: https://go.dev/blog/godoc

Though a minor change, but found this while browsing through the code.