### PR TITLE
golangci: enable 'unused' and disable deprecated replaced by it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
   disable-all: true
   enable:
     #- bodyclose
-    - deadcode
+    # - deadcode ! deprecated since v1.49.0; replaced by 'unused'
     #- depguard
     #- dogsled
     #- dupl
@@ -51,12 +51,12 @@ linters:
     #- rowserrcheck
     #- scopelint
     #- staticcheck
-    - structcheck
+    #- structcheck ! deprecated since v1.49.0; replaced by 'unused'
     #- stylecheck
     #- typecheck
     - unconvert
     #- unparam
-    #- unused
-    - varcheck
+    - unused
+    # - varcheck ! deprecated since v1.49.0; replaced by 'unused'
     #- whitespace
   fast: false


### PR DESCRIPTION
Minimal changes to the golangci configuration, to get rid of the following warnings:

```
  level=warning msg="[runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
  level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
  level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
```