### PR TITLE
Fix grammar: 'allows to'

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -85,7 +85,7 @@ __%[1]s_handle_go_custom_completion()
     local out requestComp lastParam lastChar comp directive args
 
     # Prepare the command to request completions for the program.
-    # Calling ${words[0]} instead of directly %[1]s allows to handle aliases
+    # Calling ${words[0]} instead of directly %[1]s allows handling aliases
     args=("${words[@]:1}")
     # Disable ActiveHelp which is not supported for bash completion v1
     requestComp="%[8]s=0 ${words[0]} %[2]s ${args[*]}"

--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -57,7 +57,7 @@ __%[1]s_get_completion_results() {
     local requestComp lastParam lastChar args
 
     # Prepare the command to request completions for the program.
-    # Calling ${words[0]} instead of directly %[1]s allows to handle aliases
+    # Calling ${words[0]} instead of directly %[1]s allows handling aliases
     args=("${words[@]:1}")
     requestComp="${words[0]} %[2]s ${args[*]}"
 

--- a/cobra.go
+++ b/cobra.go
@@ -48,7 +48,7 @@ const (
 	defaultCaseInsensitive = false
 )
 
-// EnablePrefixMatching allows to set automatic prefix matching. Automatic prefix matching can be a dangerous thing
+// EnablePrefixMatching allows setting automatic prefix matching. Automatic prefix matching can be a dangerous thing
 // to automatically enable in CLI tools.
 // Set this to true to enable it.
 var EnablePrefixMatching = defaultPrefixMatching


### PR DESCRIPTION
The use in generated bash completion files is getting flagged by Lintian (the Debian package linting tool).
