### PR TITLE
feat: support hiding selected command aliases from help

### DIFF
--- a/command.go
+++ b/command.go
@@ -33,6 +33,7 @@ import (
 const (
 	FlagSetByCobraAnnotation     = "cobra_annotation_flag_set_by_cobra"
 	CommandDisplayNameAnnotation = "cobra_annotation_command_display_name"
+	HiddenAliasesAnnotation      = "cobra_annotation_hidden_aliases"
 
 	helpFlagName    = "help"
 	helpCommandName = "help"
@@ -1557,6 +1558,86 @@ func (c *Command) HasAlias(s string) bool {
 	return false
 }
 
+// MarkAliasesHidden marks the provided aliases as hidden from help output.
+// Hidden aliases remain functional but are omitted from usage and help text.
+// Passing an empty slice clears previously hidden aliases.
+func (c *Command) MarkAliasesHidden(aliases ...string) error {
+	if len(aliases) == 0 {
+		if c.Annotations != nil {
+			delete(c.Annotations, HiddenAliasesAnnotation)
+		}
+		return nil
+	}
+	if len(c.Aliases) == 0 {
+		return nil
+	}
+
+	existing := make(map[string]struct{}, len(c.Aliases))
+	for _, a := range c.Aliases {
+		existing[a] = struct{}{}
+	}
+
+	unique := make(map[string]struct{}, len(aliases))
+	result := make([]string, 0, len(aliases))
+	for _, hiddenAlias := range aliases {
+		if hiddenAlias == "" {
+			return fmt.Errorf("hidden alias cannot be empty")
+		}
+		if _, ok := existing[hiddenAlias]; !ok {
+			return fmt.Errorf("alias %q not found", hiddenAlias)
+		}
+		if _, ok := unique[hiddenAlias]; ok {
+			continue
+		}
+		unique[hiddenAlias] = struct{}{}
+		result = append(result, hiddenAlias)
+	}
+
+	sort.Strings(result)
+
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string, 1)
+	}
+	c.Annotations[HiddenAliasesAnnotation] = strings.Join(result, ",")
+	return nil
+}
+
+func (c *Command) hiddenAliases() map[string]struct{} {
+	if c.Annotations == nil {
+		return nil
+	}
+
+	v, ok := c.Annotations[HiddenAliasesAnnotation]
+	if !ok || v == "" {
+		return nil
+	}
+
+	aliases := strings.Split(v, ",")
+	result := make(map[string]struct{}, len(aliases))
+	for _, alias := range aliases {
+		result[alias] = struct{}{}
+	}
+	return result
+}
+
+func (c *Command) HasVisibleAliases() bool {
+	if len(c.Aliases) == 0 {
+		return false
+	}
+
+	hidden := c.hiddenAliases()
+	if hidden == nil {
+		return true
+	}
+
+	for _, a := range c.Aliases {
+		if _, ok := hidden[a]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
 // CalledAs returns the command name or alias that was used to invoke
 // this command or an empty string if the command has not been called.
 func (c *Command) CalledAs() string {
@@ -1584,7 +1665,21 @@ func (c *Command) hasNameOrAliasPrefix(prefix string) bool {
 
 // NameAndAliases returns a list of the command name and all aliases
 func (c *Command) NameAndAliases() string {
-	return strings.Join(append([]string{c.Name()}, c.Aliases...), ", ")
+	hidden := c.hiddenAliases()
+	if hidden == nil {
+		return strings.Join(append([]string{c.Name()}, c.Aliases...), ", ")
+	}
+
+	aliases := make([]string, 0, len(c.Aliases)+1)
+	aliases = append(aliases, c.Name())
+
+	for _, alias := range c.Aliases {
+		if _, ok := hidden[alias]; !ok {
+			aliases = append(aliases, alias)
+		}
+	}
+
+	return strings.Join(aliases, ", ")
 }
 
 // HasExample determines if the command has example.
@@ -1941,7 +2036,7 @@ type tmplFunc struct {
 
 const defaultUsageTemplate = `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  {{.CommandPath}} [command]{{end}}{{if .HasVisibleAliases}}
 
 Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
@@ -1980,7 +2075,7 @@ func defaultUsageFunc(w io.Writer, in interface{}) error {
 	if c.HasAvailableSubCommands() {
 		fmt.Fprintf(w, "\n  %s [command]", c.CommandPath())
 	}
-	if len(c.Aliases) > 0 {
+	if c.HasVisibleAliases() {
 		fmt.Fprintf(w, "\n\nAliases:\n")
 		fmt.Fprintf(w, "  %s", c.NameAndAliases())
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,259 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+func TestCommandNameAndAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *Command
+		want string
+	}{
+		{
+			name: "no aliases",
+			cmd:  &Command{Use: "signin"},
+			want: "signin",
+		},
+		{
+			name: "aliases without hidden annotation",
+			cmd:  &Command{Use: "signin", Aliases: []string{"login", "in"}},
+			want: "signin, login, in",
+		},
+		{
+			name: "hide one alias",
+			cmd: &Command{
+				Use:         "signin",
+				Aliases:     []string{"login", "in"},
+				Annotations: map[string]string{HiddenAliasesAnnotation: "in"},
+			},
+			want: "signin, login",
+		},
+		{
+			name: "hide all aliases",
+			cmd: &Command{
+				Use:         "signin",
+				Aliases:     []string{"login", "in"},
+				Annotations: map[string]string{HiddenAliasesAnnotation: "login,in"},
+			},
+			want: "signin",
+		},
+		{
+			name: "empty hidden annotation value is ignored",
+			cmd: &Command{
+				Use:         "signin",
+				Aliases:     []string{"login"},
+				Annotations: map[string]string{HiddenAliasesAnnotation: ""},
+			},
+			want: "signin, login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cmd.NameAndAliases()
+			if got != tt.want {
+				t.Fatalf("NameAndAliases() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandMarkAliasesHidden(t *testing.T) {
+	t.Run("hide single alias", func(t *testing.T) {
+		cmd := &Command{
+			Use:     "signin",
+			Aliases: []string{"login", "in"},
+		}
+
+		err := cmd.MarkAliasesHidden("in")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cmd.Annotations == nil {
+			t.Fatalf("annotations should not be nil")
+		}
+
+		v := cmd.Annotations[HiddenAliasesAnnotation]
+		if v != "in" {
+			t.Fatalf("expected hidden alias to be 'in', got %q", v)
+		}
+	})
+
+	t.Run("hide multiple aliases", func(t *testing.T) {
+		cmd := &Command{
+			Use:     "signin",
+			Aliases: []string{"login", "in"},
+		}
+
+		err := cmd.MarkAliasesHidden("login", "in")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		v := cmd.Annotations[HiddenAliasesAnnotation]
+		if v != "in,login" {
+			t.Fatalf("expected sorted hidden aliases 'in,login', got %q", v)
+		}
+	})
+
+	t.Run("clear hidden aliases", func(t *testing.T) {
+		cmd := &Command{
+			Use:     "signin",
+			Aliases: []string{"login"},
+			Annotations: map[string]string{
+				HiddenAliasesAnnotation: "login",
+			},
+		}
+
+		err := cmd.MarkAliasesHidden()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cmd.Annotations != nil {
+			if _, ok := cmd.Annotations[HiddenAliasesAnnotation]; ok {
+				t.Fatalf("hidden aliases should be removed")
+			}
+		}
+	})
+
+	t.Run("error on unknown alias", func(t *testing.T) {
+		cmd := &Command{
+			Use:     "signin",
+			Aliases: []string{"login"},
+		}
+
+		err := cmd.MarkAliasesHidden("unknown")
+		if err == nil {
+			t.Fatalf("expected error for unknown alias")
+		}
+	})
+
+	t.Run("deduplicate input", func(t *testing.T) {
+		cmd := &Command{
+			Use:     "signin",
+			Aliases: []string{"login"},
+		}
+
+		err := cmd.MarkAliasesHidden("login", "login")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		v := cmd.Annotations[HiddenAliasesAnnotation]
+		if v != "login" {
+			t.Fatalf("expected deduplicated value 'login', got %q", v)
+		}
+	})
+}
+
+func TestHelpHidesMarkedAliases(t *testing.T) {
+	child := &Command{
+		Use:     "signin",
+		Short:   "Sign in",
+		Run:     emptyRun,
+		Aliases: []string{"login", "in"},
+	}
+
+	if err := child.MarkAliasesHidden("login"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.AddCommand(child)
+
+	output, err := executeCommand(rootCmd, "help", "signin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	checkStringContains(t, output, "in")
+
+	if strings.Contains(output, "login") {
+		t.Fatalf("help output should not contain hidden alias %q\nOutput:\n%s", "login", output)
+	}
+}
+
+func TestHelpOmitsAliasesSectionWhenAllAliasesHidden(t *testing.T) {
+	child := &Command{
+		Use:     "signin",
+		Short:   "Sign in",
+		Run:     emptyRun,
+		Aliases: []string{"login"},
+	}
+
+	if err := child.MarkAliasesHidden("login"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.AddCommand(child)
+
+	output, err := executeCommand(rootCmd, "help", "signin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(output, "login") {
+		t.Fatalf("help output should not contain hidden alias %q\nOutput:\n%s", "login", output)
+	}
+
+	if strings.Contains(output, "Aliases:") {
+		t.Fatalf("help output should not include Aliases section when all aliases are hidden\nOutput:\n%s", output)
+	}
+}
+
+func TestCommandHasVisibleAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *Command
+		want bool
+	}{
+		{
+			name: "no aliases",
+			cmd:  &Command{Use: "signin"},
+			want: false,
+		},
+		{
+			name: "aliases without hidden annotation",
+			cmd:  &Command{Use: "signin", Aliases: []string{"login"}},
+			want: true,
+		},
+		{
+			name: "hide one of two aliases",
+			cmd: &Command{
+				Use:         "signin",
+				Aliases:     []string{"login", "in"},
+				Annotations: map[string]string{HiddenAliasesAnnotation: "in"},
+			},
+			want: true,
+		},
+		{
+			name: "hide all aliases",
+			cmd: &Command{
+				Use:         "signin",
+				Aliases:     []string{"login", "in"},
+				Annotations: map[string]string{HiddenAliasesAnnotation: "login,in"},
+			},
+			want: false,
+		},
+		{
+			name: "empty hidden annotation value is ignored",
+			cmd: &Command{
+				Use:         "signin",
+				Aliases:     []string{"login"},
+				Annotations: map[string]string{HiddenAliasesAnnotation: ""},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cmd.HasVisibleAliases()
+			if got != tt.want {
+				t.Fatalf("HasVisibleAliases() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Support hiding selected command aliases from help output.

### Motivation

Some commands may retain deprecated or compatibility aliases
that should remain functional but not be displayed in help
and usage text.

Currently, aliases are always shown if defined, which makes it
impossible to keep backward-compatible aliases without exposing
them in help output.

### Changes

- Add `MarkAliasesHidden` to allow marking specific aliases as hidden.
- Add `HasVisibleAliases` to determine whether aliases should be rendered.
- Update `NameAndAliases` and usage rendering to exclude hidden aliases.
- Keep command execution and completion behavior unchanged.
- Add tests for alias hiding and help rendering.