### PR TITLE
chore: upgrade pflags v1.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.6
 	github.com/inconshreveable/mousetrap v1.1.0
-	github.com/spf13/pflag v1.0.8
+	github.com/spf13/pflag v1.0.9
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/pflag v1.0.8 h1:/v546uKZ4gFGHpyXvV6CNKDeJBu4l5PRvxwQvdWrc0I=
-github.com/spf13/pflag v1.0.8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Edit: blast radius seems to primarily be from projects that use both cobra and pflag. The use of the re-exported type:

https://github.com/spf13/cobra/blob/main/command.go#L41-L42

shouldn't break projects now that we've cut a v1.10.0 with those changes. This now just upgrades pflag without the need to emergency roll back the original variable type changes.

---

This is an emergency roll forward to unblock `kubernetes/kubernetes` (see https://github.com/kubernetes/kubernetes/issues/133809 and [failing prow-bot](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/1962249657098702848)) and other large projects / cloud providers that directly consumed breaking changes off cobra related to downstream breaking changes in `spf13/pflags` v1.0.8:
* https://github.com/spf13/pflag/issues/445

that were merged into `spf13/cobra` in:
* https://github.com/spf13/cobra/pull/2303

We obviously want to use these more inclusive names so we'll plan to roll forward a change in the future for `ParseErrorsWhitelist` --> `ParseErrorsAllowlist` once the dust has settled and we understand what the blast radius for such a breaking change is.