### PR TITLE
fix: resolve macOS test link failure and update lint rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
         - 24
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
+    # macOS runner environments require compiled binaries to contain an LC_UUID load command.
+    # We dynamically pass -ldflags=-linkmode=external on macOS to force external linking via the system linker.
     env:
       GO_TEST_FLAGS: ${{ matrix.platform == 'macOS' && '-ldflags=-linkmode=external' || '' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,10 @@ jobs:
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     # macOS runner environments require compiled binaries to contain an LC_UUID load command.
-    # We dynamically pass -ldflags=-linkmode=external on macOS to force external linking via the system linker.
+    # Go 1.24+ natively resolves this by writing LC_UUID in Go's internal linker.
+    # For Go < 1.24, we pass -ldflags=-linkmode=external on macOS to force external linking via the system linker.
     env:
-      GO_TEST_FLAGS: ${{ matrix.platform == 'macOS' && '-ldflags=-linkmode=external' || '' }}
+      GO_TEST_FLAGS: ${{ matrix.platform == 'macOS' && matrix.go < 24 && '-ldflags=-linkmode=external' || '' }}
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
         - 24
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
+    env:
+      GO_TEST_FLAGS: ${{ matrix.platform == 'macOS' && '-ldflags=-linkmode=external' || '' }}
     steps:
 
     - uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,17 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    warn-unused: true
+    rules:
+      - path: '_test\.go'
+        linters:
+          - goconst
+      - linters:
+          - goconst
+        text: 'string `(true|bash|zsh|fish|powershell)`'
   settings:
+    nolintlint:
+      allow-unused: true
     govet:
       # Disable buildtag check to allow dual build tag syntax (both //go:build and // +build).
       # This is necessary for Go 1.15 compatibility since //go:build was introduced in Go 1.17.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,9 +65,14 @@ linters:
       - linters:
           - goconst
         text: 'string `(true|bash|zsh|fish|powershell)`'
+      # Some Go/staticcheck versions in the test matrix don't trigger staticcheck warnings
+      # on type assertions/LHS variables in test files, while others do.
+      # To avoid build failures on both sides, we allow unused staticcheck nolints in test files.
+      - path: '_test\.go'
+        linters:
+          - nolintlint
+        text: 'directive `//nolint:staticcheck` is unused'
   settings:
-    nolintlint:
-      allow-unused: true
     govet:
       # Disable buildtag check to allow dual build tag syntax (both //go:build and // +build).
       # This is necessary for Go 1.15 compatibility since //go:build was introduced in Go 1.17.

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ lint:
 
 test: install_deps
 	$(info ******************** running tests ********************)
-	go test -v ./...
+	go test -v $(GO_TEST_FLAGS) ./...
 
 richtest: install_deps
 	$(info ******************** running tests with kyoh86/richgo ********************)
-	richgo test -v ./...
+	richgo test -v $(GO_TEST_FLAGS) ./...
 
 install_deps:
 	$(info ******************** downloading dependencies ********************)


### PR DESCRIPTION
### Description

This Pull Request addresses macOS test linking failures and linter configuration adjustments to ensure clean CI/CD runs and local builds.

As suggested in https://github.com/spf13/cobra/pull/2423#issuecomment-4846919718, this PR isolates these config and CI updates into a separate branch.

---

### CI Errors Resolved

#### 1. macOS Missing Link Flags / Abort Trap
On macOS runner environments, test runs fail abruptly with `abort trap` due to a missing `LC_UUID` load command in the compiled test binaries:
```
******************** downloading dependencies ********************
go get -v ./...
******************** running tests with kyoh86/richgo ********************
richgo test -v ./...
     | dyld[6013]: missing LC_UUID load command in /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/go-build959790180/b077/cobra.test
     | dyld[6013]: missing LC_UUID load command
     | signal: abort trap
FAIL | 	github.com/spf13/cobra	0.002s
     | dyld[6011]: missing LC_UUID load command in /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/go-build959790180/b103/doc.test
     | dyld[6011]: missing LC_UUID load command
     | signal: abort trap
FAIL | 	github.com/spf13/cobra/doc	0.002s
make: *** [richtest] Error 1
Error: Process completed with exit code 2.
```

- **Failing CI Job Link**: [Link to failing macOS action run](https://github.com/SudhanshuMatrix/cobra/actions/runs/28704047114/job/85126780647)

- **Failing CI Job Link**: [Link to failing macOS action run](https://github.com/SudhanshuMatrix/cobra/actions/runs/28704047114/job/85126780639)
<details>
<summary><b>macOS Link Failure Screenshot</b></summary>
<img width="1246" height="651" alt="image" src="https://github.com/user-attachments/assets/2831e8e5-ea3e-45bb-9872-c11376338d91" />


</details>

This is resolved by passing `-ldflags=-linkmode=external` to force external linking via the system linker on macOS. Since Go 1.24+ natively resolves this issue in its internal linker, this workaround is constrained to Go versions `< 1.24`.

#### 2. `golangci-lint` Failures (`goconst`)
The `goconst` linter reports multiple alerts on test files for repeating test assertions and commands:
```
Error: active_help_test.go:51:3: string `Completion ended with directive: ShellCompDirectiveDefault` has 48 occurrences, make it a constant (goconst)
		"Completion ended with directive: ShellCompDirectiveDefault", ""}, "\n")
		^
Error: active_help_test.go:62:10: string `The child command` has 7 occurrences, make it a constant (goconst)
		Short: "The child command",
		^
Error: active_help_test.go:198:3: string `Completion ended with directive: ShellCompDirectiveNoFileComp` has 100 occurrences, make it a constant (goconst)
		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
		^
Error: command_test.go:375:12: string `1.0.0` has 17 occurrences, make it a constant (goconst)
		Version: "1.0.0",
		         ^
```

- **Failing CI Job Link**: [Link to failing golangci-lint action run](https://github.com/SudhanshuMatrix/cobra/actions/runs/28704047114/job/85126780608)

<details>
<summary><b>Linter Failure Screenshot</b></summary>

<img width="1246" height="651" alt="image" src="https://github.com/user-attachments/assets/ab0c8956-6aa1-4a7b-a7b4-8725f9f7b9b1" />


</details>

We resolve this by excluding `_test.go` files from `goconst` checks.

#### 3. `nolintlint` Unused Directive Warnings
In Go/staticcheck versions where type compatibility checks do not trigger warnings on type assertions in tests, `nolintlint` fails the build reporting unused directives:
```
completions_test.go:2902:35: directive `//nolint:staticcheck` is unused (nolintlint)
```
However, removing the comment causes builds to fail on other matrix environments (e.g. older Go versions) where the warning *is* triggered. We resolve this by adding a targeted exclusion rule to allow unused `staticcheck` directives in `_test.go` files.

---

### Changes Proposed

1. **macOS Test Link Fix**:
   - Added `GO_TEST_FLAGS: -ldflags=-linkmode=external` environment variable for macOS platforms under Go `< 1.24` in the GitHub Actions `test-unix` job (with an explanatory comment).
   - Updated the `Makefile` (`test` and `richtest` targets) to reference `$(GO_TEST_FLAGS)`, keeping target execution platform-independent while resolving macOS-specific link issues.


2. **Linter Rule Exclusions & Hygiene (`.golangci.yml`)**:
   - Disabled `goconst` on all `_test.go` files to prevent noisy alerts on duplicated test strings.
   - Added `goconst` exclusions for common shell inputs (`true`, `bash`, `zsh`, `fish`, `powershell`).
   - Replaced the global `allow-unused: true` setting for `nolintlint` with a specific exclusion rule under `linters.exclusions.rules` that ignores unused `staticcheck` directives in `_test.go` files, keeping `nolintlint` fully active for all other linters and production files.

---

### Verification Results

* **Unit Tests**: All tests pass successfully locally (`go test ./...`).
* **Linter Validation**: Verified locally via `golangci-lint run` (0 issues). Both local and CI environments successfully validate with these changes.
