### PR TITLE
Make detection for test-binary more universal

### DIFF
--- a/command.go
+++ b/command.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -1079,7 +1078,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	args := c.args
 
 	// Workaround FAIL with "go test -v" or "cobra.test -test.v", see #155
-	if c.args == nil && filepath.Base(os.Args[0]) != "cobra.test" {
+	if c.args == nil && !isTesting() {
 		args = os.Args[1:]
 	}
 

--- a/command.go
+++ b/command.go
@@ -1077,7 +1077,10 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 
 	args := c.args
 
-	// Workaround FAIL with "go test -v" or "cobra.test -test.v", see #155
+	// If running unit tests, we don't want to take the os.Args, see #155 and #2173.
+	// For example, the following would fail:
+	//   go test -c -o foo.test
+	//   ./foo.test -test.run TestNoArgs
 	if c.args == nil && !isTesting() {
 		args = os.Args[1:]
 	}

--- a/command_go120.go
+++ b/command_go120.go
@@ -1,0 +1,30 @@
+// Copyright 2013-2023 The Cobra Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.21
+// +build !go1.21
+
+package cobra
+
+import (
+	"os"
+	"strings"
+)
+
+// based on golang.org/x/mod/internal/lazyregexp: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.19.0:internal/lazyregexp/lazyre.go;l=66
+var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
+
+func isTesting() bool {
+	return inTest
+}

--- a/command_go120.go
+++ b/command_go120.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 The Cobra Authors
+// Copyright 2013-2024 The Cobra Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ import (
 )
 
 // based on golang.org/x/mod/internal/lazyregexp: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.19.0:internal/lazyregexp/lazyre.go;l=66
+// For a non-go-test program which still has a name ending with ".test[.exe]", it will need to either:
+// 1- Use go >= 1.21, or
+// 2- call "rootCmd.SetArgs(os.Args[1:])" before calling "rootCmd.Execute()"
 var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
 
 func isTesting() bool {

--- a/command_go121.go
+++ b/command_go121.go
@@ -1,0 +1,24 @@
+// Copyright 2013-2023 The Cobra Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.21
+// +build go1.21
+
+package cobra
+
+import "testing"
+
+func isTesting() bool {
+	return testing.Testing()
+}

--- a/command_go121.go
+++ b/command_go121.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 The Cobra Authors
+// Copyright 2013-2024 The Cobra Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,5 +20,6 @@ package cobra
 import "testing"
 
 func isTesting() bool {
+	// Only available starting with go 1.21
 	return testing.Testing()
 }

--- a/command_test.go
+++ b/command_test.go
@@ -2839,3 +2839,16 @@ func TestUnknownFlagShouldReturnSameErrorRegardlessOfArgPosition(t *testing.T) {
 		})
 	}
 }
+
+// This tests verifies that when running unit tests, os.Args are not used.
+// This is because we don't want to process any arguments that are provided
+// by "go test"; instead, unit tests must set the arguments they need using
+// rootCmd.SetArgs().
+func TestNoOSArgsWhenTesting(t *testing.T) {
+	root := &Command{Use: "root", Run: emptyRun}
+	os.Args = append(os.Args, "--unknown")
+
+	if _, err := root.ExecuteC(); err != nil {
+		t.Errorf("error: %v", err)
+	}
+}


### PR DESCRIPTION
- relates to https://github.com/spf13/cobra/pull/155
- relates to https://github.com/docker/cli/pull/5224

When running tests in verbose mode (or other options), tests involving Cobra may fail if the test does not explicitly set Command.args to an empty slice; in this case, Cobra defaults to using `os.Args`, which will contain arguments passed to the test (such as `-v` (verbose)).

Commits e5762054c9a6429fa7c234897707d and 1ef0913976db2004980575ed815c3 implemented a workaround for this when running (unit) tests for Cobra itself, but this check is specifig to Cobra (checking for `cobra.test`), and don't work on Windows (which will have a `.exe` extension),

This patch implements a more universal check, so that users of Cobra as a module also benefit from this workaround.

go1.21 and up provides a `testing.Testing()` utility ([1]); as the Cobra module still supports Go1.16 and up, an alternative implementation was added for older versions, based on golang.org/x/mod/lazyregexp [2].

[1]: https://pkg.go.dev/testing#Testing
[2]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.19.0:internal/lazyregexp/lazyre.go;l=66-78