### PR TITLE
Add Post terminator args support

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -89,6 +89,22 @@ func TestNoArgs(t *testing.T) {
 	output, err := executeCommand(c)
 	expectSuccess(output, err, t)
 }
+func TestNoArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(NoArgs, false)
+	_, err := executeCommand(c, "--", "post", "args")
+	noArgsWithArgs(err, t, "post")
+	// got := c.PostTerminatorArgs()
+	// expected := []string{"post", "args"}
+	// if strings.Join(got, ",") != strings.Join(expected, ",") {
+	// 	t.Fatalf("Expected %q, got %q", expected, got)
+	// }
+}
+func TestNoArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(NoArgs, false)
+	c.IgnorePostTerminatorArgs = true
+	output, err := executeCommand(c, "--", "post", "args")
+	expectSuccess(output, err, t)
+}
 
 func TestNoArgs_WithArgs(t *testing.T) {
 	c := getCommand(NoArgs, false)
@@ -119,6 +135,19 @@ func TestNoArgs_WithValidOnly_WithInvalidArgs(t *testing.T) {
 func TestOnlyValidArgs(t *testing.T) {
 	c := getCommand(OnlyValidArgs, true)
 	output, err := executeCommand(c, "one", "two")
+	expectSuccess(output, err, t)
+}
+
+func TestOnlyValidArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(OnlyValidArgs, true)
+	_, err := executeCommand(c, "one", "two", "--", "post", "args")
+	expectError("invalid argument \"post\" for \"c\"", err, t)
+}
+
+func TestOnlyValidArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(OnlyValidArgs, true)
+	c.IgnorePostTerminatorArgs = true
+	output, err := executeCommand(c, "one", "two", "--", "post", "args")
 	expectSuccess(output, err, t)
 }
 
@@ -185,10 +214,21 @@ func TestMinimumNArgs_WithLessArgs(t *testing.T) {
 	_, err := executeCommand(c, "a")
 	minimumNArgsWithLessArgs(err, t)
 }
+func TestMinimumNArgs_WithLessArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MinimumNArgs(2), false)
+	output, err := executeCommand(c, "a", "--", "post", "args")
+	expectSuccess(output, err, t)
+}
+func TestMinimumNArgs_WithLessArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MinimumNArgs(2), false)
+	c.IgnorePostTerminatorArgs = true
+	_, err := executeCommand(c, "a", "--", "post", "args")
+	minimumNArgsWithLessArgs(err, t)
+}
 
 func TestMinimumNArgs_WithLessArgs_WithValid(t *testing.T) {
 	c := getCommand(MinimumNArgs(2), true)
-	_, err := executeCommand(c, "one")
+	_, err := executeCommand(c, "one") // @todo check
 	minimumNArgsWithLessArgs(err, t)
 }
 
@@ -212,12 +252,37 @@ func TestMaximumNArgs(t *testing.T) {
 	expectSuccess(output, err, t)
 }
 
+func TestMaximumNArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MaximumNArgs(3), false)
+	_, err := executeCommand(c, "a", "b", "--", "post", "args")
+	expectError("accepts at most 3 arg(s), received 4", err, t)
+}
+
+func TestMaximumNArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MaximumNArgs(3), false)
+	c.IgnorePostTerminatorArgs = true
+	output, err := executeCommand(c, "a", "b", "--", "post", "args")
+	expectSuccess(output, err, t)
+}
+
 func TestMaximumNArgs_WithValid(t *testing.T) {
 	c := getCommand(MaximumNArgs(2), true)
 	output, err := executeCommand(c, "one", "three")
 	expectSuccess(output, err, t)
 }
 
+func TestMaximumNArgs_WithValid_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MaximumNArgs(2), true)
+	_, err := executeCommand(c, "one", "three", "--", "post", "args")
+	expectError("accepts at most 2 arg(s), received 4", err, t)
+}
+
+func TestMaximumNArgs_WithValid_WithIgnoredPostTermintatorArgs(t *testing.T) {
+	c := getCommand(MaximumNArgs(2), true)
+	c.IgnorePostTerminatorArgs = true
+	output, err := executeCommand(c, "one", "three", "--", "post", "args")
+	expectSuccess(output, err, t)
+}
 func TestMaximumNArgs_WithValid_WithInvalidArgs(t *testing.T) {
 	c := getCommand(MaximumNArgs(2), true)
 	output, err := executeCommand(c, "a", "b")
@@ -233,6 +298,19 @@ func TestMaximumNArgs_WithValidOnly_WithInvalidArgs(t *testing.T) {
 func TestMaximumNArgs_WithMoreArgs(t *testing.T) {
 	c := getCommand(MaximumNArgs(2), false)
 	_, err := executeCommand(c, "a", "b", "c")
+	maximumNArgsWithMoreArgs(err, t)
+}
+
+func TestMaximumNArgs_WithMoreArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MaximumNArgs(2), false)
+	_, err := executeCommand(c, "a", "b", "c", "--", "post", "args")
+	expectError("accepts at most 2 arg(s), received 5", err, t)
+}
+
+func TestMaximumNArgs_WithMoreArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(MaximumNArgs(2), false)
+	c.IgnorePostTerminatorArgs = true
+	_, err := executeCommand(c, "a", "b", "c", "--", "post", "args")
 	maximumNArgsWithMoreArgs(err, t)
 }
 
@@ -259,6 +337,19 @@ func TestMaximumNArgs_WithMoreArgs_WithValidOnly_WithInvalidArgs(t *testing.T) {
 func TestExactArgs(t *testing.T) {
 	c := getCommand(ExactArgs(3), false)
 	output, err := executeCommand(c, "a", "b", "c")
+	expectSuccess(output, err, t)
+}
+
+func TestExactArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(ExactArgs(3), false)
+	_, err := executeCommand(c, "a", "b", "c", "--", "post", "args")
+	expectError("accepts 3 arg(s), received 5", err, t)
+}
+
+func TestExactArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(ExactArgs(3), false)
+	c.IgnorePostTerminatorArgs = true
+	output, err := executeCommand(c, "a", "b", "c", "--", "post", "args")
 	expectSuccess(output, err, t)
 }
 
@@ -309,6 +400,19 @@ func TestExactArgs_WithInvalidCount_WithValidOnly_WithInvalidArgs(t *testing.T) 
 func TestRangeArgs(t *testing.T) {
 	c := getCommand(RangeArgs(2, 4), false)
 	output, err := executeCommand(c, "a", "b", "c")
+	expectSuccess(output, err, t)
+}
+
+func TestRangeArgs_WithPostTerminatorArgs(t *testing.T) {
+	c := getCommand(RangeArgs(2, 4), false)
+	_, err := executeCommand(c, "a", "b", "c", "--", "post", "args")
+	expectError("accepts between 2 and 4 arg(s), received 5", err, t)
+}
+
+func TestRangeArgs_WithIgnoredPostTerminatorArgs(t *testing.T) {
+	c := getCommand(RangeArgs(2, 4), false)
+	c.IgnorePostTerminatorArgs = true
+	output, err := executeCommand(c, "a", "b", "c", "--", "post", "args")
 	expectSuccess(output, err, t)
 }
 
@@ -428,20 +532,34 @@ func TestMatchAll(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		args []string
-		fail bool
+		args           []string
+		ignorePostArgs bool
+		fail           bool
 	}{
 		"happy path": {
 			[]string{"aa", "bb", "cc"},
 			false,
+			false,
 		},
 		"incorrect number of args": {
 			[]string{"aa", "bb", "cc", "dd"},
+			false,
 			true,
 		},
 		"incorrect number of bytes in one arg": {
 			[]string{"aa", "bb", "abc"},
+			false,
 			true,
+		},
+		"happy path with post args makes unhappy": {
+			[]string{"aa", "bb", "cc", "--", "post", "args"},
+			false,
+			true,
+		},
+		"happy path with ignored post args stay happy": {
+			[]string{"aa", "bb", "cc", "--", "post", "args"},
+			true,
+			false,
 		},
 	}
 
@@ -449,6 +567,7 @@ func TestMatchAll(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			rootCmd.IgnorePostTerminatorArgs = tc.ignorePostArgs
 			_, err := executeCommand(rootCmd, tc.args...)
 			if err != nil && !tc.fail {
 				t.Errorf("unexpected: %v\n", err)

--- a/args_test.go
+++ b/args_test.go
@@ -33,6 +33,7 @@ func getCommand(args PositionalArgs, withValid bool) *Command {
 }
 
 func expectSuccess(output string, err error, t *testing.T) {
+	t.Helper()
 	if output != "" {
 		t.Errorf("Unexpected output: %v", output)
 	}
@@ -40,71 +41,45 @@ func expectSuccess(output string, err error, t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
-
-func validOnlyWithInvalidArgs(err error, t *testing.T) {
+func expectError(expected string, err error, t *testing.T) {
+	t.Helper()
 	if err == nil {
 		t.Fatal("Expected an error")
 	}
 	got := err.Error()
-	expected := `invalid argument "a" for "c"`
 	if got != expected {
-		t.Errorf("Expected: %q, got: %q", expected, got)
+		t.Fatalf("Expected %q, got %q", expected, got)
 	}
+}
+
+func validOnlyWithInvalidArgs(err error, t *testing.T) {
+	t.Helper()
+	expectError(`invalid argument "a" for "c"`, err, t)
 }
 
 func noArgsWithArgs(err error, t *testing.T, arg string) {
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-	got := err.Error()
-	expected := `unknown command "` + arg + `" for "c"`
-	if got != expected {
-		t.Errorf("Expected: %q, got: %q", expected, got)
-	}
+	t.Helper()
+	expectError(`unknown command "`+arg+`" for "c"`, err, t)
 }
 
 func minimumNArgsWithLessArgs(err error, t *testing.T) {
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-	got := err.Error()
-	expected := "requires at least 2 arg(s), only received 1"
-	if got != expected {
-		t.Fatalf("Expected %q, got %q", expected, got)
-	}
+	t.Helper()
+	expectError("requires at least 2 arg(s), only received 1", err, t)
 }
 
 func maximumNArgsWithMoreArgs(err error, t *testing.T) {
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-	got := err.Error()
-	expected := "accepts at most 2 arg(s), received 3"
-	if got != expected {
-		t.Fatalf("Expected %q, got %q", expected, got)
-	}
+	t.Helper()
+	expectError("accepts at most 2 arg(s), received 3", err, t)
 }
 
 func exactArgsWithInvalidCount(err error, t *testing.T) {
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-	got := err.Error()
-	expected := "accepts 2 arg(s), received 3"
-	if got != expected {
-		t.Fatalf("Expected %q, got %q", expected, got)
-	}
+	t.Helper()
+	expectError("accepts 2 arg(s), received 3", err, t)
 }
 
 func rangeArgsWithInvalidCount(err error, t *testing.T) {
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-	got := err.Error()
-	expected := "accepts between 2 and 4 arg(s), received 1"
-	if got != expected {
-		t.Fatalf("Expected %q, got %q", expected, got)
-	}
+	t.Helper()
+	expectError("accepts between 2 and 4 arg(s), received 1", err, t)
 }
 
 // NoArgs

--- a/user_guide.md
+++ b/user_guide.md
@@ -410,7 +410,7 @@ var cmd = &cobra.Command{
 }
 ```
 
-## Example
+### Example
 
 In the example below, we have defined three commands. Two are at the top level
 and one (cmdTimes) is a child of one of the top commands. In this case the root
@@ -479,6 +479,28 @@ a count and a string.`,
 ```
 
 For a more complete example of a larger application, please checkout [Hugo](https://gohugo.io/).
+
+### post arg terminator "--" args
+
+By default args passed to the Run method will include arguments passed after
+the arg terminator "--". You can change this behavior by setting the field
+IgnorePostTerminatorArgs to true. You can retrieve these arguments easily by
+calling the PostTerminatorArgs() method of the command. This can be useful when
+calling child command from your program.
+
+```go
+var cmd = &cobra.Command{
+  Use: "exec",
+  IgnorePostTerminatorArgs: true,
+  Run: func(cmd *cobra.Command, args []string) {
+    bin := args[0]
+    //...pass all args after -- to the underlying command
+    cmd := exec.Command(bin, cmd.PostTerminatorArgs())
+  },
+}
+```
+
+
 
 ## Help Command
 


### PR DESCRIPTION
This PR addresses #1895, adding an easy way to ignore args after the arg terminator --.
It also add easy retrieving of such arguments to easily manipulate them.
It is an optin feature, without setting IgnorePostTerminatorArgs to true it should not change anything, so no breaking change.

this PR includes:
- Adding a field IgnorePostTerminatorArgs to the Command struct
- Adding a method PostTerminatorArgs to the Command struct 
- test we don't break normal behaviour such as args validation
- documentation for the added feature

Hope this can be of any help to others.