### PR TITLE
all: refactor to use %q instead of "%s"

### DIFF
--- a/doc/man_docs.go
+++ b/doc/man_docs.go
@@ -146,7 +146,7 @@ func manPreamble(buf io.StringWriter, header *GenManHeader, cmd *cobra.Command, 
 		description = cmd.Short
 	}
 
-	cobra.WriteStringAndCheck(buf, fmt.Sprintf(`%% "%s" "%s" "%s" "%s" "%s"
+	cobra.WriteStringAndCheck(buf, fmt.Sprintf(`%% %q %q %q %q %q
 # NAME
 `, header.Title, header.Section, header.date, header.Source, header.Manual))
 	cobra.WriteStringAndCheck(buf, fmt.Sprintf("%s \\- %s\n\n", dashedName, cmd.Short))

--- a/site/content/docgen/md.md
+++ b/site/content/docgen/md.md
@@ -90,7 +90,7 @@ The `filePrepender` will prepend the return value given the full filepath to the
 ```go
 const fmTemplate = `---
 date: %s
-title: "%s"
+title: %q
 slug: %s
 url: %s
 ---

--- a/site/content/docgen/rest.md
+++ b/site/content/docgen/rest.md
@@ -90,7 +90,7 @@ The `filePrepender` will prepend the return value given the full filepath to the
 ```go
 const fmTemplate = `---
 date: %s
-title: "%s"
+title: %q
 slug: %s
 url: %s
 ---

--- a/site/content/docgen/yaml.md
+++ b/site/content/docgen/yaml.md
@@ -87,7 +87,7 @@ The `filePrepender` will prepend the return value given the full filepath to the
 ```go
 const fmTemplate = `---
 date: %s
-title: "%s"
+title: %q
 slug: %s
 url: %s
 ---


### PR DESCRIPTION
This PR simplifies code using %q rather than "%s".

Please take a look. Thanks.