### PR TITLE
doc: add word wrap support for Short and Long in generated markdown

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -48,6 +48,14 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	return nil
 }
 
+// MarkdownOptions controls optional behaviors of GenMarkdownCustomWithOptions.
+type MarkdownOptions struct {
+	// WrapWidth sets the maximum line length for the Short and Long fields.
+	// Lines already shorter than WrapWidth and existing newlines are preserved.
+	// A value of 0 disables wrapping entirely.
+	WrapWidth int
+}
+
 // GenMarkdown creates markdown output.
 func GenMarkdown(cmd *cobra.Command, w io.Writer) error {
 	return GenMarkdownCustom(cmd, w, func(s string) string { return s })
@@ -55,6 +63,11 @@ func GenMarkdown(cmd *cobra.Command, w io.Writer) error {
 
 // GenMarkdownCustom creates custom markdown output.
 func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string) string) error {
+	return GenMarkdownCustomWithOptions(cmd, w, linkHandler, MarkdownOptions{})
+}
+
+// GenMarkdownCustomWithOptions creates custom markdown output with additional options.
+func GenMarkdownCustomWithOptions(cmd *cobra.Command, w io.Writer, linkHandler func(string) string, opts MarkdownOptions) error {
 	cmd.InitDefaultHelpCmd()
 	cmd.InitDefaultHelpFlag()
 
@@ -62,10 +75,10 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	name := cmd.CommandPath()
 
 	buf.WriteString("## " + name + "\n\n")
-	buf.WriteString(cmd.Short + "\n\n")
+	buf.WriteString(wordWrap(cmd.Short, opts.WrapWidth) + "\n\n")
 	if len(cmd.Long) > 0 {
 		buf.WriteString("### Synopsis\n\n")
-		buf.WriteString(cmd.Long + "\n\n")
+		buf.WriteString(wordWrap(cmd.Long, opts.WrapWidth) + "\n\n")
 	}
 
 	if cmd.Runnable() {
@@ -131,11 +144,17 @@ func GenMarkdownTree(cmd *cobra.Command, dir string) error {
 // GenMarkdownTreeCustom is the same as GenMarkdownTree, but
 // with custom filePrepender and linkHandler.
 func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string) error {
+	return GenMarkdownTreeCustomWithOptions(cmd, dir, filePrepender, linkHandler, MarkdownOptions{})
+}
+
+// GenMarkdownTreeCustomWithOptions is the same as GenMarkdownTreeCustom, but
+// with additional options.
+func GenMarkdownTreeCustomWithOptions(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string, opts MarkdownOptions) error {
 	for _, c := range cmd.Commands() {
 		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
 			continue
 		}
-		if err := GenMarkdownTreeCustom(c, dir, filePrepender, linkHandler); err != nil {
+		if err := GenMarkdownTreeCustomWithOptions(c, dir, filePrepender, linkHandler, opts); err != nil {
 			return err
 		}
 	}
@@ -151,7 +170,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
 		return err
 	}
-	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {
+	if err := GenMarkdownCustomWithOptions(cmd, f, linkHandler, opts); err != nil {
 		return err
 	}
 	return nil

--- a/doc/md_docs_test.go
+++ b/doc/md_docs_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -103,6 +104,101 @@ func TestGenMdTree(t *testing.T) {
 		t.Fatalf("GenMarkdownTree failed: %v", err)
 	}
 
+	if _, err := os.Stat(filepath.Join(tmpdir, "do.md")); err != nil {
+		t.Fatalf("Expected file 'do.md' to exist")
+	}
+}
+
+const wrapTestCmdUse = "wraptest"
+
+func TestGenMdDocWithOptions_NoWrap(t *testing.T) {
+	long := "This is a very long description that exceeds a typical wrap width and should not be wrapped when WrapWidth is zero"
+	cmd := &cobra.Command{
+		Use:   wrapTestCmdUse,
+		Short: long,
+		Long:  long,
+		Run:   emptyRun,
+	}
+
+	buf := new(bytes.Buffer)
+	if err := GenMarkdownCustomWithOptions(cmd, buf, func(s string) string { return s }, MarkdownOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	checkStringContains(t, output, long)
+}
+
+func TestGenMdDocWithOptions_WrapWidth(t *testing.T) {
+	long := "This is a very long description that exceeds the wrap width and should be wrapped across multiple lines"
+	cmd := &cobra.Command{
+		Use:   wrapTestCmdUse,
+		Short: long,
+		Long:  long,
+		Run:   emptyRun,
+	}
+
+	buf := new(bytes.Buffer)
+	if err := GenMarkdownCustomWithOptions(cmd, buf, func(s string) string { return s }, MarkdownOptions{WrapWidth: 40}); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	for _, line := range strings.Split(output, "\n") {
+		if len(line) > 40 {
+			// Lines from flags and other sections may exceed width; only check prose lines.
+			if !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "*") && !strings.HasPrefix(line, "  ") {
+				t.Errorf("line exceeds wrap width of 40: %q", line)
+			}
+		}
+	}
+}
+
+func TestGenMdDocWithOptions_PreservesExistingNewlines(t *testing.T) {
+	long := "First sentence.\nSecond sentence on its own line."
+	cmd := &cobra.Command{
+		Use:  "test",
+		Long: long,
+		Run:  emptyRun,
+	}
+
+	buf := new(bytes.Buffer)
+	if err := GenMarkdownCustomWithOptions(cmd, buf, func(s string) string { return s }, MarkdownOptions{WrapWidth: 80}); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	checkStringContains(t, output, "First sentence.")
+	checkStringContains(t, output, "Second sentence on its own line.")
+}
+
+func TestGenMdDocWithOptions_MatchesGenMarkdownCustom(t *testing.T) {
+	buf1 := new(bytes.Buffer)
+	buf2 := new(bytes.Buffer)
+	linkHandler := func(s string) string { return s }
+
+	if err := GenMarkdownCustom(echoCmd, buf1, linkHandler); err != nil {
+		t.Fatal(err)
+	}
+	if err := GenMarkdownCustomWithOptions(echoCmd, buf2, linkHandler, MarkdownOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if buf1.String() != buf2.String() {
+		t.Error("GenMarkdownCustomWithOptions with zero options should produce identical output to GenMarkdownCustom")
+	}
+}
+
+func TestGenMdTreeCustomWithOptions(t *testing.T) {
+	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
+	tmpdir, err := os.MkdirTemp("", "test-gen-md-tree-opts")
+	if err != nil {
+		t.Fatalf("Failed to create tmpdir: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	identity := func(s string) string { return s }
+	emptyStr := func(s string) string { return "" }
+	if err := GenMarkdownTreeCustomWithOptions(c, tmpdir, emptyStr, identity, MarkdownOptions{WrapWidth: 80}); err != nil {
+		t.Fatalf("GenMarkdownTreeCustomWithOptions failed: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(tmpdir, "do.md")); err != nil {
 		t.Fatalf("Expected file 'do.md' to exist")
 	}

--- a/doc/util.go
+++ b/doc/util.go
@@ -36,6 +36,39 @@ func hasSeeAlso(cmd *cobra.Command) bool {
 	return false
 }
 
+// wordWrap wraps s at word boundaries so no line exceeds width characters.
+// Existing newlines are preserved and not re-joined. width <= 0 is a no-op.
+func wordWrap(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	var out []string
+	for _, line := range lines {
+		out = append(out, wrapLine(line, width)...)
+	}
+	return strings.Join(out, "\n")
+}
+
+func wrapLine(line string, width int) []string {
+	if len(line) <= width {
+		return []string{line}
+	}
+	var lines []string
+	for len(line) > width {
+		cutAt := width
+		if idx := strings.LastIndex(line[:width], " "); idx > 0 {
+			cutAt = idx
+		}
+		lines = append(lines, line[:cutAt])
+		line = strings.TrimLeft(line[cutAt:], " ")
+	}
+	if len(line) > 0 {
+		lines = append(lines, line)
+	}
+	return lines
+}
+
 // Temporary workaround for yaml lib generating incorrect yaml with long strings
 // that do not contain \n.
 func forceMultiLine(s string) string {


### PR DESCRIPTION
## Summary

- Adds `GenMarkdownCustomWithOptions` and `GenMarkdownTreeCustomWithOptions` with a `MarkdownOptions` struct
- `MarkdownOptions.WrapWidth` sets the max line length for `Short` and `Long` fields; `0` disables wrapping (fully backward-compatible)
- `cmd.Example` is intentionally excluded: it renders inside a Markdown code fence which is always verbatim; wrapping it would corrupt command syntax

## Test plan

- [x] `TestGenMdDocWithOptions_NoWrap` : `WrapWidth=0` produces identical output to `GenMarkdownCustom`
- [x] `TestGenMdDocWithOptions_WrapWidth` : prose lines respect the configured width
- [x] `TestGenMdDocWithOptions_PreservesExistingNewlines` : existing `\n` in text is not re-joined
- [x] `TestGenMdDocWithOptions_MatchesGenMarkdownCustom` : output identity with zero options
- [x] `TestGenMdTreeCustomWithOptions` : tree variant generates files correctly
- [x] All existing tests pass (`go test ./...`)

Closes #2282