### PR TITLE
refactor: change minUsagePadding from var to const

### DIFF
--- a/command.go
+++ b/command.go
@@ -557,7 +557,7 @@ func (c *Command) FlagErrorFunc() (f func(*Command, error) error) {
 	}
 }
 
-var minUsagePadding = 25
+const minUsagePadding = 25
 
 // UsagePadding return padding for the usage.
 func (c *Command) UsagePadding() int {


### PR DESCRIPTION
I noticed minUsagePadding was defined as a var even though it's never changed anywhere. Since it's a fixed value, using const makes more sense and prevents accidental modifications.

This is just a small cleanup - no functional changes.

Fixes #2323 