### PR TITLE
feat: document positional arguments in help output

### DIFF
--- a/args_usage.go
+++ b/args_usage.go
@@ -1,0 +1,93 @@
+// Copyright 2013-2023 The Cobra Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cobra
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ArgSpec documents one positional argument of a command. It is descriptive
+// only: Cobra renders it in the help output and exposes it for introspection,
+// but does not use it to validate input. Set Command.Args for validation.
+type ArgSpec struct {
+	// Name is the placeholder shown in help, rendered as <name>.
+	Name string
+
+	// Description explains what the argument is. Keep it to a short phrase; it
+	// is aligned against the other arguments in the help output.
+	Description string
+
+	// Example is an optional value a caller can copy. When set, and not already
+	// present in Description, it is appended as " (e.g. <example>)".
+	Example string
+}
+
+// HasAvailableArguments reports whether the command documents any positional
+// arguments to show in the help output.
+func (c *Command) HasAvailableArguments() bool {
+	return len(c.Arguments) > 0
+}
+
+// placeholder renders the argument name as it appears in help, wrapping a bare
+// name in angle brackets. A name that already carries its own notation is left
+// untouched, so the author keeps control of it: a bracketed form such as
+// "[note]", "<id>", or "{a|b}", or a variadic suffix such as "files...". Any
+// other name — including a bare dotted one like "config.file" — is wrapped.
+func (a ArgSpec) placeholder() string {
+	name := a.Name
+	if name == "" {
+		return name
+	}
+	if strings.HasSuffix(name, "...") {
+		return name
+	}
+	switch name[0] {
+	case '[', '<', '{', '(':
+		return name
+	}
+	return "<" + name + ">"
+}
+
+// ArgumentUsages returns a formatted, aligned listing of the command's
+// documented positional arguments, one per line, ready to print under an
+// "Arguments:" heading. It mirrors the layout of flag usages.
+func (c *Command) ArgumentUsages() string {
+	if len(c.Arguments) == 0 {
+		return ""
+	}
+
+	width := 0
+	placeholders := make([]string, len(c.Arguments))
+	for i, a := range c.Arguments {
+		placeholders[i] = a.placeholder()
+		if l := len(placeholders[i]); l > width {
+			width = l
+		}
+	}
+
+	var b strings.Builder
+	for i, a := range c.Arguments {
+		desc := a.Description
+		if a.Example != "" && !strings.Contains(desc, a.Example) {
+			if desc != "" {
+				desc += " "
+			}
+			desc += "(e.g. " + a.Example + ")"
+		}
+		fmt.Fprintf(&b, "  %-*s   %s\n", width, placeholders[i], desc)
+	}
+	return b.String()
+}

--- a/args_usage_test.go
+++ b/args_usage_test.go
@@ -1,0 +1,166 @@
+// Copyright 2013-2023 The Cobra Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cobra
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestHasAvailableArguments(t *testing.T) {
+	none := &Command{Use: "none", Run: emptyRun}
+	if none.HasAvailableArguments() {
+		t.Error("expected no documented arguments")
+	}
+
+	some := &Command{
+		Use:       "some <id>",
+		Run:       emptyRun,
+		Arguments: []ArgSpec{{Name: "id", Description: "an id"}},
+	}
+	if !some.HasAvailableArguments() {
+		t.Error("expected documented arguments")
+	}
+}
+
+func TestArgumentUsages(t *testing.T) {
+	c := &Command{
+		Use: "get <id> <path>",
+		Arguments: []ArgSpec{
+			{Name: "id", Description: "item id", Example: "10239"},
+			{Name: "path", Description: "destination file"},
+			{Name: "[note]", Description: "optional note"},
+		},
+	}
+
+	got := c.ArgumentUsages()
+	want := "" +
+		"  <id>     item id (e.g. 10239)\n" +
+		"  <path>   destination file\n" +
+		"  [note]   optional note\n"
+	if got != want {
+		t.Errorf("ArgumentUsages mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestArgSpecPlaceholder(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"id", "<id>"},
+		{"config.file", "<config.file>"}, // bare dotted name is still wrapped
+		{"user.email", "<user.email>"},
+		{"[note]", "[note]"},         // authored optional notation kept
+		{"<id>", "<id>"},             // already wrapped, kept
+		{"{a|b}", "{a|b}"},           // alternation kept
+		{"files...", "files..."},     // variadic suffix kept
+		{"[files...]", "[files...]"}, // bracketed variadic kept
+		{"", ""},                     // degenerate empty name
+	}
+	for _, tt := range tests {
+		if got := (ArgSpec{Name: tt.name}).placeholder(); got != tt.want {
+			t.Errorf("placeholder(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestArgumentUsagesEmpty(t *testing.T) {
+	c := &Command{Use: "bare"}
+	if got := c.ArgumentUsages(); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestArgumentUsagesExampleNotDuplicated(t *testing.T) {
+	c := &Command{
+		Use: "do",
+		Arguments: []ArgSpec{
+			{Name: "ref", Description: "submission ref such as DEVOOPS-8298", Example: "DEVOOPS-8298"},
+		},
+	}
+	if n := strings.Count(c.ArgumentUsages(), "DEVOOPS-8298"); n != 1 {
+		t.Errorf("expected the example to appear once, got %d", n)
+	}
+}
+
+func TestArgumentsInHelpOutput(t *testing.T) {
+	c := &Command{
+		Use:   "get <id> <path>",
+		Short: "download an item",
+		Run:   emptyRun,
+		Arguments: []ArgSpec{
+			{Name: "id", Description: "item id", Example: "10239"},
+			{Name: "path", Description: "destination file"},
+		},
+	}
+
+	output, err := executeCommand(c, "--help")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	checkStringContains(t, output, "Arguments:")
+	checkStringContains(t, output, "<id>")
+	checkStringContains(t, output, "item id (e.g. 10239)")
+	checkStringContains(t, output, "<path>")
+}
+
+func TestArgumentsOmittedWhenAbsent(t *testing.T) {
+	c := &Command{Use: "noargs", Short: "no positionals", Run: emptyRun}
+
+	output, err := executeCommand(c, "--help")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	checkStringOmits(t, output, "Arguments:")
+}
+
+// TestArgumentsTemplateMatchesFunc guards the invariant that defaultUsageFunc
+// stays equivalent to defaultUsageTemplate for the Arguments block.
+func TestArgumentsTemplateMatchesFunc(t *testing.T) {
+	mk := func() *Command {
+		return &Command{
+			Use:   "get <id> <path>",
+			Short: "download an item",
+			Run:   emptyRun,
+			Arguments: []ArgSpec{
+				{Name: "id", Description: "item id", Example: "10239"},
+				{Name: "path", Description: "destination file"},
+			},
+		}
+	}
+
+	fromFunc := new(bytes.Buffer)
+	cf := mk()
+	cf.SetOut(fromFunc)
+	if err := cf.Usage(); err != nil {
+		t.Fatal(err)
+	}
+
+	fromTemplate := new(bytes.Buffer)
+	ct := mk()
+	ct.SetOut(fromTemplate)
+	ct.SetUsageTemplate(ct.UsageTemplate()) // force the text-template path
+	if err := ct.Usage(); err != nil {
+		t.Fatal(err)
+	}
+
+	if fromFunc.String() != fromTemplate.String() {
+		t.Errorf("usage func and template differ:\nfunc:\n%s\ntemplate:\n%s", fromFunc.String(), fromTemplate.String())
+	}
+}

--- a/command.go
+++ b/command.go
@@ -92,6 +92,12 @@ type Command struct {
 	// Expected arguments
 	Args PositionalArgs
 
+	// Arguments documents the positional arguments the command accepts. It is
+	// descriptive only: it feeds the help output and machine-readable
+	// introspection, and does not validate input — set Args for that. An empty
+	// slice means the command documents no positional arguments.
+	Arguments []ArgSpec
+
 	// ArgAliases is List of aliases for ValidArgs.
 	// These are not suggested to the user in the shell completion,
 	// but accepted if entered manually.
@@ -1956,7 +1962,10 @@ Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help")
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
 Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableArguments}}
+
+Arguments:
+{{.ArgumentUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
@@ -2015,6 +2024,10 @@ func defaultUsageFunc(w io.Writer, in interface{}) error {
 				}
 			}
 		}
+	}
+	if c.HasAvailableArguments() {
+		fmt.Fprintf(w, "\n\nArguments:\n")
+		fmt.Fprint(w, trimRightSpace(c.ArgumentUsages()))
 	}
 	if c.HasAvailableLocalFlags() {
 		fmt.Fprintf(w, "\n\nFlags:\n")

--- a/site/content/user_guide.md
+++ b/site/content/user_guide.md
@@ -489,6 +489,43 @@ var cmd = &cobra.Command{
 }
 ```
 
+### Documenting positional arguments
+
+`Args` validates positional arguments but does not describe them. Use the `Arguments`
+field to document each one. Cobra renders the descriptions in an `Arguments:` block in
+the help output, and exposes them for tooling such as agents that read a command's
+contract before calling it.
+
+`Arguments` is descriptive only — it never validates input. Set `Args` for validation.
+
+```go
+var cmd = &cobra.Command{
+  Use:   "download <id> <path>",
+  Short: "download an item",
+  Args:  cobra.ExactArgs(2),
+  Arguments: []cobra.ArgSpec{
+    {Name: "id", Description: "item id", Example: "10239"},
+    {Name: "path", Description: "destination file, or a directory to keep the original name"},
+  },
+  Run: func(cmd *cobra.Command, args []string) {},
+}
+```
+
+The help output then includes:
+
+```
+Usage:
+  download <id> <path> [flags]
+
+Arguments:
+  <id>     item id (e.g. 10239)
+  <path>   destination file, or a directory to keep the original name
+```
+
+A name that already carries its own notation — `[note]` for an optional argument or
+`files...` for a variadic one — is shown as written; a bare name is wrapped in
+`<angle brackets>`.
+
 ## Example
 
 In the example below, we have defined three commands. Two are at the top level


### PR DESCRIPTION
## Why

Cobra documents flags in `--help`, but has no slot to describe **positional arguments**. Authors either hand-roll an `Arguments:` block inside `Long` or work around it entirely. This is the long-standing request in #571: show help text for positional arguments alongside the flags.

The same gap hurts machine consumers (CLIs driven by agents): a command's positional contract is invisible unless it is hand-written into prose.

## What

Add a descriptive `Arguments []ArgSpec` field on `Command`:

```go
&cobra.Command{
    Use:   "download <id> <path>",
    Args:  cobra.ExactArgs(2),
    Arguments: []cobra.ArgSpec{
        {Name: "id", Description: "item id", Example: "10239"},
        {Name: "path", Description: "destination file, or a directory to keep the original name"},
    },
}
```

renders:

```
Usage:
  download <id> <path> [flags]

Arguments:
  <id>     item id (e.g. 10239)
  <path>   destination file, or a directory to keep the original name
```

- `ArgSpec` pairs a placeholder `Name` with a `Description` and an optional `Example`.
- New `Command.ArgumentUsages()` and `Command.HasAvailableArguments()` expose the listing for custom templates and tooling.
- The block is rendered before `Flags:` in `defaultUsageTemplate`, with `defaultUsageFunc` updated in sync.

**Scope and compatibility:**

- `Arguments` is **descriptive only** — it never validates input. `Args` (the existing `PositionalArgs` validator) is unchanged and still owns validation.
- Purely additive: the zero value renders nothing, so existing commands and golden help output are unaffected.
- A name that already carries its own notation (e.g. `[note]`, `files...`) is shown verbatim; a bare name is wrapped in `<angle brackets>`.
- Custom usage templates do not show the block until they add `{{if .HasAvailableArguments}}…{{end}}`.

## How to verify

- `go test ./...` — all tests pass, including:
  - `TestArgumentUsages`, `TestArgumentUsagesEmpty`, `TestArgumentUsagesExampleNotDuplicated`
  - `TestArgumentsInHelpOutput`, `TestArgumentsOmittedWhenAbsent`, `TestHasAvailableArguments`
  - `TestArgumentsTemplateMatchesFunc` — guards that `defaultUsageFunc` stays equivalent to `defaultUsageTemplate`.
- `go vet ./...` and `gofmt` are clean.
- User guide updated: *Positional and Custom Arguments → Documenting positional arguments*.

Closes #571