### PR TITLE
docs: update viper examples to use instance-based pattern

### DIFF
--- a/site/content/user_guide.md
+++ b/site/content/user_guide.md
@@ -82,6 +82,7 @@ var (
 	// Used for flags.
 	cfgFile     string
 	userLicense string
+	v           *viper.Viper
 
 	rootCmd = &cobra.Command{
 		Use:   "cobra-cli",
@@ -98,16 +99,17 @@ func Execute() error {
 }
 
 func init() {
+	v = viper.New()
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
 	rootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "author name for copyright attribution")
 	rootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "name of license for the project")
 	rootCmd.PersistentFlags().Bool("viper", true, "use Viper for configuration")
-	viper.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author"))
-	viper.BindPFlag("useViper", rootCmd.PersistentFlags().Lookup("viper"))
-	viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
-	viper.SetDefault("license", "apache")
+	v.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author"))
+	v.BindPFlag("useViper", rootCmd.PersistentFlags().Lookup("viper"))
+	v.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
+	v.SetDefault("license", "apache")
 
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(initCmd)
@@ -116,22 +118,22 @@ func init() {
 func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+		v.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
 
 		// Search config in home directory with name ".cobra" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".cobra")
+		v.AddConfigPath(home)
+		v.SetConfigType("yaml")
+		v.SetConfigName(".cobra")
 	}
 
-	viper.AutomaticEnv()
+	v.AutomaticEnv()
 
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	if err := v.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", v.ConfigFileUsed())
 	}
 }
 ```
@@ -299,11 +301,12 @@ command := cobra.Command{
 You can also bind your flags with [viper](https://github.com/spf13/viper):
 
 ```go
-var author string
+var v *viper.Viper
 
 func init() {
+  v = viper.New()
   rootCmd.PersistentFlags().StringVar(&author, "author", "YOUR NAME", "Author name for copyright attribution")
-  viper.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author"))
+  v.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author"))
 }
 ```
 


### PR DESCRIPTION
Update the user guide to use viper.New() instead of the deprecated global singleton pattern. This aligns with Viper's best practice recommendation: initialize a Viper instance and pass it around.