### PR TITLE
fix: resolve macOS test link failure and update lint rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
         - 24
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
+    env:
+      GO_TEST_FLAGS: ${{ matrix.platform == 'macOS' && '-ldflags=-linkmode=external' || '' }}
     steps:
 
     - uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,17 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    warn-unused: true
+    rules:
+      - path: '_test\.go'
+        linters:
+          - goconst
+      - linters:
+          - goconst
+        text: 'string `(true|bash|zsh|fish|powershell)`'
   settings:
+    nolintlint:
+      allow-unused: true
     govet:
       # Disable buildtag check to allow dual build tag syntax (both //go:build and // +build).
       # This is necessary for Go 1.15 compatibility since //go:build was introduced in Go 1.17.

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ lint:
 
 test: install_deps
 	$(info ******************** running tests ********************)
-	go test -v ./...
+	go test -v $(GO_TEST_FLAGS) ./...
 
 richtest: install_deps
 	$(info ******************** running tests with kyoh86/richgo ********************)
-	richgo test -v ./...
+	richgo test -v $(GO_TEST_FLAGS) ./...
 
 install_deps:
 	$(info ******************** downloading dependencies ********************)

--- a/completions_test.go
+++ b/completions_test.go
@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
 					t.Errorf("Unexpected completions %q", comps)
 				}
 				if tc.directive != directive {
-					t.Errorf("Unexpected directive %s", directive.string())
+					t.Errorf("Unexpected directive %q", directive.string())
 				}
 			}
 		})

--- a/completions_test.go
+++ b/completions_test.go
@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
 					t.Errorf("Unexpected completions %q", comps)
 				}
 				if tc.directive != directive {
-					t.Errorf("Unexpected directive %q", directive)
+					t.Errorf("Unexpected directive %s", directive.string())
 				}
 			}
 		})


### PR DESCRIPTION
### Description

This Pull Request addresses macOS test linking failures and linter configuration adjustments to ensure clean CI/CD runs and local builds.

As suggested in https://github.com/spf13/cobra/pull/2423#issuecomment-4846919718, this PR isolates these config and CI updates into a separate branch.

### Changes Proposed

1. **macOS Test Link Fix**:
   - Added `GO_TEST_FLAGS: -ldflags=-linkmode=external` environment variable for macOS platforms in the GitHub Actions `test-unix` job.
   - Updated the `Makefile` (`test` and `richtest` targets) to reference `$(GO_TEST_FLAGS)`, keeping target execution platform-independent while resolving macOS-specific link issues.

2. **Linter Rule Exclusions & Hygiene (`.golangci.yml`)**:
   - Disabled `goconst` on all `_test.go` files to prevent noisy alerts on duplicated test strings.
   - Added `goconst` exclusions for common shell inputs (`true`, `bash`, `zsh`, `fish`, `powershell`).
   - Configured `linters.settings.nolintlint.allow-unused: true` (following the `version: "2"` config schema) to prevent build failures under newer Go versions (like Go 1.26) where some pre-existing `//nolint` comments are no longer triggered.

### Verification Results

* **Unit Tests**: All tests pass successfully locally (`go test ./...`).
* **Linter Validation**: Verified against the `golangci-lint` JSON schema for version 2. The configuration modifications resolve all `nolintlint` warnings and pass schema validation checks.
