### PR TITLE
fix: stderr/stdout handling when custom err/out is defined (SetErrFallback)

### DIFF
--- a/command.go
+++ b/command.go
@@ -188,6 +188,11 @@ type Command struct {
 	// errWriter is a writer defined by the user that replaces stderr
 	errWriter io.Writer
 
+	// outFallbackWriter is a writer defined by the user that is used if outWriter is nil
+	outFallbackWriter io.Writer
+	// errFallbackWriter is a writer defined by the user that is used if errWriter is nil
+	errFallbackWriter io.Writer
+
 	// FParseErrWhitelist flag parse errors to be ignored
 	FParseErrWhitelist FParseErrWhitelist
 
@@ -279,14 +284,28 @@ func (c *Command) SetOutput(output io.Writer) {
 
 // SetOut sets the destination for usage messages.
 // If newOut is nil, os.Stdout is used.
+// Deprecated: Use SetOutFallback and/or SetErrFallback instead (see https://github.com/spf13/cobra/issues/1708)
 func (c *Command) SetOut(newOut io.Writer) {
 	c.outWriter = newOut
 }
 
 // SetErr sets the destination for error messages.
 // If newErr is nil, os.Stderr is used.
+// Deprecated: Use SetOutFallback and/or SetErrFallback instead (see https://github.com/spf13/cobra/issues/1708)
 func (c *Command) SetErr(newErr io.Writer) {
 	c.errWriter = newErr
+}
+
+// SetOutFallback sets the destination for usage messages when SetOut() was not used.
+// If newOut is nil, os.Stdout is used.
+func (c *Command) SetOutFallback(newOut io.Writer) {
+	c.outFallbackWriter = newOut
+}
+
+// SetErrFallback sets the destination for error messages when SetErr() was not used.
+// If newErr is nil, os.Stderr is used.
+func (c *Command) SetErrFallback(newErr io.Writer) {
+	c.errFallbackWriter = newErr
 }
 
 // SetIn sets the source for input data
@@ -363,9 +382,10 @@ func (c *Command) OutOrStdout() io.Writer {
 	return c.getOut(os.Stdout)
 }
 
-// OutOrStderr returns output to stderr
+// OutOrStderr returns output to stderr.
+// Deprecated: Use OutOrStdout or ErrOrStderr instead
 func (c *Command) OutOrStderr() io.Writer {
-	return c.getOut(os.Stderr)
+	return c.getOutFallbackToErr(os.Stderr)
 }
 
 // ErrOrStderr returns output to stderr
@@ -382,6 +402,9 @@ func (c *Command) getOut(def io.Writer) io.Writer {
 	if c.outWriter != nil {
 		return c.outWriter
 	}
+	if c.outFallbackWriter != nil {
+		return c.outFallbackWriter
+	}
 	if c.HasParent() {
 		return c.parent.getOut(def)
 	}
@@ -392,8 +415,27 @@ func (c *Command) getErr(def io.Writer) io.Writer {
 	if c.errWriter != nil {
 		return c.errWriter
 	}
+	if c.errFallbackWriter != nil {
+		return c.errFallbackWriter
+	}
 	if c.HasParent() {
 		return c.parent.getErr(def)
+	}
+	return def
+}
+
+// getOutFallbackToErr should only be used inside OutOrStderr.
+// Deprecated: this function exists to allow for backwards compatibility only
+// (see https://github.com/spf13/cobra/issues/1708)
+func (c *Command) getOutFallbackToErr(def io.Writer) io.Writer {
+	if c.outWriter != nil {
+		return c.outWriter
+	}
+	if c.errFallbackWriter != nil {
+		return c.errFallbackWriter
+	}
+	if c.HasParent() {
+		return c.parent.getOutFallbackToErr(def)
 	}
 	return def
 }


### PR DESCRIPTION
Fix: Allows capturing cmd output and errors
The current behavior of OutOrStderr() is inconsistent. This PR introduces a feature to achieve the desired behavior without causing any breaking changes.

---

If I understood correctly, the problem is caused by using `OutOrStderr()`, which uses `out` but falls back to `err`.
If you don't use the new `SetOutFallback / SetErrFallback`, the behavior remains the same as before.
However, by replacing `SetErr` with `SetErrFallback`, we can achieve the desired behavior.

I'm not sure if `SetOutFallback` should be included. I added it for consistency, but it is not necessary in this context.
@mislav, please let me know what you think, as you were on the frontline with this one.

---

Closes: https://github.com/spf13/cobra/issues/1708
