### PR TITLE
Fix typo in fish completions

### DIFF
--- a/fish_completions.go
+++ b/fish_completions.go
@@ -113,7 +113,7 @@ function __%[1]s_clear_perform_completion_once_result
     __%[1]s_debug ""
     __%[1]s_debug "========= clearing previously set __%[1]s_perform_completion_once_result variable =========="
     set --erase __%[1]s_perform_completion_once_result
-    __%[1]s_debug "Succesfully erased the variable __%[1]s_perform_completion_once_result"
+    __%[1]s_debug "Successfully erased the variable __%[1]s_perform_completion_once_result"
 end
 
 function __%[1]s_requires_order_preservation


### PR DESCRIPTION
This is a trivial fix. The typo broke CI for projects that run a spellchecker (e.g. https://github.com/reviewdog/action-misspell) on their committed code ([like this one](https://github.com/twpayne/chezmoi/actions/runs/4617766534/jobs/8164413060)).