### PR TITLE
ci: deprecate go 1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,6 @@ jobs:
         - ubuntu
         - macOS
         go:
-        - 16
         - 17
         - 18
         - 19


### PR DESCRIPTION
As #1866, this PR removes go 1.16 from CI (since it's failing due to a test dependency) but keeps the `go.mod` unmodified.