### PR TITLE
Fix linter and allow CI to pass

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,3 +57,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+  settings:
+    govet:
+      # Disable buildtag check to allow dual build tag syntax (both //go:build and // +build).
+      # This is necessary for Go 1.15 compatibility since //go:build was introduced in Go 1.17.
+      # This can be removed once Cobra requires Go 1.17 or higher.
+      disable:
+        - buildtag


### PR DESCRIPTION
It seems that with the v2.6.1 version of golangci-lint, govet is too agressive about removing the old "// +build" tag.
We need to keep the old "+build" syntax because Cobra still allows to use a Go version as old as 1.15.

You can see the failure currently happening in #2325