### PR TITLE
fix(completions): Complete map flags multiple times

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -401,8 +401,9 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 			doCompleteFlags := func(flag *pflag.Flag) {
 				if !flag.Changed ||
 					strings.Contains(flag.Value.Type(), "Slice") ||
-					strings.Contains(flag.Value.Type(), "Array") {
-					// If the flag is not already present, or if it can be specified multiple times (Array or Slice)
+					strings.Contains(flag.Value.Type(), "Array") ||
+					strings.HasPrefix(flag.Value.Type(), "stringTo") {
+					// If the flag is not already present, or if it can be specified multiple times (Array, Slice, or stringTo)
 					// we suggest it as a completion
 					completions = append(completions, getFlagNameCompletions(flag, toComplete)...)
 				}


### PR DESCRIPTION
Cobra currently allows Slice and Array flags to be completed multiple times, but it doesn't support multiple map flags like `stringToString` and `stringToInt` in the same way.

This PR adds support for map flags to be set multiple times.