### PR TITLE
test: make fish_completions_test more robust

### DIFF
--- a/fish_completions_test.go
+++ b/fish_completions_test.go
@@ -16,9 +16,10 @@ package cobra
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"log"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -98,12 +99,12 @@ func TestFishCompletionNoActiveHelp(t *testing.T) {
 }
 
 func TestGenFishCompletionFile(t *testing.T) {
-	err := os.Mkdir("./tmp", 0755)
+	tmpFile, err := os.CreateTemp("", "cobra-test")
 	if err != nil {
-		log.Fatal(err.Error())
+		t.Fatal(err.Error())
 	}
 
-	defer os.RemoveAll("./tmp")
+	defer os.Remove(tmpFile.Name())
 
 	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
 	child := &Command{
@@ -113,18 +114,18 @@ func TestGenFishCompletionFile(t *testing.T) {
 	}
 	rootCmd.AddCommand(child)
 
-	assertNoErr(t, rootCmd.GenFishCompletionFile("./tmp/test", false))
+	assertNoErr(t, rootCmd.GenFishCompletionFile(tmpFile.Name(), false))
 }
 
 func TestFailGenFishCompletionFile(t *testing.T) {
-	err := os.Mkdir("./tmp", 0755)
+	tmpDir, err := os.MkdirTemp("", "cobra-test")
 	if err != nil {
-		log.Fatal(err.Error())
+		t.Fatal(err.Error())
 	}
 
-	defer os.RemoveAll("./tmp")
+	defer os.RemoveAll(tmpDir)
 
-	f, _ := os.OpenFile("./tmp/test", os.O_CREATE, 0400)
+	f, _ := os.OpenFile(filepath.Join(tmpDir, "test"), os.O_CREATE, 0400)
 	defer f.Close()
 
 	rootCmd := &Command{Use: "root", Args: NoArgs, Run: emptyRun}
@@ -135,18 +136,8 @@ func TestFailGenFishCompletionFile(t *testing.T) {
 	}
 	rootCmd.AddCommand(child)
 
-	got := rootCmd.GenFishCompletionFile("./tmp/test", false)
-	if got == nil {
-		t.Error("should raise permission denied error")
-	}
-
-	if os.Getenv("MSYSTEM") == "MINGW64" {
-		if got.Error() != "open ./tmp/test: Access is denied." {
-			t.Errorf("got: %s, want: %s", got.Error(), "open ./tmp/test: Access is denied.")
-		}
-	} else {
-		if got.Error() != "open ./tmp/test: permission denied" {
-			t.Errorf("got: %s, want: %s", got.Error(), "open ./tmp/test: permission denied")
-		}
+	got := rootCmd.GenFishCompletionFile(f.Name(), false)
+	if !errors.Is(got, os.ErrPermission) {
+		t.Errorf("got: %s, want: %s", got.Error(), os.ErrPermission.Error())
 	}
 }


### PR DESCRIPTION
Use temporary files instead of assuming the current directory is writable. Also, if creating a temporary file still returns an error, prevent the test from failing silently by replacing `log.Fatal` with `t.Fatal`.