### PR TITLE
provide error message

### DIFF
--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -175,6 +175,7 @@ _%[1]s()
 
     if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
         __%[1]s_debug "Completion received error. Ignoring completions."
+		_message -r "${out}"
         return
     fi
 

--- a/zsh_completions.go
+++ b/zsh_completions.go
@@ -175,7 +175,7 @@ _%[1]s()
 
     if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
         __%[1]s_debug "Completion received error. Ignoring completions."
-		_message -r "${out}"
+        _message -r "${out}"
         return
     fi
 


### PR DESCRIPTION
with this, it's possible to return some information in case of an error: `return []string{"error description"}, cobra.ShellCompDirectiveError` and have it printed on the shell