### PR TITLE
Update `projects_using_cobra.md` add `Vitess` and `Arewefastyet`

### DIFF
--- a/projects_using_cobra.md
+++ b/projects_using_cobra.md
@@ -1,6 +1,7 @@
 ## Projects using Cobra
 
 - [Allero](https://github.com/allero-io/allero)
+- [Arewefastyet](https://benchmark.vitess.io)
 - [Arduino CLI](https://github.com/arduino/arduino-cli)
 - [Bleve](https://blevesearch.com/)
 - [Cilium](https://cilium.io/)
@@ -57,6 +58,7 @@
 - [Tendermint](https://github.com/tendermint/tendermint)
 - [Twitch CLI](https://github.com/twitchdev/twitch-cli)
 - [UpCloud CLI (`upctl`)](https://github.com/UpCloudLtd/upcloud-cli)
+- [Vitess](https://vitess.io)
 - VMware's [Tanzu Community Edition](https://github.com/vmware-tanzu/community-edition) & [Tanzu Framework](https://github.com/vmware-tanzu/tanzu-framework)
 - [Werf](https://werf.io/)
 - [ZITADEL](https://github.com/zitadel/zitadel)


### PR DESCRIPTION
This Pull Request updates the `projects_using_cobra.md` file to add Vitess and Arewefastyet as projects that are using Cobra.