### PR TITLE
feat: add MarkFlagNonRepeatable to reject repeated flags

### DIFF
--- a/flag_groups.go
+++ b/flag_groups.go
@@ -76,6 +76,39 @@ func (c *Command) MarkFlagsMutuallyExclusive(flagNames ...string) {
 	}
 }
 
+// MarkFlagNonRepeatable marks the given flag so that Cobra errors if the flag
+// is specified more than once on the command line.
+func (c *Command) MarkFlagNonRepeatable(name string) {
+	c.mergePersistentFlags()
+	f := c.Flags().Lookup(name)
+	if f == nil {
+		panic(fmt.Sprintf("Failed to find flag %q and mark it as non-repeatable", name))
+	}
+	f.Value = &nonRepeatableValue{Value: f.Value, flagName: name}
+}
+
+// nonRepeatableValue wraps a pflag.Value to reject a second call to Set.
+type nonRepeatableValue struct {
+	flag.Value
+	setCount int
+	flagName string
+}
+
+func (v *nonRepeatableValue) Set(s string) error {
+	v.setCount++
+	if v.setCount > 1 {
+		return fmt.Errorf("flag %q cannot be specified more than once", v.flagName)
+	}
+	return v.Value.Set(s)
+}
+
+// IsBoolFlag forwards the BoolFlag interface so that boolean flags wrapped as
+// non-repeatable still support --flag (without a value) syntax.
+func (v *nonRepeatableValue) IsBoolFlag() bool {
+	bf, ok := v.Value.(interface{ IsBoolFlag() bool })
+	return ok && bf.IsBoolFlag()
+}
+
 // ValidateFlagGroups validates the mutuallyExclusive/oneRequired/requiredAsGroup logic and returns the
 // first error encountered.
 func (c *Command) ValidateFlagGroups() error {

--- a/flag_groups_test.go
+++ b/flag_groups_test.go
@@ -19,6 +19,64 @@ import (
 	"testing"
 )
 
+func TestNonRepeatableFlag(t *testing.T) {
+	getCmd := func() *Command {
+		c := &Command{
+			Use: "testcmd",
+			Run: func(cmd *Command, args []string) {},
+		}
+		c.Flags().String("name", "", "")
+		c.Flags().Bool("verbose", false, "")
+		c.MarkFlagNonRepeatable("name")
+		c.MarkFlagNonRepeatable("verbose")
+		return c
+	}
+
+	testcases := []struct {
+		desc      string
+		args      []string
+		expectErr string
+	}{
+		{
+			desc: "single use of string flag",
+			args: []string{"--name=foo"},
+		},
+		{
+			desc:      "repeated string flag",
+			args:      []string{"--name=foo", "--name=bar"},
+			expectErr: `cannot be specified more than once`,
+		},
+		{
+			desc: "single use of bool flag",
+			args: []string{"--verbose"},
+		},
+		{
+			desc:      "repeated bool flag",
+			args:      []string{"--verbose", "--verbose"},
+			expectErr: `cannot be specified more than once`,
+		},
+		{
+			desc: "no flags set",
+			args: []string{},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			c := getCmd()
+			c.SetArgs(tc.args)
+			err := c.Execute()
+			switch {
+			case err == nil && len(tc.expectErr) > 0:
+				t.Errorf("Expected error containing %q but got nil", tc.expectErr)
+			case err != nil && len(tc.expectErr) == 0:
+				t.Errorf("Expected no error but got %q", err)
+			case err != nil && !strings.Contains(err.Error(), tc.expectErr):
+				t.Errorf("Expected error containing %q but got %q", tc.expectErr, err)
+			}
+		})
+	}
+}
+
 func TestValidateFlagGroups(t *testing.T) {
 	getCmd := func() *Command {
 		c := &Command{


### PR DESCRIPTION
## Summary

Adds `MarkFlagNonRepeatable(name string)` to `Command`, which prevents a flag from being specified more than once on the command line.

Currently, developers who need this behavior must define custom `pflag.Value` types for every flag type they use (~60 lines each), as described in #2355. This PR offers a single-call API that wraps the flag's existing `Value` to reject a second `Set()` invocation.

### Implementation

- **`nonRepeatableValue`** — a thin wrapper around `pflag.Value` that counts `Set()` calls and returns an error on the second one.
- **`IsBoolFlag()`** is forwarded so `--verbose` (no value) still works for boolean flags.
- The approach catches the repetition at parse time, giving the user immediate feedback.

### Example

```go
cmd.Flags().String("name", "", "user name")
cmd.MarkFlagNonRepeatable("name")
// mycli --name=alice --name=bob → error
```

## Test plan

- [x] `TestNonRepeatableFlag` — 5 cases: single string, repeated string, single bool, repeated bool, no flags
- [x] All existing tests pass (`go test ./...`)
- [x] `go build ./...` and `go vet ./...` clean

Closes #2355