### PR TITLE
fix(bash): nounset unbound file filter variable on empty extension

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -146,7 +146,7 @@ __%[1]s_process_completion_results() {
 
     if (((directive & shellCompDirectiveFilterFileExt) != 0)); then
         # File extension filtering
-        local fullFilter filter filteringCmd
+        local fullFilter="" filter filteringCmd
 
         # Do not use quotes around the $completions variable or else newline
         # characters will be kept.


### PR DESCRIPTION
Happens at least if a flag is marked as filename, with "" given as extensions.

Foe example, current goreleaser (2.6.1) gives this
```shellsession
$ set -o nounset
$ goreleaser build --output <TAB>bash: fullFilter: unbound variable
```

https://github.com/goreleaser/goreleaser/blob/fb003f17c26e9388be64eb3930fe1b337325cf8d/cmd/build.go#L100

Arguably a bug to set an empty string there. Not sure if this should be filtered before it enters bash code, but at least this is a "cheap" workaround.