### PR TITLE
closes #2130 new command flag ErrorOnUnknownSubcommand

### DIFF
--- a/command.go
+++ b/command.go
@@ -44,6 +44,10 @@ type Group struct {
 	Title string
 }
 
+// ErrUnknownSubcommand is returned by Command.Execute() when the subcommand was not found.
+// Hereto, the ErrorOnUnknownSubcommand flag must be set true.
+var ErrUnknownSubcommand = errors.New("subcommand is unknown")
+
 // Command is just that, a command for your application.
 // E.g.  'go run ...' - 'run' is the command. Cobra requires
 // you to define the usage and description as part of your command
@@ -254,6 +258,17 @@ type Command struct {
 	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
 	// Must be > 0.
 	SuggestionsMinimumDistance int
+
+	// ErrorOnUnknownSubcommand controls the behavior of subcommand handling.
+	// When the flag is set true the behavior of Command.Execute() will change:
+	// If a sub-subcommand is not found ErrUnknownSubcommand will be returned on calling
+	// Command.Exec() instead of the old behavior where a nil error was sent.
+	// If the flag is false (default) the old behavior is performed.
+	// For this behavior the child subcommand must be nil.
+	// Example: in root/service/run - there would be an existing subcommand `run`
+	// in root/service/unknown - there would be an unknown subcommand `unknown` therefore returning an error
+	// `service` must have a nil Command.Run() function for this.
+	ErrorOnUnknownSubcommand bool
 }
 
 // Context returns underlying command context. If command was executed
@@ -923,9 +938,12 @@ func (c *Command) execute(a []string) (err error) {
 	}
 
 	if !c.Runnable() {
-		return flag.ErrHelp
+		if c.ErrorOnUnknownSubcommand {
+			return ErrUnknownSubcommand
+		} else {
+			return flag.ErrHelp
+		}
 	}
-
 	c.preRun()
 
 	defer c.postRun()


### PR DESCRIPTION
Proposed a backward compatible solution to https://github.com/spf13/cobra/issues/2130
Hereto a new flag `ErrorOnUnknownSubcommand` was added to the `Command` struct. Unit tests were added accordingly (TestSubcommandExecuteMissingSubcommand and TestSubcommandExecuteMissingSubcommandWithErrorOnUnknownSubcommand.