### PR TITLE
Fix directive formatting in completion test

### DIFF
--- a/completions_test.go
+++ b/completions_test.go
@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
 					t.Errorf("Unexpected completions %q", comps)
 				}
 				if tc.directive != directive {
-					t.Errorf("Unexpected directive %q", directive)
+					t.Errorf("Unexpected directive %v", directive)
 				}
 			}
 		})


### PR DESCRIPTION
Fix a completion test diagnostic that formats ShellCompDirective with %q. Current Go vet reports this as an invalid format string.

ShellCompDirective is a numeric bitmask type, so %v is the appropriate diagnostic format here.

Tested:
- go test ./...