### PR TITLE
feat: missing support for removing group

### DIFF
--- a/command.go
+++ b/command.go
@@ -1397,6 +1397,23 @@ func (c *Command) AddGroup(groups ...*Group) {
 	c.commandgroups = append(c.commandgroups, groups...)
 }
 
+// RemoveGroup removes one or more command groups from a parent command by ID.
+// Groups whose ID matches one of the given ids are removed; an ID with no
+// matching group is a no-op. See issue #1911.
+func (c *Command) RemoveGroup(ids ...string) {
+	groups := []*Group{}
+main:
+	for _, group := range c.commandgroups {
+		for _, id := range ids {
+			if group.ID == id {
+				continue main
+			}
+		}
+		groups = append(groups, group)
+	}
+	c.commandgroups = groups
+}
+
 // RemoveCommand removes one or more commands from a parent command.
 func (c *Command) RemoveCommand(cmds ...*Command) {
 	commands := []*Command{}


### PR DESCRIPTION
Closes #1911.

Add RemoveGroup(ids...) that removes the groups with matching IDs from the command, mirroring RemoveCommand's pattern. An ID with no matching group is a no op; removing a group does not remove the commands assigned to it.