### PR TITLE
Replace deprecated ioutil usage

### DIFF
--- a/doc/man_docs_test.go
+++ b/doc/man_docs_test.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,7 +167,7 @@ func TestManPrintFlagsHidesShortDeprecated(t *testing.T) {
 func TestGenManTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
 	header := &GenManHeader{Section: "2"}
-	tmpdir, err := ioutil.TempDir("", "test-gen-man-tree")
+	tmpdir, err := os.MkdirTemp("", "test-gen-man-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %s", err.Error())
 	}
@@ -219,7 +218,7 @@ func assertNextLineEquals(scanner *bufio.Scanner, expectedLine string) error {
 }
 
 func BenchmarkGenManToFile(b *testing.B) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/doc/md_docs_test.go
+++ b/doc/md_docs_test.go
@@ -16,7 +16,6 @@ package doc
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,7 +93,7 @@ func TestGenMdNoTag(t *testing.T) {
 
 func TestGenMdTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
-	tmpdir, err := ioutil.TempDir("", "test-gen-md-tree")
+	tmpdir, err := os.MkdirTemp("", "test-gen-md-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %v", err)
 	}
@@ -110,7 +109,7 @@ func TestGenMdTree(t *testing.T) {
 }
 
 func BenchmarkGenMarkdownToFile(b *testing.B) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/doc/rest_docs_test.go
+++ b/doc/rest_docs_test.go
@@ -16,7 +16,6 @@ package doc
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,7 +80,7 @@ func TestGenRSTNoTag(t *testing.T) {
 func TestGenRSTTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
 
-	tmpdir, err := ioutil.TempDir("", "test-gen-rst-tree")
+	tmpdir, err := os.MkdirTemp("", "test-gen-rst-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %s", err.Error())
 	}
@@ -97,7 +96,7 @@ func TestGenRSTTree(t *testing.T) {
 }
 
 func BenchmarkGenReSTToFile(b *testing.B) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/doc/yaml_docs_test.go
+++ b/doc/yaml_docs_test.go
@@ -17,7 +17,6 @@ package doc
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,7 +57,7 @@ func TestGenYamlNoTag(t *testing.T) {
 func TestGenYamlTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
 
-	tmpdir, err := ioutil.TempDir("", "test-gen-yaml-tree")
+	tmpdir, err := os.MkdirTemp("", "test-gen-yaml-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %s", err.Error())
 	}
@@ -85,7 +84,7 @@ func TestGenYamlDocRunnable(t *testing.T) {
 }
 
 func BenchmarkGenYamlToFile(b *testing.B) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/site/content/docgen/md.md
+++ b/site/content/docgen/md.md
@@ -35,7 +35,7 @@ package main
 
 import (
 	"log"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
@@ -45,7 +45,7 @@ import (
 )
 
 func main() {
-	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, io.Discard, io.Discard)
 	err := doc.GenMarkdownTree(kubectl, "./")
 	if err != nil {
 		log.Fatal(err)

--- a/site/content/docgen/rest.md
+++ b/site/content/docgen/rest.md
@@ -35,7 +35,7 @@ package main
 
 import (
 	"log"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
@@ -45,7 +45,7 @@ import (
 )
 
 func main() {
-	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, io.Discard, io.Discard)
 	err := doc.GenReSTTree(kubectl, "./")
 	if err != nil {
 		log.Fatal(err)

--- a/site/content/docgen/yaml.md
+++ b/site/content/docgen/yaml.md
@@ -34,7 +34,7 @@ This program can actually generate docs for the kubectl command in the kubernete
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -45,7 +45,7 @@ import (
 )
 
 func main() {
-	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, io.Discard, io.Discard)
 	err := doc.GenYamlTree(kubectl, "./")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Fixing golangci-lint errors[1]:

    Error: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of
    Go 1.16, the same functionality is now provided by package [io] or
    package [os], and those implementations should be preferred in new
    code. See the specific function documentation for details.
    (staticcheck)

[1] https://github.com/spf13/cobra/actions/runs/10535452454/job/29194442289?pr=2180