### PR TITLE
powershell: escape variable with curly brackets

### DIFF
--- a/powershell_completions.go
+++ b/powershell_completions.go
@@ -47,7 +47,7 @@ filter __%[1]s_escapeStringWithSpecialChars {
 `+"    $_ -replace '\\s|#|@|\\$|;|,|''|\\{|\\}|\\(|\\)|\"|`|\\||<|>|&','`$&'"+`
 }
 
-[scriptblock]$__%[2]sCompleterBlock = {
+[scriptblock]${__%[2]sCompleterBlock} = {
     param(
             $WordToComplete,
             $CommandAst,
@@ -122,7 +122,7 @@ filter __%[1]s_escapeStringWithSpecialChars {
 
     __%[1]s_debug "Calling $RequestComp"
     # First disable ActiveHelp which is not supported for Powershell
-    $env:%[10]s=0
+    ${env:%[10]s}=0
 
     #call the command store the output in $out and redirect stderr and stdout to null
     # $Out is an array contains each line per element
@@ -279,7 +279,7 @@ filter __%[1]s_escapeStringWithSpecialChars {
     }
 }
 
-Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock $__%[2]sCompleterBlock
+Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock ${__%[2]sCompleterBlock}
 `, name, nameForVar, compCmd,
 		ShellCompDirectiveError, ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp,
 		ShellCompDirectiveFilterFileExt, ShellCompDirectiveFilterDirs, ShellCompDirectiveKeepOrder, activeHelpEnvVar(name)))

--- a/powershell_completions_test.go
+++ b/powershell_completions_test.go
@@ -29,5 +29,5 @@ func TestPwshCompletionNoActiveHelp(t *testing.T) {
 
 	// check that active help is being disabled
 	activeHelpVar := activeHelpEnvVar(c.Name())
-	check(t, output, fmt.Sprintf("%s=0", activeHelpVar))
+	check(t, output, fmt.Sprintf("${env:%s}=0", activeHelpVar))
 }


### PR DESCRIPTION
This fixes an issue with program names that include a dot, in our case `podman.exe`. This was caused by the change in commit 6ba7ebbc.

Fixes #1853