### PR TITLE
fix(bash): Escape common prefixes that are inserted by the first completion request.

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -321,6 +321,9 @@ __%[1]s_handle_completion_types() {
 }
 
 __%[1]s_escape_compreply() {
+  if (( ${#COMPREPLY[@]} == 0 )); then
+    return
+  fi
   IFS=$'\n' read -ra COMPREPLY -d '' < <(printf "%%q\n" "${COMPREPLY[@]}")
 }
 

--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -303,8 +303,8 @@ __%[1]s_handle_completion_types() {
         if (( ${#COMPREPLY[@]} == 1)); then
           __%[1]s_escape_compreply
         fi
-				# Otherwise, these completion options will be displayed to the user in a
-				# list, and we don't want to show them escape sequences.
+        # Otherwise, these completion options will be displayed to the user in a
+        # list, and we don't want to show them escape sequences.
         ;;
 
     *)


### PR DESCRIPTION
On the first tab (`COMP_TYPE=9`), Bash will automatically insert the common prefix of the matching completion options. We need to make sure those completion options are escaped since some part of them might end up on the command line.

On subsequent tabs (`COMP_TYPE=63`), Bash will display the completion options to the user, so we don't want to escape them for that `COMP_TYPE`.