### PR TITLE
Add new type to represent validating required flag error

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -17,6 +17,7 @@ package cobra
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -2951,4 +2952,15 @@ func TestHelpFuncExecuted(t *testing.T) {
 	}
 
 	checkStringContains(t, output, helpText)
+}
+
+func TestValidateRequiredFlags(t *testing.T) {
+	c := &Command{Use: "c", Run: emptyRun}
+	c.Flags().BoolP("boola", "a", false, "a boolean flag")
+	c.MarkFlagRequired("boola")
+	if err := c.ValidateRequiredFlags(); !errors.Is(err, &RequiredFlagError{
+		Err: errors.New("required flag(s) \"boola\" not set"),
+	}) {
+		t.Fatalf("Expected error: %v, got: %v", "boola", err)
+	}
 }


### PR DESCRIPTION
Currently, when we met the ValidateRequiredField error, we should compare as a raw string.
This proposal aims to compare by using errors.Is/As and to cast from interface to the type.