### PR TITLE
Remove fully inactivated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters:
     #- scopelint
     #- staticcheck
     #- structcheck ! deprecated since v1.49.0; replaced by 'unused'
-    #- stylecheck
+    - stylecheck
     #- typecheck
     - unconvert
     #- unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,16 +33,13 @@ linters:
     #- gocyclo
     #- gofmt
     - goimports
-    - golint
     #- gomnd
     #- goprintffuncname
     #- gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     #- lll
-    - maligned
     - megacheck
     #- misspell
     #- nakedret

--- a/command.go
+++ b/command.go
@@ -875,7 +875,7 @@ func (c *Command) ArgsLenAtDash() int {
 
 func (c *Command) execute(a []string) (err error) {
 	if c == nil {
-		return fmt.Errorf("Called Execute() on a nil Command")
+		return fmt.Errorf("called Execute() on a nil Command")
 	}
 
 	if len(c.Deprecated) > 0 {

--- a/completions.go
+++ b/completions.go
@@ -298,7 +298,7 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 	}
 	if err != nil {
 		// Unable to find the real command. E.g., <program> someInvalidCmd <TAB>
-		return c, []string{}, ShellCompDirectiveDefault, fmt.Errorf("Unable to find a command for arguments: %v", trimmedArgs)
+		return c, []string{}, ShellCompDirectiveDefault, fmt.Errorf("unable to find a command for arguments: %v", trimmedArgs)
 	}
 	finalCmd.ctx = c.ctx
 


### PR DESCRIPTION
"interfaces", "maligned", and "golint" do not produce any report and cause golangci-lint to fail as we can see in the CI.

- Remove "interfaces" and "maligned" linters that have no replacement.
- Replace golint with stylecheck