### PR TITLE
feat: Add MarkFlagAppendEqual to suggest --flag= in shell completion

### DIFF
--- a/completions.go
+++ b/completions.go
@@ -182,6 +182,25 @@ func (c *Command) RegisterFlagCompletionFunc(flagName string, f CompletionFunc) 
 	return nil
 }
 
+// FlagAppendEqualAnnotation is the annotation key used to mark a flag so that
+// shell completion suggests its long form with a trailing "=" (e.g. "--flag=")
+// and without a trailing space. This is opt-in per flag, so it does not
+// reintroduce the duplicate "--flag"/"--flag=" suggestions that led to the
+// "=" form being removed for all flags.
+const FlagAppendEqualAnnotation = "cobra_annotation_flag_append_equal"
+
+// MarkFlagAppendEqual instructs shell completion to suggest the given flag's
+// long name with a trailing "=" and no trailing space. This is convenient for
+// flags whose value is most commonly provided with the "--flag=value" form,
+// such as flags that carry an optional value (NoOptDefVal).
+func (c *Command) MarkFlagAppendEqual(flagName string) error {
+	flag := c.Flag(flagName)
+	if flag == nil {
+		return fmt.Errorf("MarkFlagAppendEqual: flag '%s' does not exist", flagName)
+	}
+	return c.Flags().SetAnnotation(flagName, FlagAppendEqualAnnotation, []string{"true"})
+}
+
 // GetFlagCompletionFunc returns the completion function for the given flag of the command, if available.
 func (c *Command) GetFlagCompletionFunc(flagName string) (CompletionFunc, bool) {
 	flag := c.Flag(flagName)
@@ -475,10 +494,19 @@ func (c *Command) getCompletions(args []string) (*Command, []Completion, ShellCo
 		}
 
 		directive = ShellCompDirectiveNoFileComp
-		if len(completions) == 1 && strings.HasSuffix(completions[0], "=") {
-			// If there is a single completion, the shell usually adds a space
-			// after the completion.  We don't want that if the flag ends with an =
-			directive = ShellCompDirectiveNoSpace
+		if len(completions) == 1 {
+			// A completion entry may carry a description after a tab
+			// (see CompletionWithDesc); only the text before the tab is what
+			// the shell inserts, so we inspect that part.
+			choice := strings.SplitN(completions[0], "\t", 2)[0]
+
+			// When the single choice ends with "=" (e.g. a flag suggested as
+			// "--flag=" via MarkFlagAppendEqual), tell the shell not to add a
+			// trailing space, so the user can type the value right after "=".
+			// This is OR'd in to keep the NoFileComp directive set above.
+			if strings.HasSuffix(choice, "=") {
+				directive |= ShellCompDirectiveNoSpace
+			}
 		}
 
 		if !finalCmd.DisableFlagParsing {
@@ -604,6 +632,12 @@ func getFlagNameCompletions(flag *pflag.Flag, toComplete string) []Completion {
 	var completions []Completion
 	flagName := "--" + flag.Name
 	if strings.HasPrefix(flagName, toComplete) {
+		// If the flag opted in via MarkFlagAppendEqual, suggest the "--flag="
+		// form. A single completion ending in "=" also triggers
+		// ShellCompDirectiveNoSpace below, so no trailing space is added.
+		if _, ok := flag.Annotations[FlagAppendEqualAnnotation]; ok {
+			flagName += "="
+		}
 		// Flag without the =
 		completions = append(completions, CompletionWithDesc(flagName, flag.Usage))
 

--- a/completions_test.go
+++ b/completions_test.go
@@ -671,6 +671,54 @@ func TestFlagNameCompletionInGoWithDesc(t *testing.T) {
 	}
 }
 
+func TestFlagNameCompletionAppendEqual(t *testing.T) {
+	rootCmd := &Command{
+		Use: "root",
+		Run: emptyRun,
+	}
+	rootCmd.Flags().String("dryRun", "none", "dry run flag")
+	rootCmd.Flags().String("normal", "", "normal flag")
+	if err := rootCmd.MarkFlagAppendEqual("dryRun"); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// A flag marked with MarkFlagAppendEqual is suggested with a trailing "="
+	// and the NoSpace directive so the shell does not add a trailing space.
+	output, err := executeCommand(rootCmd, ShellCompRequestCmd, "--dryRun")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"--dryRun=\tdry run flag",
+		":6",
+		"Completion ended with directive: ShellCompDirectiveNoSpace, ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+
+	// A flag that did not opt in is completed as usual: no "=", no NoSpace.
+	output, err = executeCommand(rootCmd, ShellCompRequestCmd, "--normal")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected = strings.Join([]string{
+		"--normal\tnormal flag",
+		":4",
+		"Completion ended with directive: ShellCompDirectiveNoFileComp", ""}, "\n")
+
+	if output != expected {
+		t.Errorf("expected: %q, got: %q", expected, output)
+	}
+
+	// MarkFlagAppendEqual on an unknown flag returns an error.
+	if err := rootCmd.MarkFlagAppendEqual("doesNotExist"); err == nil {
+		t.Error("Expected error for non-existent flag, got nil")
+	}
+}
+
 // customMultiString is a custom Value type that accepts multiple values,
 // but does not include "Slice" or "Array" in its "Type" string.
 type customMultiString []string


### PR DESCRIPTION
# Add `MarkFlagAppendEqual` to suggest `--flag=` in shell completion

## Summary

This adds an opt-in, per-flag mechanism to make shell completion suggest a
flag's long form with a trailing `=` and **no** trailing space
(e.g. `--flag=`), instead of `--flag ` (with a space).

It is intended for flags whose value is most naturally supplied with the
`--flag=value` form — in particular flags that carry an *optional* value via
`NoOptDefVal`, where the space-separated form (`--flag value`) does not bind the
value at all.

## Motivation

This came out of wanting to improve autocompletion for `kubectl`'s `--dry-run`
flag. `--dry-run` carries an optional value (`--dry-run=client` /
`--dry-run=server`, with a deprecated bare `--dry-run`), so it sets
`NoOptDefVal`. Today `kubectl <cmd> --dry-run<TAB>` completes to `--dry-run `
(with a space) and then offers file completion, even though the only working way
to pass a value is `--dry-run=client`. There is currently no way for a downstream
program like kubectl to make cobra suggest `--dry-run=` instead — hence this
opt-in flag.

For a flag with `NoOptDefVal` set, the only syntax that actually assigns a value
is `--flag=value`; `--flag value` treats `value` as a positional argument. Yet
today completion of the flag name produces `--flag` followed by a space, which:

- nudges the user toward the non-working space-separated form, and
- leaves them having to delete the space before typing `=value`.

Cobra used to suggest both `--flag` and `--flag=` for value flags, but that was
removed because suggesting *both* forms for *every* flag was noisy and
duplicative (see the long-standing comment in `getFlagNameCompletions`). This
change takes a different, narrower approach: it is **opt-in per flag**, so it
does not reintroduce duplicate suggestions for flags that don't want it.

## What changed

1. **New public API** `Command.MarkFlagAppendEqual(flagName string) error` and
   the `FlagAppendEqualAnnotation` key. Marking a flag makes its long-form
   completion be suggested as `--flag=`.

2. **`getFlagNameCompletions`** appends `=` to the suggested long form when the
   flag opted in.

3. **Fix to the existing `NoSpace` detection.** The code that adds
   `ShellCompDirectiveNoSpace` for a single `=`-suffixed completion compared the
   *entire* completion string against `"="`. When descriptions are enabled a
   completion is `"choice\tdescription"`, so it never ended in `=` and the
   branch was effectively dead. It now inspects only the choice (the text before
   the tab). It also OR-s the directive in (`|=`) instead of overwriting, so the
   pre-existing `ShellCompDirectiveNoFileComp` is preserved (the result is
   `NoSpace | NoFileComp` rather than `NoSpace` alone).

## Example

```go
cmd.Flags().String("dry-run", "none", `Must be "none", "server", or "client".`)
cmd.Flags().Lookup("dry-run").NoOptDefVal = "unchanged"
_ = cmd.MarkFlagAppendEqual("dry-run")
```

```
$ prog __complete cmd "--dry-run"
--dry-run=	Must be "none", "server", or "client".
:6            # ShellCompDirectiveNoSpace | ShellCompDirectiveNoFileComp
```

The shell inserts `--dry-run=` with the cursor right after `=`, ready for value
completion, and does not fall back to file completion.

## Backward compatibility

Fully backward compatible. The behavior is opt-in: flags that are not marked with
`MarkFlagAppendEqual` are completed exactly as before. The `NoSpace` detection
fix only affects completions that already end in `=`, which previously could not
be produced for flag names.

## Testing

- Added `TestFlagNameCompletionAppendEqual` covering: a marked flag
  (`--flag=` + `:6`), an unmarked flag (unchanged, `:4`), and the error returned
  for a non-existent flag.
- `go test ./...` passes with no regressions.
