### PR TITLE
ci: test Golang 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '^1.20'
           check-latest: true
           cache: true
 
@@ -67,6 +67,7 @@ jobs:
         - 17
         - 18
         - 19
+        - 20
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:


### PR DESCRIPTION
Golang 1.20 was released a month ago: https://go.dev/blog/go1.20

Ref: #1782