### PR TITLE
command: move required flag check before PreRun(E)

### DIFF
--- a/command.go
+++ b/command.go
@@ -981,6 +981,12 @@ func (c *Command) execute(a []string) (err error) {
 			parents = append(parents, p)
 		}
 	}
+	if err := c.ValidateRequiredFlags(); err != nil {
+		return err
+	}
+	if err := c.ValidateFlagGroups(); err != nil {
+		return err
+	}
 	for _, p := range parents {
 		if p.PersistentPreRunE != nil {
 			if err := p.PersistentPreRunE(c, argWoFlags); err != nil {
@@ -1003,14 +1009,6 @@ func (c *Command) execute(a []string) (err error) {
 	} else if c.PreRun != nil {
 		c.PreRun(c, argWoFlags)
 	}
-
-	if err := c.ValidateRequiredFlags(); err != nil {
-		return err
-	}
-	if err := c.ValidateFlagGroups(); err != nil {
-		return err
-	}
-
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {
 			return err


### PR DESCRIPTION
The current implementation checks the presence of required flags after `PreRun` or `PreRunE` functions are run. This commit moves that validation to happen before those steps.

There are use cases where we want to use flags inside `PreRun`/`PreRunE` functions. Checking for presence of required flags in those cases involves manually iterating and checking the flags inside your prerun functions. If we move the validation up, we get the validation for free.

The only "counter" usecase would be when users use `PreRun`/`PreRunE` to set required flags. This, however seems like a poor usecase that defeats the purpose of having required flags and/or default values in the first place.