### PR TITLE
feat: cobra should support initializers that return errors

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -40,6 +40,7 @@ var templateFuncs = template.FuncMap{
 }
 
 var initializers []func()
+var initializersE []func() error
 var finalizers []func()
 
 const (
@@ -98,6 +99,14 @@ func AddTemplateFuncs(tmplFuncs template.FuncMap) {
 // Execute method is called.
 func OnInitialize(y ...func()) {
 	initializers = append(initializers, y...)
+}
+
+// OnInitializeE registers the passed functions to be run when each command's
+// Execute method is called, after all OnInitialize functions. Each function may
+// return an error; the first non-nil error aborts execution and is returned
+// from Execute (before Run is called). See issue #798.
+func OnInitializeE(y ...func() error) {
+	initializersE = append(initializersE, y...)
 }
 
 // OnFinalize sets the passed functions to be run when each command's

--- a/command.go
+++ b/command.go
@@ -956,7 +956,9 @@ func (c *Command) execute(a []string) (err error) {
 		return flag.ErrHelp
 	}
 
-	c.preRun()
+	if err := c.preRun(); err != nil {
+		return err
+	}
 
 	defer c.postRun()
 
@@ -1044,10 +1046,16 @@ func (c *Command) execute(a []string) (err error) {
 	return nil
 }
 
-func (c *Command) preRun() {
+func (c *Command) preRun() error {
 	for _, x := range initializers {
 		x()
 	}
+	for _, x := range initializersE {
+		if err := x(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *Command) postRun() {


### PR DESCRIPTION
Closes #798.

Add OnInitializeE which registers func() error functions run after all OnInitialize functions during preRun. The first non nil error aborts execution (returned from Execute, before Run is called). When none are registered, or all return nil, behaviour is unchanged.