### PR TITLE
feat: infer version of sub from parents (#1860)

### DIFF
--- a/command.go
+++ b/command.go
@@ -1231,11 +1231,32 @@ func (c *Command) InitDefaultHelpFlag() {
 	}
 }
 
+// inferVersion attempts to determine the version of an unversioned
+// subcommand by querying the version of the parent. If the parent's
+// version is not set, then the process continues until the root command
+// is reached. If the root command is also unversioned, then the subcommand
+// remains unversioned.
+func (c *Command) inferVersion() string {
+	if c.Version != "" {
+		return c.Version
+	}
+	current := c
+	for current.HasParent() {
+		current = current.Parent()
+		if current.Version != "" {
+			return current.Version
+		}
+	}
+	return ""
+}
+
 // InitDefaultVersionFlag adds default version flag to c.
 // It is called automatically by executing the c.
 // If c already has a version flag, it will do nothing.
 // If c.Version is empty, it will do nothing.
 func (c *Command) InitDefaultVersionFlag() {
+	c.Version = c.inferVersion()
+
 	if c.Version == "" {
 		return
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -1341,7 +1341,7 @@ func TestShortVersionFlagOnlyAddedToRoot(t *testing.T) {
 	}
 }
 
-func TestVersionInference(t *testing.T) {
+func TestDirectVersionInference(t *testing.T) {
 	rootCmd := &Command{Use: "root", Version: "1.0.0", Run: emptyRun}
 	sub1 := &Command{Use: "sub1", Version: "2.0.0", Run: emptyRun}
 	sub2 := &Command{Use: "sub2", Version: "1.0.1", Run: emptyRun}
@@ -1357,6 +1357,25 @@ func TestVersionInference(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		checkStringContains(t, output, fmt.Sprintf("%s version %s", cmd.Name(), cmd.Parent().Version))
+	}
+}
+
+func TestDistantVersionInference(t *testing.T) {
+	rootCmd := &Command{Use: "root", Version: "1.0.0", Run: emptyRun}
+	sub1 := &Command{Use: "sub1", Run: emptyRun}
+	sub2 := &Command{Use: "sub2", Run: emptyRun}
+	sub1a := &Command{Use: "sub1a", Run: emptyRun}
+	sub2a := &Command{Use: "sub2a", Run: emptyRun}
+	rootCmd.AddCommand(sub1, sub2)
+	sub1.AddCommand(sub1a)
+	sub2.AddCommand(sub2a)
+	testCases := []*Command{sub1a, sub2a}
+	for _, cmd := range testCases {
+		output, err := executeCommand(rootCmd, cmd.Parent().Name(), cmd.Name(), "-v")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		checkStringContains(t, output, fmt.Sprintf("%s version %s", cmd.Name(), cmd.Parent().Parent().Version))
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -1326,11 +1326,9 @@ func TestVersionFlagOnlyAddedToRoot(t *testing.T) {
 	rootCmd.AddCommand(&Command{Use: "sub", Run: emptyRun})
 
 	_, err := executeCommand(rootCmd, "sub", "--version")
-	if err == nil {
-		t.Errorf("Expected error")
+	if err != nil {
+		t.Errorf("Unexpected error")
 	}
-
-	checkStringContains(t, err.Error(), "unknown flag: --version")
 }
 
 func TestShortVersionFlagOnlyAddedToRoot(t *testing.T) {
@@ -1338,11 +1336,28 @@ func TestShortVersionFlagOnlyAddedToRoot(t *testing.T) {
 	rootCmd.AddCommand(&Command{Use: "sub", Run: emptyRun})
 
 	_, err := executeCommand(rootCmd, "sub", "-v")
-	if err == nil {
-		t.Errorf("Expected error")
+	if err != nil {
+		t.Errorf("Unexpected error")
 	}
+}
 
-	checkStringContains(t, err.Error(), "unknown shorthand flag: 'v' in -v")
+func TestVersionInference(t *testing.T) {
+	rootCmd := &Command{Use: "root", Version: "1.0.0", Run: emptyRun}
+	sub1 := &Command{Use: "sub1", Version: "2.0.0", Run: emptyRun}
+	sub2 := &Command{Use: "sub2", Version: "1.0.1", Run: emptyRun}
+	sub1a := &Command{Use: "sub1a", Run: emptyRun}
+	sub2a := &Command{Use: "sub2a", Run: emptyRun}
+	rootCmd.AddCommand(sub1, sub2)
+	sub1.AddCommand(sub1a)
+	sub2.AddCommand(sub2a)
+	testCases := []*Command{sub1a, sub2a}
+	for _, cmd := range testCases {
+		output, err := executeCommand(rootCmd, cmd.Parent().Name(), cmd.Name(), "-v")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		checkStringContains(t, output, fmt.Sprintf("%s version %s", cmd.Name(), cmd.Parent().Version))
+	}
 }
 
 func TestVersionFlagOnlyExistsIfVersionNonEmpty(t *testing.T) {


### PR DESCRIPTION
## What
- Added transparent subcommand version inference from nearest versioned parent.
- Added tests for nested subcommands deriving versions from direct parents.
- Altered existing tests expecting errors when subcommand version is requested without being explicitly set.
- Resolves issues from some of @brianpursley's examples, including issue title.

#### Example 1: Base case, works as expected for the root command
> No change.
```
$ go run mycmd.go --version
root version 1.0.0
```

#### Example 2: Pass sub command after the flag. This is what the unit test does.
> No change.
```
$ go run mycmd.go --version sub
root version 1.0.0
```

#### Example 3: Pass sub command before the flag. Now you can see it's not really working for sub commands.
> Change: `sub` derives version from `root`.
```
$ go run mycmd.go sub --version
sub version 1.0.0
```

#### Example 4: Pass an argument to the sub command. This shows that cobra must be interpreting "sub" as a flag value because it considers `foo` to be the sub command
> No change: Probably not related to versioning mentioned in issue. I suggest a new issue is raised for this.
```
$ go run mycmd.go --version sub foo
Error: unknown command "foo" for "root"
Run 'root --help' for usage.
```

#### Example 5: To further show that it is skipping over the sub, I can pass sub twice and it then says `--version` is an unknown flag for sub:
> Change: The version of `sub` is returned rather than throwing an error. We expect this command to return the version of `root`. Possibly related to the bug from above. 
```
$ go run mycmd.go --version sub sub
sub version 1.0.0
```

## Why
- Addresses part of #1860, including issue title.