### PR TITLE
Fix hidden and deprecated commands changing padding in help text

### DIFF
--- a/command.go
+++ b/command.go
@@ -1345,18 +1345,22 @@ func (c *Command) AddCommand(cmds ...*Command) {
 			panic("Command can't be a child of itself")
 		}
 		cmds[i].parent = c
-		// update max lengths
-		usageLen := len(x.Use)
-		if usageLen > c.commandsMaxUseLen {
-			c.commandsMaxUseLen = usageLen
-		}
-		commandPathLen := len(x.CommandPath())
-		if commandPathLen > c.commandsMaxCommandPathLen {
-			c.commandsMaxCommandPathLen = commandPathLen
-		}
-		nameLen := len(x.Name())
-		if nameLen > c.commandsMaxNameLen {
-			c.commandsMaxNameLen = nameLen
+		// hidden and deprecated commands are not shown in the help text
+		// so they should not affect the padding
+		if len(x.Deprecated) == 0 && !x.Hidden {
+			// update max lengths
+			usageLen := len(x.Use)
+			if usageLen > c.commandsMaxUseLen {
+				c.commandsMaxUseLen = usageLen
+			}
+			commandPathLen := len(x.CommandPath())
+			if commandPathLen > c.commandsMaxCommandPathLen {
+				c.commandsMaxCommandPathLen = commandPathLen
+			}
+			nameLen := len(x.Name())
+			if nameLen > c.commandsMaxNameLen {
+				c.commandsMaxNameLen = nameLen
+			}
 		}
 		// If global normalization function exists, update all children
 		if c.globNormFunc != nil {
@@ -1416,6 +1420,11 @@ main:
 	c.commandsMaxCommandPathLen = 0
 	c.commandsMaxNameLen = 0
 	for _, command := range c.commands {
+		// hidden and deprecated commands are not shown in the help text
+		// so they should not affect the padding
+		if len(command.Deprecated) != 0 || command.Hidden {
+			continue
+		}
 		usageLen := len(command.Use)
 		if usageLen > c.commandsMaxUseLen {
 			c.commandsMaxUseLen = usageLen

--- a/command_test.go
+++ b/command_test.go
@@ -2952,3 +2952,46 @@ func TestHelpFuncExecuted(t *testing.T) {
 
 	checkStringContains(t, output, helpText)
 }
+
+// TestPadding checks that hidden and deprecated commands are excluded
+// from the padding calculation of the help text.
+// Related to https://github.com/spf13/cobra/issues/1272.
+func TestPadding(t *testing.T) {
+	rootCmd := &Command{Use: "root", Run: emptyRun}
+	childCmd := &Command{Use: "child", Run: emptyRun}
+	longChildCmd := &Command{Use: "long-name-child-abcdefghijklmnopqrstuvwxyz", Run: emptyRun}
+	// For this test to be useful the hidden and deprecated commands need to
+	// have a longer Use field than the longest visible command.
+	hiddenChildCmd := &Command{Use: longChildCmd.Use + "-hidden", Hidden: true, Run: emptyRun}
+	deprecatedChildCmd := &Command{Use: longChildCmd.Use + "-deprecated", Deprecated: "deprecated", Run: emptyRun}
+
+	rootCmd.AddCommand(childCmd, longChildCmd, hiddenChildCmd, deprecatedChildCmd)
+
+	expectedUsePad := len(longChildCmd.Use)
+	expectedPathPad := len(longChildCmd.CommandPath())
+	expectedNamePad := len(longChildCmd.Name())
+
+	if got := childCmd.UsagePadding(); got != expectedUsePad {
+		t.Errorf("Expected usage padding %d, got %d", expectedUsePad, got)
+	}
+	if got := childCmd.CommandPathPadding(); got != expectedPathPad {
+		t.Errorf("Expected command path padding %d, got %d", expectedPathPad, got)
+	}
+	if got := childCmd.NamePadding(); got != expectedNamePad {
+		t.Errorf("Expected name padding %d, got %d", expectedNamePad, got)
+	}
+
+	// Removing the longest visible command must recompute the padding,
+	// still ignoring hidden and deprecated commands.
+	rootCmd.RemoveCommand(longChildCmd)
+
+	if got := childCmd.UsagePadding(); got != minUsagePadding {
+		t.Errorf("Expected usage padding %d, got %d", minUsagePadding, got)
+	}
+	if got := childCmd.CommandPathPadding(); got != minCommandPathPadding {
+		t.Errorf("Expected command path padding %d, got %d", minCommandPathPadding, got)
+	}
+	if got := childCmd.NamePadding(); got != minNamePadding {
+		t.Errorf("Expected name padding %d, got %d", minNamePadding, got)
+	}
+}


### PR DESCRIPTION
Hidden and deprecated commands are not shown in the help text, so they should not affect the padding used to align the visible commands. Currently, a subcommand with a long name that is hidden or deprecated makes the help text of its siblings wider than necessary.

Fixes #1272
Supersedes #1632 (now conflicting and inactive since 2022 — this PR re-applies the approach that was already approved there, rebased onto current main)

## Approach

As discussed in #1632, this checks `.Hidden` and `.Deprecated` explicitly rather than using `IsAvailableCommand()`, because the latter would incorrectly exclude doc-only commands (`AdditionalHelpTopic`, e.g. `go help go.mod`) which *are* shown in the help text (pointed out by @Luap99).

- `AddCommand`: skip hidden/deprecated commands when updating `commandsMaxUseLen`, `commandsMaxCommandPathLen` and `commandsMaxNameLen`
- `RemoveCommand`: skip them likewise when recomputing the max lengths (not covered by the original PR)
- Added `TestPadding` in `command_test.go` covering both cases

## Example

Before:

```
Available Commands:
  breakdown                                  Show full breakdown of costs
  comment                                    Post a comment
```

After:

```
Available Commands:
  breakdown   Show full breakdown of costs
  comment     Post a comment
```

(where a hidden `fig-autocomplete-very-long-hidden-command` subcommand exists)

## Regarding the open question in #1632

@jpmcb raised the concern that users who override the help template to display hidden/deprecated commands could be affected. For such users, this change only reduces the padding value returned by `NamePadding()`/`UsagePadding()`/`CommandPathPadding()`, so their custom templates keep working — long hidden entries would simply extend past the alignment column, exactly as any over-long visible entry already does today (the minimum paddings `minNamePadding` etc. are unchanged). Users who want the old behavior in a custom template can compute their own padding.
