### PR TITLE
command.go: fix flag ordering when only persistent flags disable SortFlags

### DIFF
--- a/command.go
+++ b/command.go
@@ -1723,7 +1723,7 @@ func (c *Command) LocalFlags() *flag.FlagSet {
 		}
 		c.lflags.SetOutput(c.flagErrorBuf)
 	}
-	c.lflags.SortFlags = c.Flags().SortFlags
+	c.lflags.SortFlags = c.Flags().SortFlags && c.PersistentFlags().SortFlags
 	if c.globNormFunc != nil {
 		c.lflags.SetNormalizeFunc(c.globNormFunc)
 	}
@@ -1734,8 +1734,13 @@ func (c *Command) LocalFlags() *flag.FlagSet {
 			c.lflags.AddFlag(f)
 		}
 	}
-	c.Flags().VisitAll(addToLocal)
-	c.PersistentFlags().VisitAll(addToLocal)
+	persistentFlags := c.PersistentFlags()
+	c.Flags().VisitAll(func(f *flag.Flag) {
+		if persistentFlags.Lookup(f.Name) == nil && f != c.parentsPflags.Lookup(f.Name) {
+			addToLocal(f)
+		}
+	})
+	persistentFlags.VisitAll(addToLocal)
 	return c.lflags
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -2264,6 +2264,43 @@ Flags:
 	}
 }
 
+// TestSortedPersistentFlags checks that PersistentFlags().SortFlags = false
+// preserves definition order in LocalFlags() and help output.
+// https://github.com/spf13/cobra/issues/1033
+func TestSortedPersistentFlags(t *testing.T) {
+	c := &Command{Use: "root", Run: emptyRun}
+	pFlags := c.PersistentFlags()
+	pFlags.SortFlags = false
+	names := []string{"z", "a"}
+	for _, name := range names {
+		pFlags.String(name, strings.ToUpper(name), "")
+	}
+
+	i := 0
+	c.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if i == len(names) {
+			return
+		}
+		if names[i] != f.Name {
+			t.Errorf("Incorrect order. Expected %v, got %v", names[i], f.Name)
+		}
+		i++
+	})
+
+	out, err := executeCommand(c, "-h")
+	if err != nil {
+		t.Fatalf("-h should not fail: %v", err)
+	}
+	zIdx := strings.Index(out, "--z")
+	aIdx := strings.Index(out, "--a")
+	if zIdx == -1 || aIdx == -1 {
+		t.Fatalf("help missing flags:\n%s", out)
+	}
+	if zIdx > aIdx {
+		t.Errorf("help shows flags sorted; --z at %d, --a at %d\n%s", zIdx, aIdx, out)
+	}
+}
+
 // TestSortedFlags checks,
 // if cmd.LocalFlags() is unsorted when cmd.Flags().SortFlags set to false.
 // Related to https://github.com/spf13/cobra/issues/404.


### PR DESCRIPTION
Fixes #1033

LocalFlags() now respects PersistentFlags().SortFlags and adds persistent flags from their own flag set so help output preserves definition order.

Co-authored-by: Cursor <cursoragent@cursor.com>