### PR TITLE
fix: preserve colon arguments in bash completions

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -233,6 +233,41 @@ __%[1]s_handle_activeHelp() {
     fi
 }
 
+__%[1]s_rejoin_colon_wordbreak()
+{
+    if [[ "$COMP_WORDBREAKS" != *:* || "$cur" == *:* ]]; then
+        return
+    fi
+
+    local rawWord
+    rawWord=${COMP_LINE:0:COMP_POINT}
+    rawWord=${rawWord##*[[:space:]]}
+    if [[ "$rawWord" != *:* ]]; then
+        return
+    fi
+
+    local i
+    for ((i=cword; i>0; i--)); do
+        if [[ "${words[i]}" == ":" ]]; then
+            words[i-1]="${words[i-1]}:${cur}"
+            words=("${words[@]:0:i}")
+            cur="${words[i-1]}"
+            cword=$((i - 1))
+            __%[1]s_debug "Rejoined colon wordbreak: ${cur}"
+            return
+        fi
+
+        if [[ "${words[i]}" == *: ]]; then
+            words[i]="${words[i]}${cur}"
+            words=("${words[@]:0:$((i + 1))}")
+            cur="${words[i]}"
+            cword=$i
+            __%[1]s_debug "Rejoined colon-suffixed word: ${cur}"
+            return
+        fi
+    done
+}
+
 __%[1]s_reprint_commandLine() {
     # The prompt format is only available from bash 4.4.
     # We test if it is available before using it.
@@ -447,6 +482,8 @@ __start_%[1]s()
     # to truncate the command-line ($words) up to the $cword location.
     words=("${words[@]:0:$cword+1}")
     __%[1]s_debug "Truncated words[*]: ${words[*]},"
+
+    __%[1]s_rejoin_colon_wordbreak
 
     local out directive
     __%[1]s_get_completion_results

--- a/bash_completionsV2_test.go
+++ b/bash_completionsV2_test.go
@@ -17,6 +17,9 @@ package cobra
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -30,4 +33,58 @@ func TestBashCompletionV2WithActiveHelp(t *testing.T) {
 	// check that active help is not being disabled
 	activeHelpVar := activeHelpEnvVar(c.Name())
 	checkOmit(t, output, fmt.Sprintf("%s=0", activeHelpVar))
+}
+
+func TestBashCompletionV2RejoinsColonWordbreak(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is not available")
+	}
+
+	c := &Command{Use: "c", Run: emptyRun}
+
+	buf := new(bytes.Buffer)
+	assertNoErr(t, c.GenBashCompletionV2(buf, false))
+
+	tempDir := t.TempDir()
+	completionFile := tempDir + "/completion.bash"
+	requestFile := tempDir + "/request.log"
+	assertNoErr(t, os.WriteFile(completionFile, buf.Bytes(), 0o600))
+
+	script := fmt.Sprintf(`
+set -euo pipefail
+source "$COMPLETION_FILE"
+_init_completion() {
+	cur="/"
+	prev=":"
+	words=(c ls local : /)
+	cword=4
+}
+c() {
+	printf '%%s\n' "$@" > "$REQUEST_FILE"
+	printf ':%d\n'
+}
+COMP_TYPE=9
+COMP_LINE='c ls local:/'
+COMP_POINT=${#COMP_LINE}
+__start_c
+`, ShellCompDirectiveNoFileComp)
+
+	cmd := exec.Command(bash, "-c", script)
+	cmd.Env = append(os.Environ(),
+		"COMPLETION_FILE="+completionFile,
+		"REQUEST_FILE="+requestFile,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash completion failed: %v\n%s", err, output)
+	}
+
+	request, err := os.ReadFile(requestFile)
+	assertNoErr(t, err)
+
+	expected := "__completeNoDesc\nls\nlocal:/"
+	if got := strings.TrimSpace(string(request)); got != expected {
+		t.Fatalf("expected request:\n%s\ngot:\n%s", expected, got)
+	}
 }


### PR DESCRIPTION
Fixes #2376.

## Summary
- rejoin Bash words split around `:` before Cobra calls `__complete`
- keep `ValidArgsFunction` receiving URI-like values such as `local:/` as the active argument
- add a Bash-driven regression test for the split `local : /` case

## Tests
- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./ -run TestBashCompletionV2RejoinsColonWordbreak -count=1` (failed before the fix)
- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./ -run 'TestBashCompletionV2(RejoinsColonWordbreak|WithActiveHelp)' -count=1`
- `GOMODCACHE=/tmp/cobra-2376-gomodcache GOCACHE=/tmp/cobra-2376-gocache make all`
- `PATH=/tmp/cobra-2376-bin:$PATH GOMODCACHE=/tmp/cobra-2376-gomodcache GOCACHE=/tmp/cobra-2376-gocache golangci-lint run --new-from-rev=upstream/main --verbose`
- `git diff --check`
