### PR TITLE
Add function to print command aliases

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -29,6 +29,16 @@ import (
 
 const markdownExtension = ".md"
 
+func printAliases(buf *bytes.Buffer, cmd *cobra.Command) {
+	if len(cmd.Aliases) > 0 {
+		buf.WriteString("### Aliases\n\n")
+		for _, alias := range cmd.Aliases {
+			buf.WriteString(fmt.Sprintf("* `%s`\n", alias))
+		}
+		buf.WriteString("\n")
+	}
+}
+
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)


### PR DESCRIPTION
This PR adds a function in `md_doc` to print the list of Aliases of a command in the markdown