### PR TITLE
powershell: fix non-ASCII character corruption in tab completion on Windows

### DIFF
--- a/powershell_completions.go
+++ b/powershell_completions.go
@@ -126,7 +126,10 @@ filter __%[1]s_escapeStringWithSpecialChars {
 
     #call the command store the output in $out and redirect stderr and stdout to null
     # $Out is an array contains each line per element
+    $oldEncoding = [Console]::OutputEncoding
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     Invoke-Expression -OutVariable out "$RequestComp" 2>&1 | Out-Null
+    [Console]::OutputEncoding = $oldEncoding
 
     # get directive from last line
     [int]$Directive = $Out[-1].TrimStart(':')


### PR DESCRIPTION
## Problem

On Windows, `[Console]::OutputEncoding` defaults to the system OEM code page
rather than UTF-8. This causes non-ASCII characters in remote/path names to be
corrupted after tab completion.

Example: `Zażółć` becomes `Za┼╝├│┼é─ç`

Reported in rclone/rclone#9412 (rclone uses cobra-generated completions).

## Fix

Temporarily switch `[Console]::OutputEncoding` to UTF-8 around the completion
command invocation and restore it afterwards — the same pattern already used
in the generated script for other purposes.

## Testing

Tested on Windows PowerShell 5.1 with Polish diacritics in path names.