### PR TITLE
fix: Preserve ArgsLenAtDash during shell completion

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -360,6 +360,8 @@ func (c *Command) getCompletions(args []string) (*Command, []Completion, ShellCo
 	// the extra added -- is counted as arg.
 	flagCompletion := true
 	_ = finalCmd.ParseFlags(append(finalArgs, "--"))
+	// Reset ArgsLenAtDash.
+	finalCmd.Flags().Init(finalCmd.Flags().Name(), pflag.ContinueOnError)
 	newArgCount := finalCmd.Flags().NArg()
 
 	// Parse the flags early so we can check if required flags are set


### PR DESCRIPTION
Fixes https://github.com/spf13/cobra/issues/1877. This is just a workaround, a real fix is described in the issue itself.

Tested with:
```go
func TestCompleteArgsLenAtDash(t *testing.T) {
	compareArgsLenAtDash(t, nil)
	compareArgsLenAtDash(t, []string{"foo"})
	compareArgsLenAtDash(t, []string{"--"})
	compareArgsLenAtDash(t, []string{"--", "foo"})
	compareArgsLenAtDash(t, []string{"--", "foo", "bar"})
	compareArgsLenAtDash(t, []string{"foo", "--"})
	compareArgsLenAtDash(t, []string{"foo", "--", "bar"})
	compareArgsLenAtDash(t, []string{"foo", "bar", "--"})
	compareArgsLenAtDash(t, []string{"--", "--"})
	compareArgsLenAtDash(t, []string{"--", "--", "foo"})
	compareArgsLenAtDash(t, []string{"--", "foo", "--"})
	compareArgsLenAtDash(t, []string{"foo", "--", "--"})
	compareArgsLenAtDash(t, []string{"foo", "--", "--", "bar"})
	compareArgsLenAtDash(t, []string{"foo", "--", "bar", "--"})
	compareArgsLenAtDash(t, []string{"foo", "bar", "--", "--"})
}

func compareArgsLenAtDash(t *testing.T, args []string) {
	argsLenAtDash1 := 0
	argsLenAtDash2 := 0

	cmd := &Command{
		Run: func(cmd *Command, args []string) {
			argsLenAtDash1 = cmd.ArgsLenAtDash()
		},
		ValidArgsFunction: func(cmd *Command, args []string, toComplete string) ([]Completion, ShellCompDirective) {
			argsLenAtDash2 = cmd.ArgsLenAtDash()
			return nil, ShellCompDirectiveDefault
		},
	}

	cmd.SetArgs(args)
	if err := cmd.Execute(); err != nil {
		t.Errorf("Unexpected error: %v", err)
	}

	cmd.SetArgs(append(append([]string{"__complete"}, args...), ""))
	if err := cmd.Execute(); err != nil {
		t.Errorf("Unexpected error: %v", err)
	}

	if argsLenAtDash1 != argsLenAtDash2 {
		t.Errorf("expected %v, got: %v", argsLenAtDash1, argsLenAtDash2)
	}
}
```