### PR TITLE
Add feature to allow ValidArgsFunction to be called when processing command line completions of just flags

### DIFF
--- a/command.go
+++ b/command.go
@@ -257,6 +257,11 @@ type Command struct {
 	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
 	// Must be > 0.
 	SuggestionsMinimumDistance int
+
+	// When performing commandline completions specific to handling flags only, override
+	// Cobra's default behavior and allow ValidArgsFunction to be used if it exists, otherwise
+	// use the default behavior
+	AllowCustomFlagCompletions bool
 }
 
 // Context returns underlying command context. If command was executed

--- a/command.go
+++ b/command.go
@@ -1609,6 +1609,17 @@ func (c *Command) HasSubCommands() bool {
 
 // IsAvailableCommand determines if a command is available as a non-help command
 // (this includes all non deprecated/hidden commands).
+func (c *Command) HasCustomFlagCompletion() bool {
+
+	if c.ValidArgsFunction == nil {
+		return false
+	}
+
+	return c.AllowCustomFlagCompletions
+}
+
+// IsAvailableCommand determines if a command is available as a non-help command
+// (this includes all non deprecated/hidden commands).
 func (c *Command) IsAvailableCommand() bool {
 	if len(c.Deprecated) != 0 || c.Hidden {
 		return false

--- a/command.go
+++ b/command.go
@@ -1607,10 +1607,11 @@ func (c *Command) HasSubCommands() bool {
 	return len(c.commands) > 0
 }
 
-// IsAvailableCommand determines if a command is available as a non-help command
-// (this includes all non deprecated/hidden commands).
+// HasCustomFlagCompletion determines if a command has a defined
+// ValidArgsFunction, if it does, then it returns the value of
+// the AllowCustomFlagCompletions field indicating if the function
+// should be used for handling custom flag completions.
 func (c *Command) HasCustomFlagCompletion() bool {
-
 	if c.ValidArgsFunction == nil {
 		return false
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,83 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+func TestHasCustomFlagCompletion(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		cmd            *Command
+		expectedResult bool
+	}{
+		{
+			name: "HasCustomFlagCompletion() AllowCustomFlagCompletions not set",
+			cmd: &Command{
+				Use: "c",
+				Run: emptyRun,
+			},
+			expectedResult: false,
+		},
+		{
+			name: "HasCustomFlagCompletion() AllowCustomFlagCompletions set true",
+			cmd: &Command{
+				Use:                        "c",
+				Run:                        emptyRun,
+				AllowCustomFlagCompletions: true,
+			},
+			expectedResult: false,
+		},
+		{
+			name: "HasCustomFlagCompletion() AllowCustomFlagCompletions set false",
+			cmd: &Command{
+				Use:                        "c",
+				Run:                        emptyRun,
+				AllowCustomFlagCompletions: false,
+			},
+			expectedResult: false,
+		},
+		{
+			name: "HasCustomFlagCompletion() AllowCustomFlagCompletions not set with Valid",
+			cmd: &Command{
+				Use: "c",
+				Run: emptyRun,
+				ValidArgsFunction: func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+					return []string{}, ShellCompDirectiveNoFileComp
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "HasCustomFlagCompletion() AllowCustomFlagCompletions set true",
+			cmd: &Command{
+				Use:                        "c",
+				Run:                        emptyRun,
+				AllowCustomFlagCompletions: true,
+				ValidArgsFunction: func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+					return []string{}, ShellCompDirectiveNoFileComp
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "HasCustomFlagCompletion() AllowCustomFlagCompletions set false",
+			cmd: &Command{
+				Use:                        "c",
+				Run:                        emptyRun,
+				AllowCustomFlagCompletions: false,
+				ValidArgsFunction: func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+					return []string{}, ShellCompDirectiveNoFileComp
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cmd.HasCustomFlagCompletion() != tc.expectedResult {
+				t.Errorf("did not return expected results")
+			}
+		})
+	}
+
+}

--- a/completions.go
+++ b/completions.go
@@ -358,7 +358,7 @@ func (c *Command) getCompletions(args []string) (*Command, []Completion, ShellCo
 	// This works by counting the arguments. Normally -- is not counted as arg but
 	// if -- was already set or interspersed is false and there is already one arg then
 	// the extra added -- is counted as arg.
-	flagCompletion := true
+	flagCompletion := !finalCmd.HasCustomFlagCompletion()
 	_ = finalCmd.ParseFlags(append(finalArgs, "--"))
 	newArgCount := finalCmd.Flags().NArg()
 


### PR DESCRIPTION

Addresses issue raised in https://github.com/spf13/cobra/issues/2243

Implements a new Command field **AllowCustomFlagCompletions** _(I am not married to the name.)_ which when set and when a Command has a **ValidArgsFunction** set will call the **ValidArgsFunction** function when processing flag command line completions instead of **getCompletions()**'s default processing of flags.

The value of this feature is it allows a developer more fine grain control over command line completion results over flags based upon non-flag based context.  (ie: allows for the suppression of a flag that may not be applicable when a particular argument is present, or when a certain number of arguments are present.)

I am not well versed with all aspects of the completion code and would suggest this be reviewed by others who are more familiar with the code base.

