### PR TITLE
fix(find): keep unknown-flag errors stable when next arg is another flag

### DIFF
--- a/command.go
+++ b/command.go
@@ -659,6 +659,10 @@ func hasNoOptDefVal(name string, fs *flag.FlagSet) bool {
 	return flag.NoOptDefVal != ""
 }
 
+func hasFlag(name string, fs *flag.FlagSet) bool {
+	return fs.Lookup(name) != nil
+}
+
 func shortHasNoOptDefVal(name string, fs *flag.FlagSet) bool {
 	if len(name) == 0 {
 		return false
@@ -669,6 +673,14 @@ func shortHasNoOptDefVal(name string, fs *flag.FlagSet) bool {
 		return false
 	}
 	return flag.NoOptDefVal != ""
+}
+
+func shortHasFlag(name string, fs *flag.FlagSet) bool {
+	if len(name) == 0 {
+		return false
+	}
+
+	return fs.ShorthandLookup(name[:1]) != nil
 }
 
 func stripFlags(args []string, c *Command) []string {
@@ -689,18 +701,27 @@ Loop:
 			// "--" terminates the flags
 			break Loop
 		case strings.HasPrefix(s, "--") && !strings.Contains(s, "=") && !hasNoOptDefVal(s[2:], flags):
-			// If '--flag arg' then
-			// delete arg from args.
-			fallthrough // (do the same as below)
-		case strings.HasPrefix(s, "-") && !strings.Contains(s, "=") && len(s) == 2 && !shortHasNoOptDefVal(s[1:], flags):
-			// If '-f arg' then
-			// delete 'arg' from args or break the loop if len(args) <= 1.
-			if len(args) <= 1 {
-				break Loop
-			} else {
-				args = args[1:]
+			// If '--flag arg' then delete arg from args.
+			// For unknown flags, only consume the next arg when it is not another flag token.
+			if !hasFlag(s[2:], flags) && len(args) > 0 && isFlagArg(args[0]) {
 				continue
 			}
+			if len(args) <= 1 {
+				break Loop
+			}
+			args = args[1:]
+			continue
+		case strings.HasPrefix(s, "-") && !strings.Contains(s, "=") && len(s) == 2 && !shortHasNoOptDefVal(s[1:], flags):
+			// If '-f arg' then delete arg from args.
+			// For unknown shorthands, only consume the next arg when it is not another flag token.
+			if !shortHasFlag(s[1:], flags) && len(args) > 0 && isFlagArg(args[0]) {
+				continue
+			}
+			if len(args) <= 1 {
+				break Loop
+			}
+			args = args[1:]
+			continue
 		case s != "" && !strings.HasPrefix(s, "-"):
 			commands = append(commands, s)
 		}
@@ -727,8 +748,17 @@ Loop:
 			// -- means we have reached the end of the parseable args. Break out of the loop now.
 			break Loop
 		case strings.HasPrefix(s, "--") && !strings.Contains(s, "=") && !hasNoOptDefVal(s[2:], flags):
-			fallthrough
+			if !hasFlag(s[2:], flags) && pos+1 < len(args) && isFlagArg(args[pos+1]) {
+				continue
+			}
+			// This is a long flag without a default value and without an equal sign. Increment pos
+			// in order to skip over the next arg, because that is the value of this flag.
+			pos++
+			continue
 		case strings.HasPrefix(s, "-") && !strings.Contains(s, "=") && len(s) == 2 && !shortHasNoOptDefVal(s[1:], flags):
+			if !shortHasFlag(s[1:], flags) && pos+1 < len(args) && isFlagArg(args[pos+1]) {
+				continue
+			}
 			// This is a flag without a default value, and an equal sign is not used. Increment pos in order to skip
 			// over the next arg, because that is the value of this flag.
 			pos++

--- a/command_test.go
+++ b/command_test.go
@@ -2881,7 +2881,7 @@ func TestFind(t *testing.T) {
 
 func TestUnknownFlagShouldReturnSameErrorRegardlessOfArgPosition(t *testing.T) {
 	testCases := [][]string{
-		// {"--unknown", "--namespace", "foo", "child", "--bar"}, // FIXME: This test case fails, returning the error `unknown command "foo" for "root"` instead of the expected error `unknown flag: --unknown`
+		{"--unknown", "--namespace", "foo", "child", "--bar"},
 		{"--namespace", "foo", "--unknown", "child", "--bar"},
 		{"--namespace", "foo", "child", "--unknown", "--bar"},
 		{"--namespace", "foo", "child", "--bar", "--unknown"},


### PR DESCRIPTION
## Summary
Fixes command/flag discovery so unknown flags do not consume subsequent flag tokens as their values.

## Problem
When scanning args in Find/stripFlags, unknown flags that looked like value-taking flags could incorrectly consume the next token even when that token was itself another flag. This could change the resulting error to an unrelated command parse error (e.g. `unknown command "foo"`) instead of the expected `unknown flag` error.

## Root cause
The scanner consumed the next arg for --flag value and -f value patterns based only on NoOptDefVal checks, without confirming whether the flag actually exists when deciding to consume the next token.

## Fix
- Added helpers to check whether a long/short flag exists in the active flag set.
- For unknown flags, only consume the next token if it is not another flag token.
- Applied this logic consistently in both stripFlags and argsMinusFirstX.
- Enabled the previously commented regression case in TestUnknownFlagShouldReturnSameErrorRegardlessOfArgPosition.

## Files changed
- command.go
- command_test.go

## Test notes
Go toolchain is unavailable in this execution environment (go/gofmt not found), so tests could not be run locally here. The PR includes a focused regression test case so CI can validate behavior.