### PR TITLE
[codex] Deduplicate command suggestions

### DIFF
--- a/command.go
+++ b/command.go
@@ -862,17 +862,20 @@ func (c *Command) Traverse(args []string) (*Command, []string, error) {
 // SuggestionsFor provides suggestions for the typedName.
 func (c *Command) SuggestionsFor(typedName string) []string {
 	suggestions := []string{}
+	typedNameLower := strings.ToLower(typedName)
 	for _, cmd := range c.commands {
 		if cmd.IsAvailableCommand() {
 			levenshteinDistance := ld(typedName, cmd.Name(), true)
 			suggestByLevenshtein := levenshteinDistance <= c.SuggestionsMinimumDistance
-			suggestByPrefix := strings.HasPrefix(strings.ToLower(cmd.Name()), strings.ToLower(typedName))
+			suggestByPrefix := strings.HasPrefix(strings.ToLower(cmd.Name()), typedNameLower)
 			if suggestByLevenshtein || suggestByPrefix {
 				suggestions = append(suggestions, cmd.Name())
+				continue
 			}
 			for _, explicitSuggestion := range cmd.SuggestFor {
 				if strings.EqualFold(typedName, explicitSuggestion) {
 					suggestions = append(suggestions, cmd.Name())
+					break
 				}
 			}
 		}

--- a/command_test.go
+++ b/command_test.go
@@ -1475,6 +1475,25 @@ func TestSuggestions(t *testing.T) {
 	}
 }
 
+func TestSuggestionsForDoesNotDuplicateExplicitMatches(t *testing.T) {
+	rootCmd := &Command{
+		Use:                        "root",
+		Run:                        emptyRun,
+		SuggestionsMinimumDistance: 2,
+	}
+	timesCmd := &Command{
+		Use:        "times",
+		SuggestFor: []string{"time"},
+		Run:        emptyRun,
+	}
+	rootCmd.AddCommand(timesCmd)
+
+	expected := []string{"times"}
+	if suggestions := rootCmd.SuggestionsFor("time"); !reflect.DeepEqual(suggestions, expected) {
+		t.Errorf("Expected suggestions %v, got %v", expected, suggestions)
+	}
+}
+
 func TestCaseInsensitive(t *testing.T) {
 	rootCmd := &Command{Use: "root", Run: emptyRun}
 	childCmd := &Command{Use: "child", Run: emptyRun, Aliases: []string{"alternative"}}


### PR DESCRIPTION
## Summary
- Avoid adding the same command suggestion twice when prefix or distance matching and explicit SuggestFor both match.

## Validation
- targeted Go tests and full go test ./... passed in Docker.

## Notes
- Opened as a draft PR for maintainer review.
