### PR TITLE
Improve API to get flag completion function

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -145,23 +145,18 @@ func (c *Command) RegisterFlagCompletionFunc(flagName string, f func(cmd *Comman
 	return nil
 }
 
-// GetFlagCompletion returns the completion function for the given flag, if available.
-func GetFlagCompletion(flag *pflag.Flag) (func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective), bool) {
+// GetFlagCompletionFunc returns the completion function for the given flag of the command, if available.
+func (c *Command) GetFlagCompletionFunc(flagName string) (func(*Command, []string, string) ([]string, ShellCompDirective), bool) {
+	flag := c.Flag(flagName)
+	if flag == nil {
+		return nil, false
+	}
+
 	flagCompletionMutex.RLock()
 	defer flagCompletionMutex.RUnlock()
 
 	completionFunc, exists := flagCompletionFunctions[flag]
 	return completionFunc, exists
-}
-
-// GetFlagCompletionByName returns the completion function for the given flag in the command by name, if available.
-func (c *Command) GetFlagCompletionByName(flagName string) (func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective), bool) {
-	flag := c.Flags().Lookup(flagName)
-	if flag == nil {
-		return nil, false
-	}
-
-	return GetFlagCompletion(flag)
 }
 
 // Returns a string listing the different directive enabled in the specified parameter


### PR DESCRIPTION
With #1943 we aimed to allow programs to have access to flag completion functions.
There were two issues with this change:
1. it was not handling persistent flags (I missed that in the review)
2. it was not similar to the existing `c.RegisterFlagCompletionFunc()` because it provided a global function, which is not as future proof.

This PR proposes a simpler API that matches the `c.RegisterFlagCompletionFunc()` API.  By removing the global function `GetFlagCompletion()` we are more future proof if we ever move from a global map of flag completion functions to something associated with the command.

The commit also makes this API work with persistent flags by using `c.Flag(flagName)` instead of `c.Flags().Lookup(flagName)`.

The commit also adds unit tests.

cc @jpmcb @avirtopeanu-ionos @maxlandon