### PR TITLE
completions: Update instruction for installing

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -814,11 +814,11 @@ To load completions for every new session, execute once:
 
 #### Linux:
 
-	%[1]s completion bash > /etc/bash_completion.d/%[1]s
+	%[1]s completion bash > /usr/share/bash-completion/completions/%[1]s.bash
 
 #### macOS:
 
-	%[1]s completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
+	%[1]s completion bash > $(brew --prefix)/share/bash-completion/completions/%[1]s.bash
 
 You will need to start a new shell for this setup to take effect.
 `, c.Root().Name()),


### PR DESCRIPTION
/etc/bash_completion.d/ is meant for backwards compatibility, the recommended way is to have the file in
`/usr/share/bash-completion/completions/<cmdname>.bash`.

I  didn't test the macOS version, but it should work the same.
Note that https://cobra.dev/docs/how-to-guides/shell-completion/ also recommends putting it there, but I couldn't find the source of it.