### PR TITLE
Add Taikun CLI to list of projects

### DIFF
--- a/site/content/projects_using_cobra.md
+++ b/site/content/projects_using_cobra.md
@@ -57,6 +57,7 @@
 - [Scaleway CLI](https://github.com/scaleway/scaleway-cli)
 - [Sia](https://github.com/SiaFoundation/siad)
 - [Skaffold](https://skaffold.dev/)
+- [Taikun](https://taikun.cloud/)
 - [Tendermint](https://github.com/tendermint/tendermint)
 - [Twitch CLI](https://github.com/twitchdev/twitch-cli)
 - [UpCloud CLI (`upctl`)](https://github.com/UpCloudLtd/upcloud-cli)


### PR DESCRIPTION
I'd like to add Taikun to the list o CLIs that use the Cobra framework.
The ClI repo is opensource and can be found [here](https://github.com/itera-io/taikun-cli)

Thanks.