### PR TITLE
feat: Command.Example does not support templates

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -37,6 +37,7 @@ var templateFuncs = template.FuncMap{
 	"rpad":                    rpad,
 	"gt":                      Gt,
 	"eq":                      Eq,
+	"example":                renderExample,
 }
 
 var initializers []func()
@@ -174,6 +175,14 @@ func appendIfNotPresent(s, stringToAppend string) string {
 func rpad(s string, padding int) string {
 	formattedString := fmt.Sprintf("%%-%ds", padding)
 	return fmt.Sprintf(formattedString, s)
+}
+
+// renderExample is the "example" template helper, for use in custom usage
+// templates (e.g. {{example .}}). It renders the receiver command's Example,
+// executing it as a text/template against the command when it looks like a
+// template, and returning it literally otherwise.
+func renderExample(c *Command) string {
+	return c.ExampleString()
 }
 
 func tmpl(text string) *tmplFunc {

--- a/command.go
+++ b/command.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"text/template"
 
 	flag "github.com/spf13/pflag"
 )
@@ -1590,6 +1591,30 @@ func (c *Command) NameAndAliases() string {
 // HasExample determines if the command has example.
 func (c *Command) HasExample() bool {
 	return len(c.Example) > 0
+}
+
+// ExampleString returns the example text for the command. When Example looks
+// like a text/template (it contains "{{") it is executed as a template
+// against the command, giving access to the command's fields and methods
+// such as {{.CommandPath}} and {{.UseLine}}. Otherwise, or if the template
+// fails to parse or execute, it is returned as-is.
+//
+// ExampleString is exposed for use in custom usage templates via the "example"
+// template helper (e.g. {{example .}}); the default usage rendering keeps
+// rendering Example literally.
+func (c *Command) ExampleString() string {
+	if c.Example == "" || !strings.Contains(c.Example, "{{") {
+		return c.Example
+	}
+	t, err := template.New("example").Parse(c.Example)
+	if err != nil {
+		return c.Example
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, c); err != nil {
+		return c.Example
+	}
+	return buf.String()
 }
 
 // Runnable determines if the command is itself runnable.


### PR DESCRIPTION
Closes #903.

Add a way to render Example as a text/template executed against the command, so placeholders like {{.CommandPath}} and {{.UseLine}} resolve to the command's own values. Expose this through a new "example" template helper available to custom usage templates (e.g. {{example .}}), plus an ExampleString method.