### PR TITLE
Address golangci-lint deprecation warnings, enable some more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,6 @@ linters:
     - errcheck
     #- exhaustive
     #- funlen
-    - gas
     #- gochecknoinits
     - goconst
     - gocritic
@@ -35,19 +34,18 @@ linters:
     - goimports
     #- gomnd
     #- goprintffuncname
-    #- gosec
+    - gosec
     - gosimple
     - govet
     - ineffassign
     #- lll
-    - megacheck
     #- misspell
     #- nakedret
     #- noctx
     #- nolintlint
     #- rowserrcheck
     #- scopelint
-    #- staticcheck
+    - staticcheck
     #- structcheck ! deprecated since v1.49.0; replaced by 'unused'
     - stylecheck
     #- typecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
     - goconst
     - gocritic
     #- gocyclo
-    #- gofmt
+    - gofmt
     - goimports
     #- gomnd
     #- goprintffuncname
@@ -39,10 +39,10 @@ linters:
     - govet
     - ineffassign
     #- lll
-    #- misspell
+    - misspell
     #- nakedret
     #- noctx
-    #- nolintlint
+    - nolintlint
     #- rowserrcheck
     #- scopelint
     - staticcheck

--- a/command.go
+++ b/command.go
@@ -1460,7 +1460,6 @@ func (c *Command) UseLine() string {
 
 // DebugFlags used to determine which flags have been assigned to which commands
 // and which persist.
-// nolint:goconst
 func (c *Command) DebugFlags() {
 	c.Println("DebugFlags called on", c.Name())
 	var debugflags func(*Command)


### PR DESCRIPTION
See individual commit messages for details.