### PR TITLE
Add HelpExitCode feature to allow custom exit code when --help is triggered

### DIFF
--- a/command.go
+++ b/command.go
@@ -238,6 +238,10 @@ type Command struct {
 	// SilenceUsage is an option to silence usage when an error occurs.
 	SilenceUsage bool
 
+	// HelpExitCode is the exit code returned when --help is triggered.
+	// If set to 0 (default), exit code is 0. If set to non-zero, that exit code is returned.
+	HelpExitCode int
+
 	// DisableFlagParsing disables the flag parsing.
 	// If this is true all flags will be passed to the command as arguments.
 	DisableFlagParsing bool
@@ -352,6 +356,11 @@ func (c *Command) SetHelpCommandGroupID(groupID string) {
 func (c *Command) SetCompletionCommandGroupID(groupID string) {
 	// completionCommandGroupID is used if no completion command is defined by the user
 	c.Root().completionCommandGroupID = groupID
+}
+
+// SetHelpExitCode sets the exit code returned when --help is triggered.
+func (c *Command) SetHelpExitCode(code int) {
+	c.HelpExitCode = code
 }
 
 // SetHelpTemplate sets help template to be used. Application can use it to set custom template.
@@ -1151,6 +1160,10 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		// effect
 		if errors.Is(err, flag.ErrHelp) {
 			cmd.HelpFunc()(cmd, args)
+			// If HelpExitCode is set to non-zero, return that as the error to set exit code
+			if cmd.HelpExitCode != 0 {
+				return cmd, fmt.Errorf("help exit code: %d", cmd.HelpExitCode)
+			}
 			return cmd, nil
 		}
 

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,40 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+func TestHelpExitCodeDefault(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+
+	_, err := executeCommand(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestHelpExitCodeCustom(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.SetHelpExitCode(1)
+
+	_, err := executeCommand(rootCmd, "--help")
+	if err == nil {
+		t.Error("Expected error when HelpExitCode is set to 1, got nil")
+	}
+	if err.Error() != "help exit code: 1" {
+		t.Errorf("Expected error message 'help exit code: 1', got: %v", err)
+	}
+}
+
+func TestHelpExitCodeCustomOnChild(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	childCmd := &Command{Use: "child", Run: emptyRun}
+	rootCmd.AddCommand(childCmd)
+	childCmd.SetHelpExitCode(2)
+
+	_, err := executeCommand(rootCmd, "child", "--help")
+	if err == nil {
+		t.Error("Expected error when HelpExitCode is set to 2 on child, got nil")
+	}
+	if err.Error() != "help exit code: 2" {
+		t.Errorf("Expected error message 'help exit code: 2', got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements feature request #2338 - allows users to customize the exit code returned when `--help` is triggered.

## Changes

- Add `HelpExitCode` field to Command struct
- Modify `ExecuteC()` to return custom exit code when HelpExitCode is non-zero
- Add `SetHelpExitCode()` setter method for easy configuration
- Add tests covering default (0), custom (non-zero), and child command scenarios

## Why this matters
When embedding Cobra-based CLIs in shell scripts, users need a way to distinguish between help output and other errors. Currently, `--help` always returns exit code 0, making it impossible to handle specially in scripts.

## Usage

```go
rootCmd.SetHelpExitCode(1)
Now when users run myapp --help, the exit code will be 1 instead of 0, allowing scripts to handle it differently.

Fixes #2338