### PR TITLE
feat: Add Finalize function to commands

### DIFF
--- a/command.go
+++ b/command.go
@@ -138,6 +138,8 @@ type Command struct {
 	RunE func(cmd *Command, args []string) error
 	// PostRun: run after the Run command.
 	PostRun func(cmd *Command, args []string)
+	// Finalize: run at the end of the Run command, even if it panics.
+	Finalize func(cmd *Command, args []string)
 	// PostRunE: PostRun but returns an error.
 	PostRunE func(cmd *Command, args []string) error
 	// PersistentPostRun: children of this command will inherit and execute after PostRun.
@@ -961,6 +963,11 @@ func (c *Command) execute(a []string) (err error) {
 	defer c.postRun()
 
 	argWoFlags := c.Flags().Args()
+
+	if c.Finalize != nil {
+		defer c.Finalize(c, argWoFlags)
+	}
+
 	if c.DisableFlagParsing {
 		argWoFlags = a
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,25 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+func TestFinalizeCalledOnPanic(t *testing.T) {
+	finalizeCalls := 0
+	defer func() {
+		if recover() == nil {
+			t.Error("The code should have panicked due to panicking run")
+		}
+		if finalizeCalls != 1 {
+			t.Errorf("finalize() called %d times, want 1", finalizeCalls)
+		}
+	}()
+	rootCmd := &Command{
+		Use: "root",
+		Run: func(cmd *Command, args []string) {
+			panic("should panic")
+		},
+		Finalize: func(cmd *Command, args []string) {
+			finalizeCalls++
+		},
+	}
+	executeCommand(rootCmd)
+}


### PR DESCRIPTION
This adds a "Finalize" function to the command, which is executed at the end of every run, even if the run panics.
Done as a follow-up for https://github.com/spf13/cobra/pull/2275