### PR TITLE
feat: add EnablePostRunOnError to run post hooks on failure

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -65,6 +65,12 @@ var EnableCaseInsensitive = defaultCaseInsensitive
 // By default this is disabled, which means only the first run hook to be found is executed.
 var EnableTraverseRunHooks = defaultTraverseRunHooks
 
+// EnablePostRunOnError executes PostRun and PersistentPostRun hooks even when
+// RunE or PostRunE returns an error. This is useful for cleanup operations
+// (logging, resource release, etc.) that must run regardless of command outcome.
+// By default this is disabled to maintain backward compatibility.
+var EnablePostRunOnError = false
+
 // MousetrapHelpText enables an information splash screen on Windows
 // if the CLI is started from explorer.exe.
 // To disable the mousetrap, just set this variable to blank string ("").

--- a/command.go
+++ b/command.go
@@ -1011,16 +1011,23 @@ func (c *Command) execute(a []string) (err error) {
 		return err
 	}
 
+	var runErr error
 	if c.RunE != nil {
-		if err := c.RunE(c, argWoFlags); err != nil {
-			return err
+		runErr = c.RunE(c, argWoFlags)
+		if runErr != nil && !EnablePostRunOnError {
+			return runErr
 		}
 	} else {
 		c.Run(c, argWoFlags)
 	}
 	if c.PostRunE != nil {
 		if err := c.PostRunE(c, argWoFlags); err != nil {
-			return err
+			if !EnablePostRunOnError {
+				return err
+			}
+			if runErr == nil {
+				runErr = err
+			}
 		}
 	} else if c.PostRun != nil {
 		c.PostRun(c, argWoFlags)
@@ -1028,7 +1035,12 @@ func (c *Command) execute(a []string) (err error) {
 	for p := c; p != nil; p = p.Parent() {
 		if p.PersistentPostRunE != nil {
 			if err := p.PersistentPostRunE(c, argWoFlags); err != nil {
-				return err
+				if !EnablePostRunOnError {
+					return err
+				}
+				if runErr == nil {
+					runErr = err
+				}
 			}
 			if !EnableTraverseRunHooks {
 				break
@@ -1041,7 +1053,7 @@ func (c *Command) execute(a []string) (err error) {
 		}
 	}
 
-	return nil
+	return runErr
 }
 
 func (c *Command) preRun() {

--- a/command_test.go
+++ b/command_test.go
@@ -1785,6 +1785,58 @@ func testPersistentHooks(t *testing.T, expectedHookRunOrder []string) {
 	}
 }
 
+// Related to https://github.com/spf13/cobra/issues/1893.
+func TestPostRunOnError(t *testing.T) {
+	var hookRunOrder []string
+
+	parentCmd := &Command{
+		Use: "parent",
+		PersistentPostRun: func(_ *Command, args []string) {
+			hookRunOrder = append(hookRunOrder, "parent PersistentPostRun")
+		},
+	}
+
+	childCmd := &Command{
+		Use: "child",
+		RunE: func(_ *Command, args []string) error {
+			hookRunOrder = append(hookRunOrder, "child RunE")
+			return fmt.Errorf("run failed")
+		},
+		PostRun: func(_ *Command, args []string) {
+			hookRunOrder = append(hookRunOrder, "child PostRun")
+		},
+	}
+	parentCmd.AddCommand(childCmd)
+
+	// Without EnablePostRunOnError: PostRun and PersistentPostRun should NOT execute
+	hookRunOrder = nil
+	_, err := executeCommand(parentCmd, "child")
+	if err == nil {
+		t.Fatal("Expected error from RunE")
+	}
+	expected := []string{"child RunE"}
+	if !reflect.DeepEqual(hookRunOrder, expected) {
+		t.Errorf("Without EnablePostRunOnError: expected %v, got %v", expected, hookRunOrder)
+	}
+
+	// With EnablePostRunOnError: PostRun and PersistentPostRun SHOULD execute
+	EnablePostRunOnError = true
+	defer func() { EnablePostRunOnError = false }()
+
+	hookRunOrder = nil
+	_, err = executeCommand(parentCmd, "child")
+	if err == nil {
+		t.Fatal("Expected error from RunE")
+	}
+	if err.Error() != "run failed" {
+		t.Errorf("Expected 'run failed' error, got %q", err.Error())
+	}
+	expected = []string{"child RunE", "child PostRun", "parent PersistentPostRun"}
+	if !reflect.DeepEqual(hookRunOrder, expected) {
+		t.Errorf("With EnablePostRunOnError: expected %v, got %v", expected, hookRunOrder)
+	}
+}
+
 // Related to https://github.com/spf13/cobra/issues/521.
 func TestGlobalNormFuncPropagation(t *testing.T) {
 	normFunc := func(f *pflag.FlagSet, name string) pflag.NormalizedName {


### PR DESCRIPTION
## Summary

Fixes #1893.

When `EnablePostRunOnError` is set to `true`, `PostRun`, `PersistentPostRun` (and their `E` variants) execute even when `RunE` or `PostRunE` returns an error. The original error is still returned to the caller.

### Why

Currently, when `RunE` returns an error, execution stops immediately and all post-run hooks are skipped. This prevents cleanup operations like logging, resource release, or support archive creation from running when a command fails, which is exactly when they're most needed.

### Design

Follows the same pattern as `EnableTraverseRunHooks` — a package-level variable, disabled by default, fully backward compatible.

```go
cobra.EnablePostRunOnError = true
```

### Example

```go
rootCmd := &cobra.Command{
    Use: "app",
    PersistentPostRun: func(cmd *cobra.Command, args []string) {
        // This now runs even when RunE fails
        logger.Flush()
        telemetry.Close()
    },
}
```

### Changes

- `cobra.go`: Added `EnablePostRunOnError` variable
- `command.go`: Modified `execute()` to continue to post-run hooks when flag is set, preserving the original error
- `command_test.go`: Added `TestPostRunOnError` verifying both disabled (backward compat) and enabled behavior

### Test results

```
ok  github.com/spf13/cobra      0.370s
ok  github.com/spf13/cobra/doc  0.006s
```