### PR TITLE
Capitalized letter

### DIFF
--- a/command.go
+++ b/command.go
@@ -1188,7 +1188,7 @@ func (c *Command) checkCommandGroups() {
 func (c *Command) InitDefaultHelpFlag() {
 	c.mergePersistentFlags()
 	if c.Flags().Lookup("help") == nil {
-		usage := "help for "
+		usage := "Help for "
 		name := c.displayName()
 		if name == "" {
 			usage += "this command"


### PR DESCRIPTION
I noticed that the default help message had this for flags:
```
Flags:
  -h, --help     help for [project-name]
  -t, --toggle   Help message for toggle
```
So I capitalized the letter so both lines would be the same and now it is as follows:
```
Flags:
  -h, --help     Help for [project-name]
  -t, --toggle   Help message for toggle
```