### PR TITLE
feat: GenMarkdownTreeCustom with a custom per command markdown handler

### DIFF
--- a/doc/md_docs.go
+++ b/doc/md_docs.go
@@ -156,3 +156,42 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 	}
 	return nil
 }
+
+// GenMarkdownTreeCustomE is the same as GenMarkdownTreeCustom, but additionally
+// accepts a cmdHandler that, when non-nil, generates each command's markdown body
+// (replacing the default GenMarkdownCustom(filePrepender, linkHandler)). When
+// cmdHandler is nil, behavior is identical to GenMarkdownTreeCustom. See issue #1250.
+func GenMarkdownTreeCustomE(
+	cmd *cobra.Command,
+	dir string,
+	filePrepender, linkHandler func(string) string,
+	cmdHandler func(*cobra.Command, string, io.Writer) error,
+) error {
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
+			continue
+		}
+		if err := GenMarkdownTreeCustomE(c, dir, filePrepender, linkHandler, cmdHandler); err != nil {
+			return err
+		}
+	}
+
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + markdownExtension
+	filename := filepath.Join(dir, basename)
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
+		return err
+	}
+	if cmdHandler != nil {
+		return cmdHandler(cmd, filename, f)
+	}
+	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #1250.

Add GenMarkdownTreeCustomE(cmd, dir, filePrepender, linkHandler, cmdHandler): identical to GenMarkdownTreeCustom when cmdHandler is nil; when cmdHandler is non nil, it generates each command's markdown body via that handler (cmd, filename, writer) instead of GenMarkdownCustom. Recurses into subcommands like GenMarkdownTreeCustom. Existing GenMarkdownTree/GenMarkdownTreeCustom are unchanged.