### PR TITLE
fix: Tutorial my-cli documentation incorrect

### DIFF
--- a/site/content/user_guide.md
+++ b/site/content/user_guide.md
@@ -37,6 +37,23 @@ For complete details on using the Cobra generator, please refer to [The Cobra-CL
 To manually implement Cobra you need to create a bare main.go file and a rootCmd file.
 You will optionally provide additional commands as you see fit.
 
+### Initialize a Go module
+
+Before you can use the Cobra library, you need to create a Go module for your project.
+If you don't already have a Go module, follow these steps:
+
+```console
+mkdir myapp
+cd myapp
+go mod init github.com/your-username/myapp
+```
+
+Replace `github.com/your-username/myapp` with your actual module path. After initializing the module, you can fetch the Cobra library:
+
+```console
+go get github.com/spf13/cobra@latest
+```
+
 ### Create rootCmd
 
 Cobra doesn't require any special constructors. Simply create your commands.


### PR DESCRIPTION
Fixes #2340

## Changes
- Add missing go mod init step to user guide tutorial
- Include instructions for creating project directory and fetching Cobra library