### PR TITLE
feat: add fileAppender parameter to GenMarkdownTreeCustom

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -125,17 +125,17 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 func GenMarkdownTree(cmd *cobra.Command, dir string) error {
 	identity := func(s string) string { return s }
 	emptyStr := func(s string) string { return "" }
-	return GenMarkdownTreeCustom(cmd, dir, emptyStr, identity)
+	return GenMarkdownTreeCustom(cmd, dir, emptyStr, emptyStr, identity)
 }
 
 // GenMarkdownTreeCustom is the same as GenMarkdownTree, but
-// with custom filePrepender and linkHandler.
-func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string) error {
+// with custom filePrepender, fileAppender, and linkHandler.
+func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, fileAppender, linkHandler func(string) string) error {
 	for _, c := range cmd.Commands() {
 		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
 			continue
 		}
-		if err := GenMarkdownTreeCustom(c, dir, filePrepender, linkHandler); err != nil {
+		if err := GenMarkdownTreeCustom(c, dir, filePrepender, fileAppender, linkHandler); err != nil {
 			return err
 		}
 	}
@@ -152,6 +152,9 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 		return err
 	}
 	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(f, fileAppender(filename)); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This is an independent contribution submitted in a personal capacity and is not associated with any competition or organized event.

## Summary

Add a `fileAppender` parameter to `GenMarkdownTreeCustom`, enabling callers to append content (such as footers or custom metadata) to generated markdown files — mirroring the existing `filePrepender` behavior.

## Root Cause

`GenMarkdownTreeCustom` accepts a `filePrepender func(string) string` that writes content before the generated markdown, but there is no equivalent mechanism to append content after the markdown body. Users who need to inject footers must resort to post-processing the generated files.

Closes: #1140

## Fix

Added a `fileAppender func(string) string` parameter to `GenMarkdownTreeCustom`. The appender is called with the filename after `GenMarkdownCustom` writes the markdown content, following the same pattern as `filePrepender`.

- `GenMarkdownTree` passes `emptyStr` for the new parameter (backward compatible)
- Recursive calls pass `fileAppender` through
- Doc comment updated

## Testing

- `go build ./doc/...` compiles without errors
- Existing `GenMarkdownTree` behavior is unchanged — the default `emptyStr` appender writes nothing