### PR TITLE
completion: improve detection for flags that accept multiple values

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -270,6 +270,14 @@ func (c *Command) initCompleteCmd(args []string) {
 	}
 }
 
+// sliceValue is a reduced version of [pflag.SliceValue]. It is used to detect
+// flags that accept multiple values and therefore can provide completion
+// multiple times.
+type sliceValue interface {
+	// GetSlice returns the flag value list as an array of strings.
+	GetSlice() []string
+}
+
 func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDirective, error) {
 	// The last argument, which is not completely typed by the user,
 	// should not be part of the list of arguments
@@ -399,7 +407,10 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 		// If we have not found any required flags, only then can we show regular flags
 		if len(completions) == 0 {
 			doCompleteFlags := func(flag *pflag.Flag) {
+				_, acceptsMultiple := flag.Value.(sliceValue)
+
 				if !flag.Changed ||
+					acceptsMultiple ||
 					strings.Contains(flag.Value.Type(), "Slice") ||
 					strings.Contains(flag.Value.Type(), "Array") ||
 					strings.HasPrefix(flag.Value.Type(), "stringTo") {

--- a/completions.go
+++ b/completions.go
@@ -270,10 +270,10 @@ func (c *Command) initCompleteCmd(args []string) {
 	}
 }
 
-// sliceValue is a reduced version of [pflag.SliceValue]. It is used to detect
+// SliceValue is a reduced version of [pflag.SliceValue]. It is used to detect
 // flags that accept multiple values and therefore can provide completion
 // multiple times.
-type sliceValue interface {
+type SliceValue interface {
 	// GetSlice returns the flag value list as an array of strings.
 	GetSlice() []string
 }
@@ -407,13 +407,13 @@ func (c *Command) getCompletions(args []string) (*Command, []string, ShellCompDi
 		// If we have not found any required flags, only then can we show regular flags
 		if len(completions) == 0 {
 			doCompleteFlags := func(flag *pflag.Flag) {
-				_, acceptsMultiple := flag.Value.(sliceValue)
-
-				if !flag.Changed ||
-					acceptsMultiple ||
+				_, acceptsMultiple := flag.Value.(SliceValue)
+				acceptsMultiple = acceptsMultiple ||
 					strings.Contains(flag.Value.Type(), "Slice") ||
 					strings.Contains(flag.Value.Type(), "Array") ||
-					strings.HasPrefix(flag.Value.Type(), "stringTo") {
+					strings.HasPrefix(flag.Value.Type(), "stringTo")
+
+				if !flag.Changed || acceptsMultiple {
 					// If the flag is not already present, or if it can be specified multiple times (Array, Slice, or stringTo)
 					// we suggest it as a completion
 					completions = append(completions, getFlagNameCompletions(flag, toComplete)...)

--- a/completions_test.go
+++ b/completions_test.go
@@ -675,7 +675,7 @@ func TestFlagNameCompletionInGoWithDesc(t *testing.T) {
 // but does not include "Slice" or "Array" in its "Type" string.
 type customMultiString []string
 
-var _ sliceValue = (*customMultiString)(nil)
+var _ SliceValue = (*customMultiString)(nil)
 
 func (s *customMultiString) String() string {
 	return fmt.Sprintf("%v", *s)


### PR DESCRIPTION
The completion code attempts to detect whether a flag can be specified more than once, and therefore should provide completion even if already set.

Currently, this code depends on conventions used in the pflag package, which uses an "Array" or "Slice" suffix or for some types a "stringTo" prefix.

Cobra allows custom value types to be used, which may not use the same convention for naming, and therefore currently aren't detected to allow multiple values.

The pflag module defines a [SliceValue] interface, which is implemented by the Slice and Array value types it provides (unfortunately, it's not currently implemented by the "stringTo" values).

This patch adds a reduced interface based on the [SliceValue] interface mentioned above to allow detecting Value-types that accept multiple values. Custom types can implement this interface to make completion work for those values.

I deliberately used a reduced interface to keep the requirements for this detection as low as possible, without enforcing the other methods defined in the interface (Append, Replace) which may not apply to all custom types.

Future improvements can likely still be made, considering either implementing the SliceValue interface for the "stringTo" values or defining a separate "MapValue" interface for those types.

Possibly providing the reduced interface as part of the pflag module and to export it.

[SliceValue]: https://github.com/spf13/pflag/blob/d5e0c0615acee7028e1e2740a11102313be88de1/flag.go#L193-L203