### PR TITLE
doc: escape angle brackets in generated markdown

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -62,10 +62,10 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	name := cmd.CommandPath()
 
 	buf.WriteString("## " + name + "\n\n")
-	buf.WriteString(cmd.Short + "\n\n")
+	buf.WriteString(escapeAngleBrackets(cmd.Short) + "\n\n")
 	if len(cmd.Long) > 0 {
 		buf.WriteString("### Synopsis\n\n")
-		buf.WriteString(cmd.Long + "\n\n")
+		buf.WriteString(escapeAngleBrackets(cmd.Long) + "\n\n")
 	}
 
 	if cmd.Runnable() {
@@ -87,7 +87,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			pname := parent.CommandPath()
 			link := pname + markdownExtension
 			link = strings.ReplaceAll(link, " ", "_")
-			fmt.Fprintf(buf, "* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short)
+			fmt.Fprintf(buf, "* [%s](%s)\t - %s\n", pname, linkHandler(link), escapeAngleBrackets(parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
 					cmd.DisableAutoGenTag = c.DisableAutoGenTag
@@ -105,7 +105,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			cname := name + " " + child.Name()
 			link := cname + markdownExtension
 			link = strings.ReplaceAll(link, " ", "_")
-			fmt.Fprintf(buf, "* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short)
+			fmt.Fprintf(buf, "* [%s](%s)\t - %s\n", cname, linkHandler(link), escapeAngleBrackets(child.Short))
 		}
 		buf.WriteString("\n")
 	}
@@ -114,6 +114,10 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	}
 	_, err := buf.WriteTo(w)
 	return err
+}
+
+func escapeAngleBrackets(s string) string {
+	return strings.NewReplacer("<", "\\<", ">", "\\>").Replace(s)
 }
 
 // GenMarkdownTree will generate a markdown page for this command and all

--- a/doc/md_docs_test.go
+++ b/doc/md_docs_test.go
@@ -91,6 +91,32 @@ func TestGenMdNoTag(t *testing.T) {
 	checkStringOmits(t, output, "Auto generated")
 }
 
+func TestGenMdEscapesAngleBrackets(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "export <output_path>",
+		Short: "Export to <output_path>",
+		Long:  "Export the database to <output_path>.",
+		Run:   emptyRun,
+	}
+	child := &cobra.Command{
+		Use:   "status",
+		Short: "Inspect <target>",
+		Run:   emptyRun,
+	}
+	cmd.AddCommand(child)
+
+	buf := new(bytes.Buffer)
+	if err := GenMarkdown(cmd, buf); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	checkStringContains(t, output, "Export to \\<output_path\\>")
+	checkStringContains(t, output, "Export the database to \\<output_path\\>.")
+	checkStringContains(t, output, "Inspect \\<target\\>")
+	checkStringContains(t, output, "```\nexport <output_path> [flags]\n```")
+}
+
 func TestGenMdTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
 	tmpdir, err := os.MkdirTemp("", "test-gen-md-tree")


### PR DESCRIPTION
Fixes #2375.

Angle-bracket placeholders in `Short`, `Long`, and `SEE ALSO` descriptions are currently emitted as raw markdown text, so generated docs like `<output_path>` are parsed as tags by MDX consumers.

This escapes those angle brackets in markdown prose while leaving the fenced `UseLine()` output unchanged, and adds a regression test for both the synopsis text and the `SEE ALSO` descriptions.

Validation:
- `go test ./doc`
- `go test ./...`
- fresh temp-module repro that generated markdown and compiled it with `@mdx-js/mdx`
