### PR TITLE
perf: Loop over the bash variable directly instead of starting subprocesses.

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -326,7 +326,7 @@ __%[1]s_handle_standard_completion_case() {
     local longest=0
     local compline
     # Look for the longest completion so that we can format things nicely
-    while IFS='' read -r compline; do
+    for compline in "${completions[@]}"; do
         [[ -z $compline ]] && continue
 
         # Before checking if the completion matches what the user typed,
@@ -352,7 +352,7 @@ __%[1]s_handle_standard_completion_case() {
         if ((${#comp}>longest)); then
             longest=${#comp}
         fi
-    done < <(printf "%%s\n" "${completions[@]}")
+    done
 
     # If there is a single completion left, remove the description text and escape any special characters
     if ((${#COMPREPLY[*]} == 1)); then


### PR DESCRIPTION
Today, the loop is printing the completions one value per line and then reading one line to a variable. We can just skip the whole IO rigamarole by looping over the completions directly.

I had added this optimization to https://github.com/spf13/cobra/pull/2126 but it doesn't look like it got picked up by https://github.com/spf13/cobra/pull/1743.