### PR TITLE
Add aliases to doc markdown

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -72,6 +72,11 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.UseLine()))
 	}
 
+	if len(cmd.Aliases) > 0 {
+		buf.WriteString("### Aliases\n\n")
+		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.NameAndAliases()))
+	}
+
 	if len(cmd.Example) > 0 {
 		buf.WriteString("### Examples\n\n")
 		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.Example))


### PR DESCRIPTION
Adds aliases to generated markdown docs, similar to how it's handled in the default help deplate:

```
Aliases:
  {{.NameAndAliases}}{{end}}{{if .HasExample}}
```