### PR TITLE
ci: test golang 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: '^1.22'
           check-latest: true
           cache: true
 
@@ -66,6 +66,7 @@ jobs:
         - 19
         - 20
         - 21
+        - 22
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:


### PR DESCRIPTION
Golang 1.22 was released: https://go.dev/blog/go1.22

Any plans for a release soon?