### PR TITLE
fix(cobra): propagate context to subcommands in ExecuteC

### DIFF
--- a/command.go
+++ b/command.go
@@ -1139,11 +1139,10 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		cmd.commandCalledAs.name = cmd.Name()
 	}
 
-	// We have to pass global context to children command
-	// if context is present on the parent command.
-	if cmd.ctx == nil {
-		cmd.ctx = c.ctx
-	}
+	// Propagate the context from the root command (c) to the found subcommand (cmd).
+	// This ensures that the subcommand always receives the most up-to-date context
+	// from the root, overwriting any potentially stale context from a previous execution.
+	cmd.ctx = c.ctx
 
 	err = cmd.execute(flags)
 	if err != nil {


### PR DESCRIPTION
## Summary
When a command with subcommands was executed multiple times via `ExecuteContext`, the subcommand would incorrectly receive a stale context from a previous run. This fix ensures the latest context is always propagated from the parent to the child command during execution.

Closes #2193

## Problem
The `ExecuteC` function finds and executes the appropriate subcommand based on the provided arguments. However, it failed to propagate the context from the parent command (`c.ctx`) to the resolved subcommand (`cmd.ctx`). Consequently, if a root command was invoked multiple times with different contexts using `ExecuteContext`, the subcommand would retain and use the context from the initial execution, ignoring the newer contexts from subsequent calls.

## Solution
The solution involves a targeted change within the `ExecuteC` function in `command.go`. After the correct subcommand `cmd` is found via `c.Find`, the parent command's context is explicitly assigned to the subcommand with the line `cmd.ctx = c.ctx`. This ensures that before any flag parsing or execution of the subcommand occurs, it is updated with the fresh context provided to the parent, resolving the stale context issue.

## Changes
| File | Lines | Description |
|------|-------|-------------|
| `command.go` | 1084–1170 | In ExecuteC, explicitly propagate the context from the root command to the subcommand to be executed. This ensures that on subsequent runs with a new context, the subcommand receives the new context instead of a stale one from a previous execution. |

## Testing
```
All verification checkpoints passed. build ./... ✓  vet ./... ✓  test ['.'] ✓
```

All verifications passed on branch `sentinel/issue-2193/track-alpha-c1-1781081207`:
- `go vet ./...` — no issues
- `go test -short ./...` — all tests pass

## Checklist
- [x] Code follows project conventions
- [x] `go vet` passes
- [x] `go test -short ./...` passes
- [x] No unrelated changes included
- [ ] Changelog updated (if applicable)
