### PR TITLE
ci: test golang 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20'
+          go-version: '^1.21'
           check-latest: true
           cache: true
 
@@ -67,6 +67,7 @@ jobs:
         - 18
         - 19
         - 20
+        - 21
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:


### PR DESCRIPTION
Golang 1.21 was released: https://go.dev/blog/go1.21