### PR TITLE
fix: actions/setup-go v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '^1.22'
           check-latest: true
@@ -75,7 +75,7 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: 1.${{ matrix.go }}.x
         cache: true


### PR DESCRIPTION
Support for `actions/setup-go@v6` which has some fixes for the buildchain dependency management. See the following:
* Failed CI in: https://github.com/spf13/cobra/pull/2336
* https://github.com/actions/setup-go/issues/688
* https://github.com/actions/go-versions/pull/127