### PR TITLE
Closes #2193

### DIFF
--- a/command.go
+++ b/command.go
@@ -1109,11 +1109,8 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		cmd.commandCalledAs.name = cmd.Name()
 	}
 
-	// We have to pass global context to children command
-	// if context is present on the parent command.
-	if cmd.ctx == nil {
-		cmd.ctx = c.ctx
-	}
+	// Copy context
+	cmd.ctx = c.ctx
 
 	err = cmd.execute(flags)
 	if err != nil {


### PR DESCRIPTION
Context is not copied from parent to child
Comment on code states copy if parent has context but code implements copy if child doesn't have context
Fix makes behaviour consistent between root and sub commands w.r.t. contexts