### PR TITLE
Mark Flag as Enum

### DIFF
--- a/command.go
+++ b/command.go
@@ -33,6 +33,7 @@ import (
 const (
 	FlagSetByCobraAnnotation     = "cobra_annotation_flag_set_by_cobra"
 	CommandDisplayNameAnnotation = "cobra_annotation_command_display_name"
+	flagEnumAnnotation           = "cobra_annotation_flag_enum_values"
 
 	helpFlagName    = "help"
 	helpCommandName = "help"
@@ -1011,6 +1012,10 @@ func (c *Command) execute(a []string) (err error) {
 		return err
 	}
 
+	if err := c.ValidateFlagEnum(); err != nil {
+		return err
+	}
+
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {
 			return err
@@ -1176,6 +1181,44 @@ func (c *Command) ValidateArgs(args []string) error {
 	return c.Args(c, args)
 }
 
+// getFlagValues extracts all values from a flag (handles both single and slice types).
+func getFlagValues(pflag *flag.Flag) []string {
+	// Try SliceValue interface first (most efficient)
+	if sliceValue, ok := pflag.Value.(SliceValue); ok {
+		return sliceValue.GetSlice()
+	}
+
+	// Handle slice types that don't implement SliceValue
+	// Pattern from completions.go:445-449
+	if strings.Contains(pflag.Value.Type(), "Slice") ||
+		strings.Contains(pflag.Value.Type(), "Array") ||
+		strings.HasPrefix(pflag.Value.Type(), "stringTo") {
+		valueStr := pflag.Value.String()
+		if valueStr == "" || valueStr == "[]" {
+			return nil
+		}
+		valueStr = strings.Trim(valueStr, "[]")
+		values := strings.Split(valueStr, ",")
+		for i := range values {
+			values[i] = strings.TrimSpace(values[i])
+		}
+		return values
+	}
+
+	// Single value flag
+	return []string{pflag.Value.String()}
+}
+
+// contains checks if a string exists in a slice.
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateRequiredFlags validates all required flags are present and returns an error otherwise
 func (c *Command) ValidateRequiredFlags() error {
 	if c.DisableFlagParsing {
@@ -1196,6 +1239,40 @@ func (c *Command) ValidateRequiredFlags() error {
 
 	if len(missingFlagNames) > 0 {
 		return fmt.Errorf(`required flag(s) "%s" not set`, strings.Join(missingFlagNames, `", "`))
+	}
+	return nil
+}
+
+// ValidateFlagEnum validates that all flags marked with enum annotations
+// have values that match the allowed enum options.
+func (c *Command) ValidateFlagEnum() error {
+	if c.DisableFlagParsing {
+		return nil
+	}
+
+	var enumViolations []string
+
+	c.Flags().VisitAll(func(pflag *flag.Flag) {
+		enumValues, found := pflag.Annotations[flagEnumAnnotation]
+		if !found || !pflag.Changed {
+			return
+		}
+
+		for _, actualValue := range getFlagValues(pflag) {
+			if actualValue == "" {
+				continue
+			}
+
+			if !contains(enumValues, actualValue) {
+				enumViolations = append(enumViolations,
+					fmt.Sprintf("invalid argument %q for \"--%s\" flag: must be one of [%s]",
+						actualValue, pflag.Name, strings.Join(enumValues, ", ")))
+			}
+		}
+	})
+
+	if len(enumViolations) > 0 {
+		return fmt.Errorf("%s", strings.Join(enumViolations, "\n"))
 	}
 	return nil
 }

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,266 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+func TestMarkFlagEnum_SingleValue(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		value     string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			desc:      "valid enum value",
+			value:     "json",
+			expectErr: false,
+		},
+		{
+			desc:      "another valid enum value",
+			value:     "yaml",
+			expectErr: false,
+		},
+		{
+			desc:      "invalid enum value",
+			value:     "invalid",
+			expectErr: true,
+			errMsg:    `invalid argument "invalid" for "--format" flag: must be one of [json, yaml, xml]`,
+		},
+		{
+			desc:      "empty string is invalid",
+			value:     "txt",
+			expectErr: true,
+			errMsg:    `invalid argument "txt" for "--format" flag: must be one of [json, yaml, xml]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cmd := &Command{
+				Use: "test",
+				Run: emptyRun,
+			}
+			cmd.Flags().String("format", "", "output format")
+			err := cmd.MarkFlagEnum("format", "json", "yaml", "xml")
+			if err != nil {
+				t.Fatalf("MarkFlagEnum failed: %v", err)
+			}
+
+			_, err = executeCommand(cmd, "--format="+tc.value)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else {
+					checkStringContains(t, err.Error(), tc.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkFlagEnum_SliceValues(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		values    string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			desc:      "all valid values",
+			values:    "urgent,feature",
+			expectErr: false,
+		},
+		{
+			desc:      "single valid value in slice",
+			values:    "bug",
+			expectErr: false,
+		},
+		{
+			desc:      "one invalid value in slice",
+			values:    "urgent,invalid",
+			expectErr: true,
+			errMsg:    `invalid argument "invalid" for "--tags" flag: must be one of [urgent, feature, bug]`,
+		},
+		{
+			desc:      "all invalid values in slice",
+			values:    "invalid1,invalid2",
+			expectErr: true,
+			errMsg:    `invalid argument "invalid1" for "--tags" flag: must be one of [urgent, feature, bug]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cmd := &Command{
+				Use: "test",
+				Run: emptyRun,
+			}
+			cmd.Flags().StringSlice("tags", nil, "tags")
+			err := cmd.MarkFlagEnum("tags", "urgent", "feature", "bug")
+			if err != nil {
+				t.Fatalf("MarkFlagEnum failed: %v", err)
+			}
+
+			_, err = executeCommand(cmd, "--tags="+tc.values)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else {
+					checkStringContains(t, err.Error(), tc.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkFlagEnum_EmptyOptions(t *testing.T) {
+	cmd := &Command{
+		Use: "test",
+		Run: emptyRun,
+	}
+	cmd.Flags().String("format", "", "output format")
+	err := cmd.MarkFlagEnum("format")
+	if err == nil {
+		t.Error("expected error for empty options, got nil")
+	}
+	checkStringContains(t, err.Error(), "enum options cannot be empty")
+}
+
+func TestMarkFlagEnum_PersistentInheritance(t *testing.T) {
+	rootCmd := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+	rootCmd.PersistentFlags().String("log-level", "", "log level")
+	err := rootCmd.MarkPersistentFlagEnum("log-level", "debug", "info", "warn", "error")
+	if err != nil {
+		t.Fatalf("MarkPersistentFlagEnum failed: %v", err)
+	}
+
+	childCmd := &Command{
+		Use: "child",
+		Run: emptyRun,
+	}
+	rootCmd.AddCommand(childCmd)
+
+	// Valid value should work on child command
+	_, err = executeCommand(rootCmd, "child", "--log-level=debug")
+	if err != nil {
+		t.Errorf("unexpected error with valid value: %v", err)
+	}
+
+	// Invalid value should fail on child command
+	_, err = executeCommand(rootCmd, "child", "--log-level=invalid")
+	if err == nil {
+		t.Error("expected error for invalid value on child command")
+	} else {
+		checkStringContains(t, err.Error(), `invalid argument "invalid" for "--log-level" flag`)
+	}
+}
+
+func TestMarkFlagEnum_UnsetFlag(t *testing.T) {
+	cmd := &Command{
+		Use: "test",
+		Run: emptyRun,
+	}
+	cmd.Flags().String("format", "", "output format")
+	err := cmd.MarkFlagEnum("format", "json", "yaml", "xml")
+	if err != nil {
+		t.Fatalf("MarkFlagEnum failed: %v", err)
+	}
+
+	// Executing without the flag should not cause an error
+	_, err = executeCommand(cmd)
+	if err != nil {
+		t.Errorf("unexpected error for unset flag: %v", err)
+	}
+}
+
+func TestMarkFlagEnum_DefaultValue(t *testing.T) {
+	cmd := &Command{
+		Use: "test",
+		Run: emptyRun,
+	}
+	// Set default value that's NOT in the enum list
+	cmd.Flags().String("format", "default", "output format")
+	err := cmd.MarkFlagEnum("format", "json", "yaml", "xml")
+	if err != nil {
+		t.Fatalf("MarkFlagEnum failed: %v", err)
+	}
+
+	// Default value should not be validated (flag.Changed is false)
+	_, err = executeCommand(cmd)
+	if err != nil {
+		t.Errorf("unexpected error for default value: %v", err)
+	}
+
+	// But explicitly setting an invalid value should fail
+	_, err = executeCommand(cmd, "--format=invalid")
+	if err == nil {
+		t.Error("expected error for explicitly set invalid value")
+	}
+}
+
+func TestGetFlagValues_SingleValue(t *testing.T) {
+	cmd := &Command{
+		Use: "test",
+		Run: emptyRun,
+	}
+	cmd.Flags().String("flag", "value", "a string flag")
+	cmd.ParseFlags([]string{"--flag=test"})
+
+	flag := cmd.Flags().Lookup("flag")
+	values := getFlagValues(flag)
+
+	if len(values) != 1 {
+		t.Errorf("expected 1 value, got %d", len(values))
+	}
+	if values[0] != "test" {
+		t.Errorf("expected 'test', got '%s'", values[0])
+	}
+}
+
+func TestGetFlagValues_SliceValue(t *testing.T) {
+	cmd := &Command{
+		Use: "test",
+		Run: emptyRun,
+	}
+	cmd.Flags().StringSlice("flag", nil, "a string slice flag")
+	cmd.ParseFlags([]string{"--flag=a,b,c"})
+
+	flag := cmd.Flags().Lookup("flag")
+	values := getFlagValues(flag)
+
+	if len(values) != 3 {
+		t.Errorf("expected 3 values, got %d", len(values))
+	}
+	expected := []string{"a", "b", "c"}
+	for i, v := range values {
+		if v != expected[i] {
+			t.Errorf("expected '%s' at index %d, got '%s'", expected[i], i, v)
+		}
+	}
+}
+
+func TestGetFlagValues_EmptySlice(t *testing.T) {
+	cmd := &Command{
+		Use: "test",
+		Run: emptyRun,
+	}
+	cmd.Flags().StringSlice("flag", nil, "a string slice flag")
+	// Don't set the flag
+
+	flag := cmd.Flags().Lookup("flag")
+	values := getFlagValues(flag)
+
+	if values != nil && len(values) != 0 {
+		t.Errorf("expected nil or empty slice, got %v", values)
+	}
+}

--- a/completions_test.go
+++ b/completions_test.go
@@ -4072,3 +4072,82 @@ func TestCustomDefaultShellCompDirective(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkFlagEnum_ManualCompletion(t *testing.T) {
+	rootCmd := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+	rootCmd.Flags().String("format", "", "output format")
+
+	// Mark as enum
+	err := rootCmd.MarkFlagEnum("format", "json", "yaml", "xml")
+	if err != nil {
+		t.Fatalf("MarkFlagEnum failed: %v", err)
+	}
+
+	// Manually register completion function (users need to do this themselves)
+	rootCmd.RegisterFlagCompletionFunc("format", func(cmd *Command, args []string, toComplete string) ([]Completion, ShellCompDirective) {
+		return []Completion{"json", "yaml", "xml"}, ShellCompDirectiveNoFileComp
+	})
+
+	// Test completion
+	output, err := executeCommand(rootCmd, ShellCompNoDescRequestCmd, "--format", "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"json",
+		"yaml",
+		"xml",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+}
+
+func TestMarkFlagEnum_PersistentCompletion(t *testing.T) {
+	rootCmd := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+	rootCmd.PersistentFlags().String("log-level", "", "log level")
+
+	// Mark persistent flag as enum
+	err := rootCmd.MarkPersistentFlagEnum("log-level", "debug", "info", "warn", "error")
+	if err != nil {
+		t.Fatalf("MarkPersistentFlagEnum failed: %v", err)
+	}
+
+	// Manually register completion function
+	rootCmd.RegisterFlagCompletionFunc("log-level", func(cmd *Command, args []string, toComplete string) ([]Completion, ShellCompDirective) {
+		return []Completion{"debug", "info", "warn", "error"}, ShellCompDirectiveNoFileComp
+	})
+
+	childCmd := &Command{
+		Use: "child",
+		Run: emptyRun,
+	}
+	rootCmd.AddCommand(childCmd)
+
+	// Test completion on child command
+	output, err := executeCommand(rootCmd, ShellCompNoDescRequestCmd, "child", "--log-level", "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"debug",
+		"info",
+		"warn",
+		"error",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+}

--- a/shell_completions.go
+++ b/shell_completions.go
@@ -15,6 +15,8 @@
 package cobra
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
 
@@ -95,4 +97,24 @@ func (c *Command) MarkPersistentFlagDirname(name string) error {
 // limit completions for the named flag to directory names.
 func MarkFlagDirname(flags *pflag.FlagSet, name string) error {
 	return flags.SetAnnotation(name, BashCompSubdirsInDir, []string{})
+}
+
+// MarkFlagEnum restricts the named flag to a set of valid enum values.
+// Use RegisterFlagCompletionFunc to enable shell completion for the enum values.
+func (c *Command) MarkFlagEnum(name string, options ...string) error {
+	return MarkFlagEnum(c.Flags(), name, options...)
+}
+
+// MarkPersistentFlagEnum restricts the named persistent flag to a set of valid enum values.
+// Use RegisterFlagCompletionFunc to enable shell completion for the enum values.
+func (c *Command) MarkPersistentFlagEnum(name string, options ...string) error {
+	return MarkFlagEnum(c.PersistentFlags(), name, options...)
+}
+
+// MarkFlagEnum restricts the named flag to a set of valid enum values.
+func MarkFlagEnum(flags *pflag.FlagSet, name string, options ...string) error {
+	if len(options) == 0 {
+		return fmt.Errorf("enum options cannot be empty for flag %q", name)
+	}
+	return flags.SetAnnotation(name, flagEnumAnnotation, options)
 }


### PR DESCRIPTION
Adds MarkFlagEnum to command object. Usage:

```go
cmd.MarkFlagEnum("format", []string{"json", "yaml", "table"})
```

issue #2362 