### PR TITLE
Disable mark persistent required flag for help and completion command

### DIFF
--- a/command.go
+++ b/command.go
@@ -1190,6 +1190,7 @@ func (c *Command) InitDefaultHelpCmd() {
 			Short: "Help about any command",
 			Long: `Help provides help for any command in the application.
 Simply type ` + c.Name() + ` help [path to command] for full details.`,
+			DisableFlagParsing: true,
 			ValidArgsFunction: func(c *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
 				var completions []string
 				cmd, _, e := c.Root().Find(args)

--- a/command_test.go
+++ b/command_test.go
@@ -885,6 +885,18 @@ func TestHelpCommandExecuted(t *testing.T) {
 	checkStringContains(t, output, rootCmd.Long)
 }
 
+func TestHelpCommandExecutedWithPersistentRequiredFlags(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.PersistentFlags().Bool("foo", false, "")
+	childCmd := &Command{Use: "child", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+	assertNoErr(t, rootCmd.MarkPersistentFlagRequired("foo"))
+
+	if _, err := executeCommand(rootCmd, "help"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestHelpCommandExecutedOnChild(t *testing.T) {
 	rootCmd := &Command{Use: "root", Run: emptyRun}
 	childCmd := &Command{Use: "child", Long: "Long description", Run: emptyRun}

--- a/completions.go
+++ b/completions.go
@@ -713,6 +713,7 @@ You will need to start a new shell for this setup to take effect.
 `, c.Root().Name()),
 		Args:                  NoArgs,
 		DisableFlagsInUseLine: true,
+		DisableFlagParsing:    true,
 		ValidArgsFunction:     NoFileCompletions,
 		RunE: func(cmd *Command, args []string) error {
 			return cmd.Root().GenBashCompletionV2(out, !noDesc)
@@ -748,8 +749,9 @@ To load completions for every new session, execute once:
 
 You will need to start a new shell for this setup to take effect.
 `, c.Root().Name()),
-		Args:              NoArgs,
-		ValidArgsFunction: NoFileCompletions,
+		Args:               NoArgs,
+		DisableFlagParsing: true,
+		ValidArgsFunction:  NoFileCompletions,
 		RunE: func(cmd *Command, args []string) error {
 			if noDesc {
 				return cmd.Root().GenZshCompletionNoDesc(out)
@@ -776,8 +778,9 @@ To load completions for every new session, execute once:
 
 You will need to start a new shell for this setup to take effect.
 `, c.Root().Name()),
-		Args:              NoArgs,
-		ValidArgsFunction: NoFileCompletions,
+		Args:               NoArgs,
+		DisableFlagParsing: true,
+		ValidArgsFunction:  NoFileCompletions,
 		RunE: func(cmd *Command, args []string) error {
 			return cmd.Root().GenFishCompletion(out, !noDesc)
 		},
@@ -798,8 +801,9 @@ To load completions in your current shell session:
 To load completions for every new session, add the output of the above command
 to your powershell profile.
 `, c.Root().Name()),
-		Args:              NoArgs,
-		ValidArgsFunction: NoFileCompletions,
+		Args:               NoArgs,
+		DisableFlagParsing: true,
+		ValidArgsFunction:  NoFileCompletions,
 		RunE: func(cmd *Command, args []string) error {
 			if noDesc {
 				return cmd.Root().GenPowerShellCompletion(out)

--- a/completions_test.go
+++ b/completions_test.go
@@ -2447,6 +2447,17 @@ func TestDefaultCompletionCmd(t *testing.T) {
 	rootCmd.CompletionOptions.HiddenDefaultCmd = false
 	// Remove completion command for the next test
 	removeCompCmd(rootCmd)
+
+	// Test that required flag will be ignored
+	rootCmd.PersistentFlags().Bool("foo", false, "")
+	assertNoErr(t, rootCmd.MarkPersistentFlagRequired("foo"))
+	for _, shell := range []string{"bash", "fish", "powershell", "zsh"} {
+		if _, err = executeCommand(rootCmd, compCmdName, shell); err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	// Remove completion command for the next test
+	removeCompCmd(rootCmd)
 }
 
 func TestCompleteCompletion(t *testing.T) {


### PR DESCRIPTION
# Overview
This PR addresses #1918.

The auto-implemented subcommands (help and completion) did't work when MarkPersistentRequiredFlag() called on root command. So I set DisableFlagParsing true for HelpCommand and CompletionCommand (bash, zsh, fish, powershell) to avoid required flags validation.

I also added unit test to see if the code works as I expected.

# Related Issue
- https://github.com/spf13/cobra/issues/1918