### PR TITLE
Add Qlty code coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,16 @@ jobs:
         go install github.com/mitchellh/gox@latest
 
     - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin/:$PATH make richtest
+      if: ${{ !(matrix.platform == 'ubuntu' && matrix.go == 24) }}
+
+    - run: RICHGO_FORCE_COLOR=1 PATH=$HOME/go/bin/:$PATH richgo test -v -coverprofile=coverage.out ./...
+      if: ${{ matrix.platform == 'ubuntu' && matrix.go == 24 }}
+
+    - uses: qltysh/qlty-action/coverage@v2
+      if: ${{ matrix.platform == 'ubuntu' && matrix.go == 24 }}
+      with:
+        token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+        files: coverage.out
 
 
   test-win:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,8 +93,9 @@ jobs:
 
     - uses: qltysh/qlty-action/coverage@v2
       if: ${{ matrix.platform == 'ubuntu' && matrix.go == 24 }}
+      env:
+        QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
       with:
-        token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
         files: coverage.out
 
 


### PR DESCRIPTION
## Summary
- Generates Go coverage profile (`coverage.out`) on the ubuntu / Go 1.24 matrix entry
- Uploads coverage data to Qlty Cloud using the official `qltysh/qlty-action/coverage@v2` GitHub Action
- All other matrix entries continue running tests without coverage overhead

## Manual steps required
- Add the `QLTY_COVERAGE_TOKEN` secret to this repository's GitHub Actions secrets (obtain from Qlty Cloud workspace settings)

## Test plan
- [ ] Verify the `ubuntu | 1.24.x` job generates `coverage.out` and uploads it to Qlty
- [ ] Verify all other matrix jobs still run `make richtest` as before
- [ ] Verify coverage data appears in Qlty Cloud after the token is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)