### PR TITLE
fix: use %d format verb for ShellCompDirective in test error message

### DIFF
--- a/completions_test.go
+++ b/completions_test.go
@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
 					t.Errorf("Unexpected completions %q", comps)
 				}
 				if tc.directive != directive {
-					t.Errorf("Unexpected directive %q", directive)
+					t.Errorf("Unexpected directive %d", directive)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

Go 1.26 tightened `go vet` to flag `%q` used with non-string/rune arguments as an error. `ShellCompDirective` is defined as `type ShellCompDirective int`, so the format call on line 3730 of `completions_test.go` now fails the vet check and prevents the test suite from compiling on Go 1.26.

```
./completions_test.go:3730:37: (*testing.common).Errorf format %q has arg directive of wrong type github.com/spf13/cobra.ShellCompDirective
```

## Changes

- `completions_test.go` line 3730: replace `%q` with `%d` in the `t.Errorf` call that formats a `ShellCompDirective` value

## Testing

```
$ go test ./...
ok  github.com/spf13/cobra      9.4s
ok  github.com/spf13/cobra/doc  0.4s
```

Fixes #2422