### PR TITLE
fix: Prevent getCompletions from modifying os.Args

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -359,7 +359,9 @@ func (c *Command) getCompletions(args []string) (*Command, []Completion, ShellCo
 	// if -- was already set or interspersed is false and there is already one arg then
 	// the extra added -- is counted as arg.
 	flagCompletion := true
-	_ = finalCmd.ParseFlags(append(finalArgs, "--"))
+	extendedArgs := make([]string, 0, len(finalArgs)+1)
+	extendedArgs = append(append(extendedArgs, finalArgs...), "--")
+	_ = finalCmd.ParseFlags(extendedArgs)
 	newArgCount := finalCmd.Flags().NArg()
 
 	// Parse the flags early so we can check if required flags are set


### PR DESCRIPTION
Possible fix for https://github.com/spf13/cobra/issues/2257.

Tested using this test case:
```go
func TestModifiedArgs(t *testing.T) {
	cmd := &Command{TraverseChildren: true}
	args := []string{"__complete", ""}
	cmd.SetArgs(args)
	if err := cmd.Execute(); err != nil {
		t.Errorf("Unexpected error: %v", err)
	}
	if len(args) != 2 || args[1] != "" {
		t.Error("Modified args")
	}
}
```