### PR TITLE
feat: ReparseFlags: force a clean re parse of flags

### DIFF
--- a/command.go
+++ b/command.go
@@ -2070,3 +2070,25 @@ func defaultVersionFunc(w io.Writer, in interface{}) error {
 	_, err := fmt.Fprintf(w, "%s version %s\n", c.DisplayName(), c.Version)
 	return err
 }
+
+// ReparseFlags resets the command's local and persistent flags to their
+// default values and then re-parses the given args. This is useful when you
+// need to re-parse flags after the application has already started and the
+// initial flag parsing has already been done (e.g. to apply a new set of
+// args without leaving previously-parsed flags in place). See issue #1832.
+func (c *Command) ReparseFlags(args []string) error {
+	if c.DisableFlagParsing {
+		return nil
+	}
+
+	reset := func(fs *flag.FlagSet) {
+		fs.VisitAll(func(f *flag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+	reset(c.Flags())
+	reset(c.PersistentFlags())
+
+	return c.ParseFlags(args)
+}


### PR DESCRIPTION
Closes #1832.

Add ReparseFlags(args): resets the command's local and persistent flags to their default values (each flag's Value.Set(DefValue) + Changed=false), then re parses via ParseFlags. Honors DisableFlagParsing (no op). Existing ParseFlags is unchanged.