### PR TITLE
fish completions: fix double-evaluation of commandline

### DIFF
--- a/fish_completions.go
+++ b/fish_completions.go
@@ -45,7 +45,7 @@ function __%[1]s_perform_completion
     __%[1]s_debug "Starting __%[1]s_perform_completion"
 
     # Extract all args except the last one
-    set -l args (commandline -opc)
+    set -l args (commandline -opc | string escape)
     # Extract the last arg and escape it in case it is a space
     set -l lastArg (string escape -- (commandline -ct))
 


### PR DESCRIPTION
We capture the commandline tokens using fish's "commandline --tokenize" (-o).
That function turns

	echo 'some argument $(123)'

into two arguments while removing the quotes

	echo
	some argument $(123)

Later we pass "some argument $(123)" without quotes to the shell's
"eval". This is wrong and causes spurious evaluation of the parenthesis
as command substitution.

Fix this by escaping the arguments.

The downside of this change is that things like "$HOME" or "~" will
no longer be escaped. Changing this requires changes in fish, which
I'm working on.

Reproduce the issue by pasting the completion script at
https://github.com/fish-shell/fish-shell/issues/10194#issuecomment-1879563545
to a file "grafana-manager.fish" and running

	function grafana-manager; end
	source grafana-manager.fish

Then type (without pressing Enter)

	grafana-manager public-dashboards delete --organization-id 3 --dashboard-name "k8s (public)" <TAB>

Fixes https://github.com/fish-shell/fish-shell/issues/10194
