### PR TITLE
Fix zsh completion for commands which output is influenced by the permissions it is run with.

### DIFF
--- a/command.go
+++ b/command.go
@@ -254,6 +254,12 @@ type Command struct {
 	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
 	// Must be > 0.
 	SuggestionsMinimumDistance int
+
+	// InfluencedByPermissions indicates that the output is influenced by the
+	// permission it is run with. Thus, when a command such as sudo appears on the
+	// command-line, it will use commands like sudo or doas to gain extra privileges
+	// when retrieving information for completion. Available only to Zsh.
+	InfluencedByPermissions bool
 }
 
 // Context returns underlying command context. If command was executed

--- a/zsh_completions_test.go
+++ b/zsh_completions_test.go
@@ -31,3 +31,15 @@ func TestZshCompletionWithActiveHelp(t *testing.T) {
 	activeHelpVar := activeHelpEnvVar(c.Name())
 	checkOmit(t, output, fmt.Sprintf("%s=0", activeHelpVar))
 }
+
+func TestZshCompletionWithInfluencedPermission(t *testing.T) {
+	c := &Command{Use: "c", Run: emptyRun, InfluencedByPermissions: true}
+
+	buf := new(bytes.Buffer)
+	assertNoErr(t, c.GenZshCompletion(buf))
+	output := buf.String()
+
+	// check that related commands are being generated
+	check(t, output, fmt.Sprintf(ZstyleGainPrivileges, c.Name()))
+	check(t, output, fmt.Sprintf("_call_program -p %s-tag", c.Name()))
+}


### PR DESCRIPTION
This PR originates from when using `nerdctl` (which built its CLI with cobra), the auto-completion will not work for unprivileged users, even if they have sudo permission and are trying to tab out the command with `sudo` prefix.

For example, `sudo nerdctl <tab>` will fallback to file completion. That is because the hidden `nerdctl __complete ""` is run **without** sudo permission under the hood and fails.

This patch will enable the correct permission to be passed to the underlying hidden `__complete` command, thus correctly handling the case for commands which output is influenced by the permissions it is run with.

Currently, this fix is only available to zsh. And I have put it behind a switch that defaults to false.

### Before
```bash
$ sudo nerdctl
completing filename
file1   file2   image1
```

### After
```bash
$ sudo nerdctl
completing completions
apparmor    -- Manage AppArmor profiles
attach      -- Attach stdin, stdout, and stderr to a running container.
build       -- Build an image from a Dockerfile. Needs buildkitd to be runni
builder     -- Manage builds
...
```

```
$ nerdctl
completing filename
file1   file2   image1
```