### PR TITLE
completers ∀x∈ {cmds, aliases} in powershell_completions.go

### DIFF
--- a/powershell_completions.go
+++ b/powershell_completions.go
@@ -284,7 +284,7 @@ $available%[2]s = Get-Command -Name '%[1]s' -All -ErrorAction SilentlyContinue |
 # Enumerate extant aliases for %[1]s (already set by user)
 ${__%[2]sAliases} = @()
 foreach($__%[2]sCmd in $available%[2]s){
-	$__%[2]sAliases += Get-Alias | Where-Object { $_.Definition -eq ($__%[2]sCmd | Resolve-Path) -or $_.Definition -eq (Get-Command -Name $__%[2]sCmd -ErrorAction SilentlyContinue).Definition } 
+	$__%[2]sAliases += Get-Alias | Where-Object { $_.Definition -eq ($__%[2]sCmd | Resolve-Path -ErrorAction SilentlyContinue) -or $_.Definition -eq (Get-Command -Name $__%[2]sCmd -ErrorAction SilentlyContinue).Definition } 
 }
 # Register args completer for all cmds and aliases
 [string[]]$joint%[2]snames = [array]$available%[2]s.Name + [array]${__%[2]sAliases}.Name + @('%[1]s')


### PR DESCRIPTION
Where `name` is substituted for `%[1]s`, this provides PowerShell argument completer for all `%[1]s` commands and aliases. In case of `podman`, this is especially useful when user set `docker` as an alias. 

Also, the PowerShell argument completer will now apply for `%[1]s.exe` if that is an entrypoint to `%[1]s` that is set by `System.Environment`. This is useful for cases (Windows contexts) where the executable has `*.exe` extension. (We don't want to deny argument completion when the user is employing _a canonical name_ for the executable, which it does in the status quo.)

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Extend PowerShell argument completer to apply for each `%[1]s` command (including `*.exe`) and aliases.
```

See also https://github.com/containers/podman/pull/18847
