### PR TITLE
fix: permit empty string for ErrPrefix

### DIFF
--- a/command.go
+++ b/command.go
@@ -193,8 +193,8 @@ type Command struct {
 
 	// errPrefix is the error message prefix defined by user.
 	errPrefix string
-	// errPrefixSet tracks if the user explicitly set the errPrefix to allow for "" (empty string).
-	errPrefixSet bool
+	// errPrefixEmpty tracks if the user explicitly wants an empty errPrefix.
+	errPrefixEmpty bool
 
 	// inReader is a reader defined by the user that replaces stdin
 	inReader io.Reader
@@ -377,7 +377,12 @@ func (c *Command) SetVersionTemplate(s string) {
 // SetErrPrefix sets error message prefix to be used. Application can use it to set custom prefix.
 func (c *Command) SetErrPrefix(s string) {
 	c.errPrefix = s
-	c.errPrefixSet = true
+}
+
+// SetErrPrefixEmpty sets whether the error message prefix should be empty.
+// If set to true, this suppresses the default "Error: " prefix.
+func (c *Command) SetErrPrefixEmpty(empty bool) {
+	c.errPrefixEmpty = empty
 }
 
 // SetGlobalNormalizationFunc sets a normalization function to all flag sets and also to child commands.
@@ -644,8 +649,11 @@ func (c *Command) getVersionTemplateFunc() func(w io.Writer, data interface{}) e
 
 // ErrPrefix return error message prefix for the command
 func (c *Command) ErrPrefix() string {
-	if c.errPrefix != "" || c.errPrefixSet {
+	if c.errPrefix != "" {
 		return c.errPrefix
+	}
+	if c.errPrefixEmpty {
+		return ""
 	}
 
 	if c.HasParent() {

--- a/command.go
+++ b/command.go
@@ -375,14 +375,19 @@ func (c *Command) SetVersionTemplate(s string) {
 }
 
 // SetErrPrefix sets error message prefix to be used. Application can use it to set custom prefix.
+// To unset the error prefix, this function should be called with the empty string.
+// To prevent an error prefix from being used, the function SetErrPrefixEmpty(true) should be used.
 func (c *Command) SetErrPrefix(s string) {
 	c.errPrefix = s
+	c.errPrefixEmpty = false
 }
 
 // SetErrPrefixEmpty sets whether the error message prefix should be empty.
 // If set to true, this suppresses the default "Error: " prefix.
+// To unset the error prefix (so the parent chain can be checked), please use SetErrPrefix("").
 func (c *Command) SetErrPrefixEmpty(empty bool) {
 	c.errPrefixEmpty = empty
+	c.errPrefix = ""
 }
 
 // SetGlobalNormalizationFunc sets a normalization function to all flag sets and also to child commands.

--- a/command.go
+++ b/command.go
@@ -193,6 +193,8 @@ type Command struct {
 
 	// errPrefix is the error message prefix defined by user.
 	errPrefix string
+	// errPrefixSet tracks if the user explicitly set the errPrefix to allow for "" (empty string).
+	errPrefixSet bool
 
 	// inReader is a reader defined by the user that replaces stdin
 	inReader io.Reader
@@ -375,6 +377,7 @@ func (c *Command) SetVersionTemplate(s string) {
 // SetErrPrefix sets error message prefix to be used. Application can use it to set custom prefix.
 func (c *Command) SetErrPrefix(s string) {
 	c.errPrefix = s
+	c.errPrefixSet = true
 }
 
 // SetGlobalNormalizationFunc sets a normalization function to all flag sets and also to child commands.
@@ -641,7 +644,7 @@ func (c *Command) getVersionTemplateFunc() func(w io.Writer, data interface{}) e
 
 // ErrPrefix return error message prefix for the command
 func (c *Command) ErrPrefix() string {
-	if c.errPrefix != "" {
+	if c.errPrefix != "" || c.errPrefixSet {
 		return c.errPrefix
 	}
 
@@ -1128,7 +1131,11 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 			c = cmd
 		}
 		if !c.SilenceErrors {
-			c.PrintErrln(c.ErrPrefix(), err.Error())
+			if errPrefix := c.ErrPrefix(); errPrefix != "" {
+				c.PrintErrln(errPrefix, err.Error())
+			} else {
+				c.PrintErrln(err.Error())
+			}
 			c.PrintErrf("Run '%v --help' for usage.\n", c.CommandPath())
 		}
 		return c, err
@@ -1157,7 +1164,11 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		// If root command has SilenceErrors flagged,
 		// all subcommands should respect it
 		if !cmd.SilenceErrors && !c.SilenceErrors {
-			c.PrintErrln(cmd.ErrPrefix(), err.Error())
+			if errPrefix := cmd.ErrPrefix(); errPrefix != "" {
+				c.PrintErrln(errPrefix, err.Error())
+			} else {
+				c.PrintErrln(err.Error())
+			}
 		}
 
 		// If root command has SilenceUsage flagged,

--- a/command_test.go
+++ b/command_test.go
@@ -1297,6 +1297,24 @@ func TestRootAndSubErrPrefix(t *testing.T) {
 	}
 }
 
+func TestRootErrPrefixEmpty(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.SetErrPrefix("")
+
+	output, err := executeCommand(rootCmd, "--unknown-root-flag")
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	checkStringOmits(t, output, "Error: ")
+	checkStringContains(t, output, "unknown flag: --unknown-root-flag")
+
+	// Ensure there is no leading space which used to happen with empty prefix
+	if strings.HasPrefix(output, " ") {
+		t.Errorf("Expected no leading space in error output, got %q", output)
+	}
+}
+
 func TestVersionFlagExecutedOnSubcommand(t *testing.T) {
 	rootCmd := &Command{Use: "root", Version: "1.0.0"}
 	rootCmd.AddCommand(&Command{Use: "sub", Run: emptyRun})

--- a/command_test.go
+++ b/command_test.go
@@ -1299,7 +1299,7 @@ func TestRootAndSubErrPrefix(t *testing.T) {
 
 func TestRootErrPrefixEmpty(t *testing.T) {
 	rootCmd := &Command{Use: "root", Run: emptyRun}
-	rootCmd.SetErrPrefix("")
+	rootCmd.SetErrPrefixEmpty(true)
 
 	output, err := executeCommand(rootCmd, "--unknown-root-flag")
 	if err == nil {
@@ -1313,6 +1313,21 @@ func TestRootErrPrefixEmpty(t *testing.T) {
 	if strings.HasPrefix(output, " ") {
 		t.Errorf("Expected no leading space in error output, got %q", output)
 	}
+}
+
+func TestSetErrPrefixEmptyStringRestoresDefault(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.SetErrPrefix("custom error:")
+
+	// Setting it to "" should restore the default "Error:" prefix for backward compatibility
+	rootCmd.SetErrPrefix("")
+
+	output, err := executeCommand(rootCmd, "--unknown-root-flag")
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+
+	checkStringContains(t, output, "Error: unknown flag: --unknown-root-flag")
 }
 
 func TestVersionFlagExecutedOnSubcommand(t *testing.T) {


### PR DESCRIPTION
Currently, when a developer sets `cmd.SetErrPrefix("")`, the system incorrectly assumes the prefix was left unset due to `""` being the default zero-value for a string, and falls back to prepending `"Error: "` and a trailing space. This makes it impossible to output pure JSON errors because of the leading space injected by `c.PrintErrln`.

This PR introduces an unexported `errPrefixSet` boolean to cleanly demarcate when the user has explicitly `SetErrPrefix`.

* Modified `ErrPrefix()` getter to honor the marker without breaking the public `Command` struct API.
* Added a conditional downstream print block inside `ExecuteC` to prevent `fmt.Sprintln` from injecting a leading space when the prefix evaluates to empty.
* Added `TestRootErrPrefixEmpty` to `command_test.go` to explicitly prevent regressions.
* Existing unit tests pass.

Fixes #2226