### PR TITLE
docs: improve ExecuteC() documentation to clarify its purpose and return values

### DIFF
--- a/command.go
+++ b/command.go
@@ -1066,7 +1066,8 @@ func (c *Command) ExecuteContext(ctx context.Context) error {
 
 // Execute uses the args (os.Args[1:] by default)
 // and run through the command tree finding appropriate matches
-// for commands and then corresponding flags.
+// for commands and then corresponding flags. See ExecuteC for a version
+// that also returns the matched command.
 func (c *Command) Execute() error {
 	_, err := c.ExecuteC()
 	return err
@@ -1080,7 +1081,14 @@ func (c *Command) ExecuteContextC(ctx context.Context) (*Command, error) {
 	return c.ExecuteC()
 }
 
-// ExecuteC executes the command.
+// ExecuteC executes the command and returns the *Command that was executed,
+// along with any error encountered. This is useful when you need to determine
+// which specific subcommand was invoked (e.g., for logging, metrics, or
+// post-execution behavior). ExecuteC always delegates to the root command,
+// regardless of which command it is called on. If the command has a parent,
+// ExecuteC is called on the root, so the returned cmd is always the
+// matched leaf command (or the root itself). See also Execute, which is a
+// convenience wrapper that discards the returned command.
 func (c *Command) ExecuteC() (cmd *Command, err error) {
 	if c.ctx == nil {
 		c.ctx = context.Background()


### PR DESCRIPTION
This PR improves the doc comments for Execute() and ExecuteC() in command.go to clearly explain how they differ.

The current ExecuteC() doc comment is just ExecuteC executes the command. It doesn't explain why you'd use it over Execute(). For users who need to know which subcommand was actually invoked (e.g., for logging, metrics, or branching post-execution behavior), this ambiguity leads them to dig through source code or guess.

Fixes #2302

Changes:
- Expanded ExecuteC() doc comment to explain that it returns the matched leaf command, always delegates to the root, and is useful when you need to know which subcommand was invoked.
- Added a cross-reference to ExecuteC from Execute() doc comment so users can discover the richer variant.