### PR TITLE
Let the commands store flagComp functions internally (and avoid global state)

### DIFF
--- a/bash_completions.go
+++ b/bash_completions.go
@@ -534,9 +534,9 @@ func writeLocalNonPersistentFlag(buf io.StringWriter, flag *pflag.Flag) {
 
 // prepareCustomAnnotationsForFlags setup annotations for go completions for registered flags
 func prepareCustomAnnotationsForFlags(cmd *Command) {
-	flagCompletionMutex.RLock()
-	defer flagCompletionMutex.RUnlock()
-	for flag := range flagCompletionFunctions {
+	cmd.flagCompletionMutex.RLock()
+	defer cmd.flagCompletionMutex.RUnlock()
+	for flag := range cmd.flagCompletionFunctions {
 		// Make sure the completion script calls the __*_go_custom_completion function for
 		// every registered flag.  We need to do this here (and not when the flag was registered
 		// for completion) so that we can know the root command name for the prefix
@@ -644,6 +644,7 @@ func writeCmdAliases(buf io.StringWriter, cmd *Command) {
 	WriteStringAndCheck(buf, `    fi`)
 	WriteStringAndCheck(buf, "\n")
 }
+
 func writeArgAliases(buf io.StringWriter, cmd *Command) {
 	WriteStringAndCheck(buf, "    noun_aliases=()\n")
 	sort.Strings(cmd.ArgAliases)

--- a/command.go
+++ b/command.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	flag "github.com/spf13/pflag"
 )
@@ -157,6 +158,13 @@ type Command struct {
 	// globNormFunc is the global normalization function
 	// that we can use on every pflag set and children commands
 	globNormFunc func(f *flag.FlagSet, name string) flag.NormalizedName
+
+	// flagsCompletions contrains completions for arbitrary lists of flags.
+	// Those flags may or may not actually strictly belong to the command in the function,
+	// but registering completions for them through the command allows for garbage-collecting.
+	flagCompletionFunctions map[*flag.Flag]func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
+	// lock for reading and writing from flagCompletionFunctions
+	flagCompletionMutex *sync.RWMutex
 
 	// usageFunc is usage func defined by user.
 	usageFunc func(*Command) error


### PR DESCRIPTION

### Problem

Currently, flag completion functions are a global map, preventing garbage collection
to work properly, especially if the commands using these funcs are garbage-collected themselves.
This might happen if commands are declared, bound and used through yielder functions.

This is also produce more coherent API usage in different cases:
- Declare flag completions close to where you declare the flags themselves, 
- When a code path happens to have access to a given command, it knows how to bind flags to it (in a more dynamic manner, for that respect).

In addition, and while in theory nothing prevents a given command `cmd1` to be called with
`RegisterFlagsCompletion(cmd2Flag)`, and still store and work correctly with another command
flag.

### Changes

Add the old `flagCompletionFunctions` map and its mutex as unexported fields of the `Command`.

