### PR TITLE
Powershell completion alias handling

### DIFF
--- a/powershell_completions.go
+++ b/powershell_completions.go
@@ -279,7 +279,12 @@ filter __%[1]s_escapeStringWithSpecialChars {
     }
 }
 
-Register-ArgumentCompleter -CommandName '%[1]s' -ScriptBlock ${__%[2]sCompleterBlock}
+# Register the completer for the command and for all aliases of the command
+'%[1]s', (Get-Alias -Definition '%[1]s' -ErrorAction Ignore).Name | ForEach-Object {
+    if ($_) {
+        Register-ArgumentCompleter -CommandName $_ -ScriptBlock ${__%[2]sCompleterBlock}
+    }
+}
 `, name, nameForVar, compCmd,
 		ShellCompDirectiveError, ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp,
 		ShellCompDirectiveFilterFileExt, ShellCompDirectiveFilterDirs, ShellCompDirectiveKeepOrder, activeHelpEnvVar(name)))


### PR DESCRIPTION
Currently the Powershell completion generator registers the completion for the default command name. Any aliases of the command will not have completion enabled.  (e.g. `k -> kubectl`)

This change will include code to register the completer for all current aliases of the command in addition to the command itself.