### PR TITLE
Allow sourcing zsh completion script

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -734,7 +734,7 @@ to enable it.  You can execute the following once:
 
 To load completions in your current shell session:
 
-	source <(%[1]s completion zsh); compdef _%[1]s %[1]s
+	source <(%[1]s completion zsh)
 
 To load completions for every new session, execute once:
 

--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -90,6 +90,7 @@ func genZshComp(buf io.StringWriter, name string, includeDesc bool) {
 		compCmd = ShellCompNoDescRequestCmd
 	}
 	WriteStringAndCheck(buf, fmt.Sprintf(`#compdef %[1]s
+compdef _%[1]s %[1]s
 
 # zsh completion for %-36[1]s -*- shell-script -*-
 


### PR DESCRIPTION
Although it is not the recommended approach, sourcing a completion script is the simplest way to get people to try using shell completion. Not allowing it for zsh has turned out to complicate shell completion adoption.  

Also, it has caused multiple issues to be opened on the Cobra project because people could not get zsh completion to work.  One can look for the string `compdef` in: #881 #986 #887 #1264 #1325 #1796

Further, many tools modify the zsh script provided by Cobra to allow sourcing, which kind of makes Cobra's stance, not that useful anyway.

This commit allows sourcing of the zsh completion script.

Note that putting the script on `$fpath` continues to be recommended approach and continues to function as before.