### PR TITLE
doc: Don't sort subcommands in "See Also" section

### DIFF
--- a/doc/man_docs.go
+++ b/doc/man_docs.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -228,9 +227,7 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 				}
 			})
 		}
-		children := cmd.Commands()
-		sort.Sort(byName(children))
-		for _, c := range children {
+		for _, c := range cmd.Commands() {
 			if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
 				continue
 			}

--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -95,10 +94,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			})
 		}
 
-		children := cmd.Commands()
-		sort.Sort(byName(children))
-
-		for _, child := range children {
+		for _, child := range cmd.Commands() {
 			if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
 				continue
 			}

--- a/doc/rest_docs.go
+++ b/doc/rest_docs.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -109,10 +108,7 @@ func GenReSTCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string, str
 			})
 		}
 
-		children := cmd.Commands()
-		sort.Sort(byName(children))
-
-		for _, child := range children {
+		for _, child := range cmd.Commands() {
 			if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
 				continue
 			}

--- a/doc/util.go
+++ b/doc/util.go
@@ -44,9 +44,3 @@ func forceMultiLine(s string) string {
 	}
 	return s
 }
-
-type byName []*cobra.Command
-
-func (s byName) Len() int           { return len(s) }
-func (s byName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s byName) Less(i, j int) bool { return s[i].Name() < s[j].Name() }

--- a/doc/yaml_docs.go
+++ b/doc/yaml_docs.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -123,9 +122,7 @@ func GenYamlCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string) str
 			parent := cmd.Parent()
 			result = append(result, parent.CommandPath()+" - "+parent.Short)
 		}
-		children := cmd.Commands()
-		sort.Sort(byName(children))
-		for _, child := range children {
+		for _, child := range cmd.Commands() {
 			if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
 				continue
 			}


### PR DESCRIPTION
The subcommands in the `Command.Commands()` slice are sorted alphabetically by default. That can be disabled by setting `cobra.EnableCommandSorting = false` in which case the order in which subcommands are added via `Command.AddCommand` is retained. That order is used in the "Available Commands:" section in the usage message. Let's also keep that order when listing subcommands in the "See Also" section of generated docs.