### PR TITLE
feat: add EnableFlagSorting, similar to EnableCommandSorting

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -45,6 +45,7 @@ var finalizers []func()
 const (
 	defaultPrefixMatching   = false
 	defaultCommandSorting   = true
+	defaultFlagSorting       = true
 	defaultCaseInsensitive  = false
 	defaultTraverseRunHooks = false
 )
@@ -57,6 +58,12 @@ var EnablePrefixMatching = defaultPrefixMatching
 // EnableCommandSorting controls sorting of the slice of commands, which is turned on by default.
 // To disable sorting, set it to false.
 var EnableCommandSorting = defaultCommandSorting
+
+// EnableFlagSorting controls sorting of the flags when generating usage/help output, which is turned on by default.
+// To disable sorting, set it to false. This avoids having to call
+// `Flags().SortFlags = false`, `PersistentFlags().SortFlags = false`, and
+// `InheritedFlags().SortFlags = false` individually for each command.
+var EnableFlagSorting = defaultFlagSorting
 
 // EnableCaseInsensitive allows case-insensitive commands names. (case sensitive by default)
 var EnableCaseInsensitive = defaultCaseInsensitive

--- a/command.go
+++ b/command.go
@@ -1688,6 +1688,7 @@ func (c *Command) GlobalNormalizationFunc() func(f *flag.FlagSet, name string) f
 func (c *Command) Flags() *flag.FlagSet {
 	if c.flags == nil {
 		c.flags = flag.NewFlagSet(c.DisplayName(), flag.ContinueOnError)
+		c.flags.SortFlags = EnableFlagSorting
 		if c.flagErrorBuf == nil {
 			c.flagErrorBuf = new(bytes.Buffer)
 		}
@@ -1775,6 +1776,7 @@ func (c *Command) NonInheritedFlags() *flag.FlagSet {
 func (c *Command) PersistentFlags() *flag.FlagSet {
 	if c.pflags == nil {
 		c.pflags = flag.NewFlagSet(c.DisplayName(), flag.ContinueOnError)
+		c.pflags.SortFlags = EnableFlagSorting
 		if c.flagErrorBuf == nil {
 			c.flagErrorBuf = new(bytes.Buffer)
 		}
@@ -1788,8 +1790,10 @@ func (c *Command) ResetFlags() {
 	c.flagErrorBuf = new(bytes.Buffer)
 	c.flagErrorBuf.Reset()
 	c.flags = flag.NewFlagSet(c.DisplayName(), flag.ContinueOnError)
+	c.flags.SortFlags = EnableFlagSorting
 	c.flags.SetOutput(c.flagErrorBuf)
 	c.pflags = flag.NewFlagSet(c.DisplayName(), flag.ContinueOnError)
+	c.pflags.SortFlags = EnableFlagSorting
 	c.pflags.SetOutput(c.flagErrorBuf)
 
 	c.lflags = nil


### PR DESCRIPTION
Closes #2091.

Add a package level `var EnableFlagSorting = true` (mirroring EnableCommandSorting). When false, cobra's FlagSets are created with SortFlags=false, so flag usage/help preserves insertion order without the user manually disabling sorting on Flags(), PersistentFlags(), and InheritedFlags() for every command. Applied at the lazy init sites of Flags() and PersistentFlags() and in ResetFlags(); LocalFlags() inherits from Flags().SortFlags (already symlinked).