### PR TITLE
Add remove group method for command

### DIFF
--- a/command.go
+++ b/command.go
@@ -1311,6 +1311,30 @@ func (c *Command) AddGroup(groups ...*Group) {
 	c.commandgroups = append(c.commandgroups, groups...)
 }
 
+// RemoveGroup removes one or more command groups to this parent command.
+func (c *Command) RemoveGroup(groupIDs ...string) {
+	// remove groups from commandgroups
+	groups := []*Group{}
+main:
+	for _, group := range c.commandgroups {
+		for _, groupID := range groupIDs {
+			if group.ID == groupID {
+				continue main
+			}
+		}
+		groups = append(groups, group)
+	}
+	c.commandgroups = groups
+	// remove the groupID from the target commands
+	for _, command := range c.commands {
+		for _, groupID := range groupIDs {
+			if command.GroupID == groupID {
+				command.GroupID = ""
+			}
+		}
+	}
+}
+
 // RemoveCommand removes one or more commands from a parent command.
 func (c *Command) RemoveCommand(cmds ...*Command) {
 	commands := []*Command{}

--- a/command_test.go
+++ b/command_test.go
@@ -1862,6 +1862,61 @@ func TestAddGroup(t *testing.T) {
 	checkStringContains(t, output, "\nTest group\n  cmd")
 }
 
+func TestRemoveSingleGroup(t *testing.T) {
+	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
+
+	rootCmd.AddGroup(
+		&Group{ID: "group", Title: "Test group"},
+		&Group{ID: "help", Title: "help"},
+		&Group{ID: "comp", Title: "comp"},
+	)
+
+	rootCmd.AddCommand(&Command{Use: "sub", GroupID: "group", Run: emptyRun})
+
+	rootCmd.SetHelpCommandGroupID("help")
+	rootCmd.SetCompletionCommandGroupID("comp")
+
+	rootCmd.RemoveGroup("group")
+
+	output, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	checkStringOmits(t, output, "\nTest group:\n  sub")
+	checkStringContains(t, output, "\nAdditional Commands:\n  sub")
+}
+
+func TestRemoveMultipleGroups(t *testing.T) {
+	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
+
+	rootCmd.AddGroup(
+		&Group{ID: "group1", Title: "Test group1"},
+		&Group{ID: "group2", Title: "Test group2"},
+		&Group{ID: "help", Title: "help"},
+		&Group{ID: "comp", Title: "comp"},
+	)
+
+	rootCmd.AddCommand(
+		&Command{Use: "sub1", Short: "sub1", GroupID: "group1", Run: emptyRun},
+		&Command{Use: "sub2", Short: "sub2", GroupID: "group2", Run: emptyRun},
+	)
+
+	rootCmd.SetHelpCommandGroupID("help")
+	rootCmd.SetCompletionCommandGroupID("comp")
+
+	rootCmd.RemoveGroup("group1", "group2")
+
+	output, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	checkStringOmits(t, output, "\nTest group1:\n  sub1")
+	checkStringOmits(t, output, "\nTest group2:\n  sub2")
+	checkStringContains(t, output, "\nAdditional Commands:\n  sub1        sub1\n  sub2        sub2")
+}
+
 func TestWrongGroupFirstLevel(t *testing.T) {
 	var rootCmd = &Command{Use: "root", Short: "test", Run: emptyRun}
 


### PR DESCRIPTION
## Overview
This PR is about #1911.
Sorry, I missed that a PR(#1912) has already been submitted regarding this Issue.
However, it appears that a PR has not been updated, so I am submitting this just in case.

I added `RemoveGroup` method for command. RemoveGroup method removes groups from commandgroups and at the same time initializes the command's groupID.

## Related Issue
- https://github.com/spf13/cobra/issues/1911