### PR TITLE
fix: respect Hidden flag for help command in usage output

### DIFF
--- a/command.go
+++ b/command.go
@@ -1282,7 +1282,7 @@ Simply type ` + c.DisplayName() + ` help [path to command] for full details.`,
 					cmd = c.Root()
 				}
 				for _, subCmd := range cmd.Commands() {
-					if subCmd.IsAvailableCommand() || subCmd == cmd.helpCommand {
+					if subCmd.IsAvailableCommand() || (subCmd == cmd.helpCommand && !subCmd.Hidden) {
 						if strings.HasPrefix(subCmd.Name(), toComplete) {
 							completions = append(completions, CompletionWithDesc(subCmd.Name(), subCmd.Short))
 						}
@@ -1375,7 +1375,7 @@ func (c *Command) Groups() []*Group {
 // AllChildCommandsHaveGroup returns if all subcommands are assigned to a group
 func (c *Command) AllChildCommandsHaveGroup() bool {
 	for _, sub := range c.commands {
-		if (sub.IsAvailableCommand() || sub == c.helpCommand) && sub.GroupID == "" {
+		if (sub.IsAvailableCommand() || (sub == c.helpCommand && !sub.Hidden)) && sub.GroupID == "" {
 			return false
 		}
 	}
@@ -1949,13 +1949,13 @@ Aliases:
 Examples:
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
 
-Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (and (eq .Name "help") (not .Hidden)))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
 
-{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (and (eq .Name "help") (not .Hidden))))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
-Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (and (eq .Name "help") (not .Hidden))))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
@@ -1993,7 +1993,7 @@ func defaultUsageFunc(w io.Writer, in interface{}) error {
 		if len(c.Groups()) == 0 {
 			fmt.Fprintf(w, "\n\nAvailable Commands:")
 			for _, subcmd := range cmds {
-				if subcmd.IsAvailableCommand() || subcmd.Name() == helpCommandName {
+				if subcmd.IsAvailableCommand() || (subcmd == c.helpCommand && !subcmd.Hidden) {
 					fmt.Fprintf(w, "\n  %s %s", rpad(subcmd.Name(), subcmd.NamePadding()), subcmd.Short)
 				}
 			}
@@ -2001,7 +2001,7 @@ func defaultUsageFunc(w io.Writer, in interface{}) error {
 			for _, group := range c.Groups() {
 				fmt.Fprintf(w, "\n\n%s", group.Title)
 				for _, subcmd := range cmds {
-					if subcmd.GroupID == group.ID && (subcmd.IsAvailableCommand() || subcmd.Name() == helpCommandName) {
+					if subcmd.GroupID == group.ID && (subcmd.IsAvailableCommand() || (subcmd == c.helpCommand && !subcmd.Hidden)) {
 						fmt.Fprintf(w, "\n  %s %s", rpad(subcmd.Name(), subcmd.NamePadding()), subcmd.Short)
 					}
 				}
@@ -2009,7 +2009,7 @@ func defaultUsageFunc(w io.Writer, in interface{}) error {
 			if !c.AllChildCommandsHaveGroup() {
 				fmt.Fprintf(w, "\n\nAdditional Commands:")
 				for _, subcmd := range cmds {
-					if subcmd.GroupID == "" && (subcmd.IsAvailableCommand() || subcmd.Name() == helpCommandName) {
+					if subcmd.GroupID == "" && (subcmd.IsAvailableCommand() || (subcmd == c.helpCommand && !subcmd.Hidden)) {
 						fmt.Fprintf(w, "\n  %s %s", rpad(subcmd.Name(), subcmd.NamePadding()), subcmd.Short)
 					}
 				}

--- a/command_test.go
+++ b/command_test.go
@@ -1910,6 +1910,26 @@ func TestHiddenCommandIsHidden(t *testing.T) {
 	}
 }
 
+func TestHiddenHelpCommandIsHidden(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	childCmd := &Command{Use: "child", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+	rootCmd.InitDefaultHelpCmd()
+
+	// Help command should appear in usage by default.
+	usage := rootCmd.UsageString()
+	if !strings.Contains(usage, "help") {
+		t.Error("help command should appear in usage by default")
+	}
+
+	// Hiding the help command should remove it from usage.
+	rootCmd.helpCommand.Hidden = true
+	usage = rootCmd.UsageString()
+	if strings.Contains(usage, "  help") {
+		t.Error("hidden help command should not appear in usage")
+	}
+}
+
 func TestCommandsAreSorted(t *testing.T) {
 	EnableCommandSorting = true
 


### PR DESCRIPTION
## Summary

Fixes spf13/cobra#2269

The `help` command was hardcoded to always appear in usage listings, completely ignoring its `Hidden` field. This meant that setting `cmd.Hidden = true` on the help command had no effect, making the property meaningless for it.

## What changed

Updated all locations where the help command receives special treatment to check `!subcmd.Hidden` before including it in output:

- `defaultUsageTemplate`: template conditions updated from `(eq .Name "help")` to `(and (eq .Name "help") (not .Hidden))`
- `printOptionCmdUsages`: three loop conditions updated
- `AllChildCommandsHaveGroup`: condition updated to respect `Hidden`
- Shell completion listing: condition updated to respect `Hidden`

## How to hide the help command

```go
rootCmd.InitDefaultHelpCmd()
rootCmd.helpCommand.Hidden = true
```

Or via `SetHelpCommand`:

```go
rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
```

## Testing

Added `TestHiddenHelpCommandIsHidden` which verifies the help command appears in usage by default and disappears when `Hidden` is set to true.

All existing tests pass.