### PR TITLE
fix: exclude hidden commands from usage padding calculation

### DIFF
--- a/command.go
+++ b/command.go
@@ -1345,18 +1345,21 @@ func (c *Command) AddCommand(cmds ...*Command) {
 			panic("Command can't be a child of itself")
 		}
 		cmds[i].parent = c
-		// update max lengths
-		usageLen := len(x.Use)
-		if usageLen > c.commandsMaxUseLen {
-			c.commandsMaxUseLen = usageLen
-		}
-		commandPathLen := len(x.CommandPath())
-		if commandPathLen > c.commandsMaxCommandPathLen {
-			c.commandsMaxCommandPathLen = commandPathLen
-		}
-		nameLen := len(x.Name())
-		if nameLen > c.commandsMaxNameLen {
-			c.commandsMaxNameLen = nameLen
+		// update max lengths, excluding hidden commands whose names are
+		// never rendered in the usage output.
+		if !x.Hidden {
+			usageLen := len(x.Use)
+			if usageLen > c.commandsMaxUseLen {
+				c.commandsMaxUseLen = usageLen
+			}
+			commandPathLen := len(x.CommandPath())
+			if commandPathLen > c.commandsMaxCommandPathLen {
+				c.commandsMaxCommandPathLen = commandPathLen
+			}
+			nameLen := len(x.Name())
+			if nameLen > c.commandsMaxNameLen {
+				c.commandsMaxNameLen = nameLen
+			}
 		}
 		// If global normalization function exists, update all children
 		if c.globNormFunc != nil {
@@ -1416,6 +1419,9 @@ main:
 	c.commandsMaxCommandPathLen = 0
 	c.commandsMaxNameLen = 0
 	for _, command := range c.commands {
+		if command.Hidden {
+			continue
+		}
 		usageLen := len(command.Use)
 		if usageLen > c.commandsMaxUseLen {
 			c.commandsMaxUseLen = usageLen

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,33 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+func TestHiddenCommandExcludedFromNamePadding(t *testing.T) {
+	root := &Command{Use: "root"}
+
+	// Visible short command
+	short := &Command{Use: "short", Run: emptyRun}
+	root.AddCommand(short)
+
+	// Hidden command with a much longer name
+	longHidden := &Command{Use: "very-long-hidden-command", Hidden: true, Run: emptyRun}
+	root.AddCommand(longHidden)
+
+	padding := short.NamePadding()
+
+	// NamePadding should be based only on visible commands.
+	// With only "short" (5 chars) visible, it should be minNamePadding (11),
+	// not inflated by the 24-char hidden command name.
+	if padding >= len(longHidden.Name()) {
+		t.Errorf("Expected padding to ignore hidden command, but padding %d >= hidden name length %d", padding, len(longHidden.Name()))
+	}
+
+	expected := minNamePadding
+	if len(short.Name()) > expected {
+		expected = len(short.Name())
+	}
+
+	if padding != expected {
+		t.Errorf("Expected NamePadding %d, got %d", expected, padding)
+	}
+}


### PR DESCRIPTION
Hidden commands were included in the max name/use/commandPath length calculation in AddCommand, inflating usage padding for visible siblings. This excludes hidden commands from the calculation in both AddCommand and RemoveCommand.

Fixes #1272