### PR TITLE
Fix deprecation comment for Command.SetOutput

### DIFF
--- a/command.go
+++ b/command.go
@@ -281,6 +281,7 @@ func (c *Command) SetArgs(a []string) {
 
 // SetOutput sets the destination for usage and error messages.
 // If output is nil, os.Stderr is used.
+//
 // Deprecated: Use SetOut and/or SetErr instead
 func (c *Command) SetOutput(output io.Writer) {
 	c.outWriter = output


### PR DESCRIPTION
Deprecation comments should be at the start of a paragraph [1], and because of that have a whitespace above them [2];

> To signal that an identifier should not be used, add a paragraph to its
> doc comment that begins with Deprecated: followed by some information
> about the deprecation (...)

With the whitespace missing, some tools, including pkg.go.dev [3] don't detect it to be deprecated.

[1]: https://go.dev/wiki/Deprecated
[2]: https://go.dev/doc/comment#paragraphs
[3]: https://pkg.go.dev/github.com/spf13/cobra@v1.8.1#Command.SetOutput


Before this patch:

<img width="541" alt="Screenshot 2024-07-16 at 17 43 46" src="https://github.com/user-attachments/assets/1f42e696-f545-478e-96cf-33b8901f622b">
<img width="1344" alt="Screenshot 2024-07-16 at 17 43 37" src="https://github.com/user-attachments/assets/b4d058ce-a7f7-4545-a32d-98a2bbae2148">



With this patch:

<img width="503" alt="Screenshot 2024-07-16 at 17 43 18" src="https://github.com/user-attachments/assets/44102932-8652-4c1a-a191-158dce5a1268">
<img width="1344" alt="Screenshot 2024-07-16 at 17 43 27" src="https://github.com/user-attachments/assets/5f33c563-d3ec-4cb6-bad5-8574e0286e13">
