### PR TITLE
test: fix completions test failure on Go 1.26

### DIFF
--- a/completions_test.go
+++ b/completions_test.go
@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
 					t.Errorf("Unexpected completions %q", comps)
 				}
 				if tc.directive != directive {
-					t.Errorf("Unexpected directive %s", directive.string())
+					t.Errorf("Unexpected directive %q", directive.string())
 				}
 			}
 		})

--- a/completions_test.go
+++ b/completions_test.go
@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
 					t.Errorf("Unexpected completions %q", comps)
 				}
 				if tc.directive != directive {
-					t.Errorf("Unexpected directive %q", directive)
+					t.Errorf("Unexpected directive %s", directive.string())
 				}
 			}
 		})


### PR DESCRIPTION
Under Go 1.26, `go vet` has tightened its format verb checks, flagging `%q` when used on the integer-based `ShellCompDirective` type:

`(*testing.common).Errorf format %q has arg directive of wrong type github.com/spf13/cobra.ShellCompDirective`

This fixes the issue by formatting the directive as a string using its unexported `string()` helper method, keeping the change isolated to the test file.

Fixes https://github.com/spf13/cobra/issues/2422