### PR TITLE
Fix documentation inconsistencies

### DIFF
--- a/command.go
+++ b/command.go
@@ -568,7 +568,7 @@ Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCo
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-Global Flags:
+Flags inherited from parent commands:
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}

--- a/command_test.go
+++ b/command_test.go
@@ -921,7 +921,7 @@ Flags:
       --foo    child foo usage
   -h, --help   help for child
 
-Global Flags:
+Flags inherited from parent commands:
       --bar   parent bar usage
 `
 

--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -31,7 +31,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
-		buf.WriteString("### Options\n\n```\n")
+		buf.WriteString("### Flags\n\n```\n")
 		flags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}
@@ -39,7 +39,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	parentFlags := cmd.InheritedFlags()
 	parentFlags.SetOutput(buf)
 	if parentFlags.HasAvailableFlags() {
-		buf.WriteString("### Options inherited from parent commands\n\n```\n")
+		buf.WriteString("### Flags inherited from parent commands\n\n```\n")
 		parentFlags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}

--- a/doc/md_docs_test.go
+++ b/doc/md_docs_test.go
@@ -39,7 +39,7 @@ func TestGenMdDoc(t *testing.T) {
 	checkStringContains(t, output, rootCmd.Short)
 	checkStringContains(t, output, echoSubCmd.Short)
 	checkStringOmits(t, output, deprecatedCmd.Short)
-	checkStringContains(t, output, "Options inherited from parent commands")
+	checkStringContains(t, output, "Flags inherited from parent commands")
 }
 
 func TestGenMdDocWithNoLongOrSynopsis(t *testing.T) {
@@ -52,7 +52,7 @@ func TestGenMdDocWithNoLongOrSynopsis(t *testing.T) {
 
 	checkStringContains(t, output, dummyCmd.Example)
 	checkStringContains(t, output, dummyCmd.Short)
-	checkStringContains(t, output, "Options inherited from parent commands")
+	checkStringContains(t, output, "Flags inherited from parent commands")
 	checkStringOmits(t, output, "### Synopsis")
 }
 
@@ -76,7 +76,7 @@ func TestGenMdNoHiddenParents(t *testing.T) {
 	checkStringContains(t, output, rootCmd.Short)
 	checkStringContains(t, output, echoSubCmd.Short)
 	checkStringOmits(t, output, deprecatedCmd.Short)
-	checkStringOmits(t, output, "Options inherited from parent commands")
+	checkStringOmits(t, output, "Flags inherited from parent commands")
 }
 
 func TestGenMdNoTag(t *testing.T) {


### PR DESCRIPTION
This fixes inconsistencies between the command help template and what is being generated as markdown.

Currently, the help template prints "Flags" and "Global Flags" when printing help for flags, while in the markdown, the two are printed as "Options" and "Options inherited from parent commands".

This Pull Request fixes this inconsistency, so that they both print the same. As for the actual formulation, I opted for using "Flags" and "Flags inherited from parent commands". In the latter case, I think this formulation actually represents it better than the previous "Global flags", since flags printed there are in fact inherited and not necessarily global in scope. This is, of course, up for discussion what to actually use.