### PR TITLE
feat: add SuggestAvailableCommands opt-in to unknown-command errors

### DIFF
--- a/command.go
+++ b/command.go
@@ -257,6 +257,17 @@ type Command struct {
 	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
 	// Must be > 0.
 	SuggestionsMinimumDistance int
+
+	// SuggestAvailableCommands, when set to true, appends the list of available
+	// subcommands to the unknown-command error message. Hidden and deprecated
+	// commands are excluded. At most SuggestAvailableCommandsMaxCount commands
+	// are listed; set that field to override the default cap of 10.
+	SuggestAvailableCommands bool
+
+	// SuggestAvailableCommandsMaxCount caps the number of available commands
+	// listed in the error message when SuggestAvailableCommands is true.
+	// If zero or negative, defaults to 10.
+	SuggestAvailableCommandsMaxCount int
 }
 
 // Context returns underlying command context. If command was executed
@@ -790,6 +801,27 @@ func (c *Command) findSuggestions(arg string) string {
 		sb.WriteString("\n\nDid you mean this?\n")
 		for _, s := range suggestions {
 			_, _ = fmt.Fprintf(&sb, "\t%v\n", s)
+		}
+	}
+	if c.SuggestAvailableCommands {
+		var avail []string
+		for _, sub := range c.Commands() {
+			if sub.IsAvailableCommand() {
+				avail = append(avail, sub.Name())
+			}
+		}
+		if len(avail) > 0 {
+			max := c.SuggestAvailableCommandsMaxCount
+			if max <= 0 {
+				max = 10
+			}
+			if len(avail) > max {
+				avail = avail[:max]
+			}
+			sb.WriteString("\n\nAvailable Commands:\n")
+			for _, name := range avail {
+				_, _ = fmt.Fprintf(&sb, "\t%v\n", name)
+			}
 		}
 	}
 	return sb.String()

--- a/command_test.go
+++ b/command_test.go
@@ -1475,6 +1475,82 @@ func TestSuggestions(t *testing.T) {
 	}
 }
 
+func TestSuggestAvailableCommands(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun, SuggestAvailableCommands: true}
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.AddCommand(&Command{Use: "list", Run: emptyRun})
+	rootCmd.AddCommand(&Command{Use: "get", Run: emptyRun})
+	rootCmd.AddCommand(&Command{Use: "add", Run: emptyRun})
+
+	output, _ := executeCommand(rootCmd, "frobnicate")
+	if !strings.Contains(output, "Available Commands:") {
+		t.Errorf("Expected 'Available Commands:' in output, got:\n%q", output)
+	}
+	for _, name := range []string{"list", "get", "add"} {
+		if !strings.Contains(output, name) {
+			t.Errorf("Expected command %q in suggestions, got:\n%q", name, output)
+		}
+	}
+}
+
+func TestSuggestAvailableCommandsDefaultOff(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	rootCmd.AddCommand(&Command{Use: "list", Run: emptyRun})
+
+	output, _ := executeCommand(rootCmd, "frobnicate")
+	if strings.Contains(output, "Available Commands") {
+		t.Errorf("Expected no available commands listing, got:\n%q", output)
+	}
+}
+
+func TestSuggestAvailableCommandsExcludesHiddenAndDeprecated(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun, SuggestAvailableCommands: true}
+	rootCmd.AddCommand(&Command{Use: "list", Run: emptyRun})
+	rootCmd.AddCommand(&Command{Use: "hidden", Run: emptyRun, Hidden: true})
+	rootCmd.AddCommand(&Command{Use: "old", Run: emptyRun, Deprecated: "use list instead"})
+
+	output, _ := executeCommand(rootCmd, "frobnicate")
+	if strings.Contains(output, "hidden") {
+		t.Errorf("Hidden command should not appear in suggestions, got:\n%q", output)
+	}
+	if strings.Contains(output, "old") {
+		t.Errorf("Deprecated command should not appear in suggestions, got:\n%q", output)
+	}
+	if !strings.Contains(output, "list") {
+		t.Errorf("Available command 'list' should appear in suggestions, got:\n%q", output)
+	}
+}
+
+func TestSuggestAvailableCommandsMaxCount(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun, SuggestAvailableCommands: true, SuggestAvailableCommandsMaxCount: 2}
+	rootCmd.AddCommand(&Command{Use: "alpha", Run: emptyRun})
+	rootCmd.AddCommand(&Command{Use: "beta", Run: emptyRun})
+	rootCmd.AddCommand(&Command{Use: "gamma", Run: emptyRun})
+
+	output, _ := executeCommand(rootCmd, "frobnicate")
+	if strings.Contains(output, "gamma") {
+		t.Errorf("Expected at most 2 commands, but 'gamma' appeared in:\n%q", output)
+	}
+	if !strings.Contains(output, "alpha") || !strings.Contains(output, "beta") {
+		t.Errorf("Expected 'alpha' and 'beta' in suggestions, got:\n%q", output)
+	}
+}
+
+func TestSuggestAvailableCommandsComposesWithDidYouMean(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun, SuggestAvailableCommands: true}
+	rootCmd.AddCommand(&Command{Use: "list", Run: emptyRun})
+	rootCmd.AddCommand(&Command{Use: "get", Run: emptyRun})
+
+	// "liist" is close enough to "list" for a "Did you mean" suggestion
+	output, _ := executeCommand(rootCmd, "liist")
+	if !strings.Contains(output, "Did you mean this?") {
+		t.Errorf("Expected 'Did you mean this?' in output, got:\n%q", output)
+	}
+	if !strings.Contains(output, "Available Commands:") {
+		t.Errorf("Expected 'Available Commands:' in output, got:\n%q", output)
+	}
+}
+
 func TestCaseInsensitive(t *testing.T) {
 	rootCmd := &Command{Use: "root", Run: emptyRun}
 	childCmd := &Command{Use: "child", Run: emptyRun, Aliases: []string{"alternative"}}


### PR DESCRIPTION
## What

Adds two opt-in fields to `Command`:

- **`SuggestAvailableCommands bool`** — when `true`, appends the list of available subcommands to the unknown-command error message.
- **`SuggestAvailableCommandsMaxCount int`** — caps the number of commands shown (defaults to 10 when zero).

Hidden and deprecated commands are excluded via `IsAvailableCommand()`. The new block composes with the existing "Did you mean this?" suggestion rather than replacing it.

## Example

```go
rootCmd := &cobra.Command{
    Use: "app",
    Run: run,
    SuggestAvailableCommands: true,
}
rootCmd.AddCommand(listCmd, getCmd, addCmd)
```

Running `app frobnicate` now produces:

```
Error: unknown command "frobnicate" for "app"

Available Commands:
	list
	get
	add

Run 'app --help' for usage.
```

If the typo is also close to a known command name, both blocks appear:

```
Error: unknown command "liist" for "app"

Did you mean this?
	list

Available Commands:
	list
	get
	add

Run 'app --help' for usage.
```

## Why

Closes #2414. Every user who wants this today re-implements `unknownSubcommandError` by hand (see the reference implementation in the issue). The feature is especially useful for LLM agents driving CLIs, which recover in one step when the full menu is in the error rather than requiring a separate `--help` call.

## Tests

Five new tests in `command_test.go`:

- `TestSuggestAvailableCommands` — basic listing
- `TestSuggestAvailableCommandsDefaultOff` — opt-in default is false
- `TestSuggestAvailableCommandsExcludesHiddenAndDeprecated` — hidden/deprecated commands absent
- `TestSuggestAvailableCommandsMaxCount` — cap is respected
- `TestSuggestAvailableCommandsComposesWithDidYouMean` — both blocks appear together