### PR TITLE
fix(args): use invalid arg for OnlyValidArgs suggestion lookup

### DIFF
--- a/args.go
+++ b/args.go
@@ -58,7 +58,7 @@ func OnlyValidArgs(cmd *Command, args []string) error {
 		}
 		for _, v := range args {
 			if !stringInSlice(v, validArgs) {
-				return fmt.Errorf("invalid argument %q for %q%s", v, cmd.CommandPath(), cmd.findSuggestions(args[0]))
+				return fmt.Errorf("invalid argument %q for %q%s", v, cmd.CommandPath(), cmd.findSuggestions(v))
 			}
 		}
 	}

--- a/args_test.go
+++ b/args_test.go
@@ -153,6 +153,27 @@ func TestOnlyValidArgs_WithInvalidArgs(t *testing.T) {
 	validOnlyWithInvalidArgs(err, t)
 }
 
+func TestOnlyValidArgs_SuggestsForInvalidArg(t *testing.T) {
+	c := &Command{
+		Use:       "c",
+		Args:      OnlyValidArgs,
+		Run:       emptyRun,
+		ValidArgs: []string{"alpha", "beta"},
+	}
+	c.AddCommand(&Command{Use: "gamma", Run: emptyRun})
+	_, err := executeCommand(c, "alpha", "gmma")
+	if err == nil {
+		t.Fatal("Expected an error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, `invalid argument "gmma"`) {
+		t.Errorf("Expected error to reference the invalid arg %q, got: %q", "gmma", got)
+	}
+	if !strings.Contains(got, "gamma") {
+		t.Errorf("Expected suggestion %q based on invalid arg %q, got: %q", "gamma", "gmma", got)
+	}
+}
+
 // ArbitraryArgs
 
 func TestArbitraryArgs(t *testing.T) {


### PR DESCRIPTION

**Repo:** spf13/cobra (⭐ 39000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +22/-1

## What
`OnlyValidArgs` in `args.go` walks positional args and errors on the first one that is not in `Command.ValidArgs`. When building the error, it called `cmd.findSuggestions(args[0])` instead of `cmd.findSuggestions(v)` — i.e. it always computed the "Did you mean …?" hint against the *first* positional arg, not the one that actually failed validation. This change passes `v` (the offending arg) so the suggestion matches the reported invalid argument.

## Why
Using `args[0]` produces misleading or empty suggestions whenever the invalid arg is not the first positional (e.g. `cmd alpha gmma` — `alpha` is valid, `gmma` is the real problem, but suggestions were computed for `alpha`). The error message already quotes `v`, so computing suggestions from a different token is self-inconsistent. One-token swap; no API change.

## Testing
Added `TestOnlyValidArgs_SuggestsForInvalidArg` in `args_test.go`: a command with a `gamma` subcommand called as `cmd alpha gmma` must include `gamma` in the error. Verified the test FAILS on pre-fix code and PASSES with the fix (via `git stash` of `args.go`). `go test -run TestOnlyValidArgs ./.` — ok.

## Risk
Low — single-argument change in an error-construction path; behavior only differs when the invalid arg is not `args[0]`, and the new behavior matches the error message's own wording.
