### PR TITLE
Add notes to doc about the execution condition of *PreRun and *PostRun functions

### DIFF
--- a/command.go
+++ b/command.go
@@ -115,6 +115,8 @@ type Command struct {
 	//   * PostRun()
 	//   * PersistentPostRun()
 	// All functions get the same args, the arguments after the command name.
+	// The *PreRun and *PostRun functions will only be executed if the Run function of the current
+	// command has been declared.
 	//
 	// PersistentPreRun: children of this command will inherit and execute.
 	PersistentPreRun func(cmd *Command, args []string)

--- a/site/content/user_guide.md
+++ b/site/content/user_guide.md
@@ -604,7 +604,7 @@ The Prefix, `Error:` can be customized using the `cmd.SetErrPrefix(s string)` fu
 
 ## PreRun and PostRun Hooks
 
-It is possible to run functions before or after the main `Run` function of your command. The `PersistentPreRun` and `PreRun` functions will be executed before `Run`. `PersistentPostRun` and `PostRun` will be executed after `Run`.  The `Persistent*Run` functions will be inherited by children if they do not declare their own.  These functions are run in the following order:
+It is possible to run functions before or after the main `Run` function of your command. The `PersistentPreRun` and `PreRun` functions will be executed before `Run`. `PersistentPostRun` and `PostRun` will be executed after `Run`.  The `Persistent*Run` functions will be inherited by children if they do not declare their own.  The `*PreRun` and `*PostRun` functions will only be executed if the `Run` function of the current command has been declared.  These functions are run in the following order:
 
 - `PersistentPreRun`
 - `PreRun`


### PR DESCRIPTION
According to #2039, As per code, if the current command does not have a `Run` function defined, the `PersistentPreRun`, `PreRun`, `PostRun`, or `PersistentPostRun` functions will not be executed at the current command. It's true for `PersistentPreRun` and `PersistentPostRun` functions that child commands inherited from the parent. I added a note to the function comment and user guide to clarify this.