### PR TITLE
feat: #1140 adding GenMarkdownTreeCustomWithFooter method

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -156,3 +156,34 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 	}
 	return nil
 }
+
+func GenMarkdownTreeCustomWithFooter(
+	cmd *cobra.Command, dir string, filePrepender, fileAppender, linkHandler func(string) string) error {
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
+			continue
+		}
+		if err := GenMarkdownTreeCustomWithFooter(c, dir, filePrepender, fileAppender, linkHandler); err != nil {
+			return err
+		}
+	}
+
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + markdownExtension
+	filename := filepath.Join(dir, basename)
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
+		return err
+	}
+	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(f, fileAppender(filename)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/doc/md_docs_test.go
+++ b/doc/md_docs_test.go
@@ -133,7 +133,7 @@ func TestGenMdTreeCustomWithFooter(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	prepender := func(s string) string { return "Prepended" }
-	appender := func(s string) string { return "Postpended" }
+	appender := func(s string) string { return "Appended" }
 	identity := func(s string) string { return s }
 
 	if err := GenMarkdownTreeCustomWithFooter(rootCmd, tmpdir, prepender, appender, identity); err != nil {
@@ -143,17 +143,17 @@ func TestGenMdTreeCustomWithFooter(t *testing.T) {
 	gotRoot := fileContents(t, tmpdir, "root.md")
 	checkStringContains(t, gotRoot, "Prepended")
 	checkStringContains(t, gotRoot, rootCmd.Long)
-	checkStringContains(t, gotRoot, "Postpended")
+	checkStringContains(t, gotRoot, "Appended")
 
 	gotEcho := fileContents(t, tmpdir, "root_echo.md")
 	checkStringContains(t, gotEcho, "Prepended")
 	checkStringContains(t, gotEcho, echoCmd.Long)
-	checkStringContains(t, gotEcho, "Postpended")
+	checkStringContains(t, gotEcho, "Appended")
 
 	gotEchoSub := fileContents(t, tmpdir, "root_echo_echosub.md")
 	checkStringContains(t, gotEchoSub, "Prepended")
 	checkStringContains(t, gotEchoSub, echoSubCmd.Long)
-	checkStringContains(t, gotEchoSub, "Postpended")
+	checkStringContains(t, gotEchoSub, "Appended")
 }
 
 func fileContents(t *testing.T, dir, filename string) string {

--- a/doc/md_docs_test.go
+++ b/doc/md_docs_test.go
@@ -124,3 +124,42 @@ func BenchmarkGenMarkdownToFile(b *testing.B) {
 		}
 	}
 }
+
+func TestGenMdTreeCustomWithFooter(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test-gen-md-tree")
+	if err != nil {
+		t.Fatalf("Failed to create tmpdir: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	prepender := func(s string) string { return "Prepended" }
+	appender := func(s string) string { return "Postpended" }
+	identity := func(s string) string { return s }
+
+	if err := GenMarkdownTreeCustomWithFooter(rootCmd, tmpdir, prepender, appender, identity); err != nil {
+		t.Fatalf("GenMarkdownTree failed: %v", err)
+	}
+
+	gotRoot := fileContents(t, tmpdir, "root.md")
+	checkStringContains(t, gotRoot, "Prepended")
+	checkStringContains(t, gotRoot, rootCmd.Long)
+	checkStringContains(t, gotRoot, "Postpended")
+
+	gotEcho := fileContents(t, tmpdir, "root_echo.md")
+	checkStringContains(t, gotEcho, "Prepended")
+	checkStringContains(t, gotEcho, echoCmd.Long)
+	checkStringContains(t, gotEcho, "Postpended")
+
+	gotEchoSub := fileContents(t, tmpdir, "root_echo_echosub.md")
+	checkStringContains(t, gotEchoSub, "Prepended")
+	checkStringContains(t, gotEchoSub, echoSubCmd.Long)
+	checkStringContains(t, gotEchoSub, "Postpended")
+}
+
+func fileContents(t *testing.T, dir, filename string) string {
+	contents, err := ioutil.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		t.Fatalf("Error loading file %q: %v ", filename, err)
+	}
+	return string(contents)
+}


### PR DESCRIPTION
These changes are to address #1140. I opted to add a net new method so we do not introduce a breaking change to the existing API. Anyone that wants the footer can refactor accordingly. Thanks to @sonjoonho for the previous PR that served as inspiration for this one.