### PR TITLE
Update README.md with proper install command as earlier cmd is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Using Cobra is easy. First, use `go get` to install the latest version
 of the library.
 
 ```
-go get -u github.com/spf13/cobra@latest
+go install github.com/spf13/cobra@latest
 ```
 
 Next, include Cobra in your application:


### PR DESCRIPTION
This is a small PR for the installation step update.  Earlier go get command is deprecated and no longer supported - https://go.dev/doc/go-get-install-deprecation.

Please feel free to close this if its already being done as part of some other PR - cheers 👋 