### PR TITLE
docs: make subcommands organization example be more explicit

### DIFF
--- a/site/content/user_guide.md
+++ b/site/content/user_guide.md
@@ -196,20 +196,22 @@ subcommands. For example, consider the following directory structure:
 ```console
 ├── cmd
 │   ├── root.go
+│   ├── leafA.go
 │   └── sub1
 │       ├── sub1.go
 │       └── sub2
-│           ├── leafA.go
 │           ├── leafB.go
+│           ├── leafC.go
 │           └── sub2.go
 └── main.go
 ```
 
 In this case:
 
-* The `init` function of `root.go` adds the command defined in `sub1.go` to the root command.
+* The `init` function of `root.go` adds the command defined in `leafA.go` and `sub1.go` to the
+  root command.
 * The `init` function of `sub1.go` adds the command defined in `sub2.go` to the sub1 command.
-* The `init` function of `sub2.go` adds the commands defined in `leafA.go` and `leafB.go` to the
+* The `init` function of `sub2.go` adds the commands defined in `leafB.go` and `leafC.go` to the
   sub2 command.
 
 This approach ensures the subcommands are always included at compile time while avoiding cyclic


### PR DESCRIPTION
It's always difficult to be sure that we understand the subcommands organization if we cannot match the example.  
In the real world we are facing a lot of time leaf and subcommand at the same level. Just put it into the example.

If we take the well-known Docker command (simplified) as an example:

```
├── ps
└── container
    ├── kill
    ├── ls
    └── logs
```

Should I put `ps` into `cmd/ps.go` beside `root.go` or into `cmd/ps/ps.go` ?

I think that the documentation is for having `cmd/ps.go` :
> The suggested approach is for the parent command to use `AddCommand` to add its most immediate subcommands.

But an example is better than words!