### PR TITLE
feat: ResetInitializers: clear OnInitialize functions (for testing)

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -244,3 +244,10 @@ func WriteStringAndCheck(b io.StringWriter, s string) {
 	_, err := b.WriteString(s)
 	CheckErr(err)
 }
+
+// ResetInitializers clears the registered initializer functions (those added
+// via OnInitialize). This is useful for testing, where initializer state would
+// otherwise leak between test cases. See issue #1180.
+func ResetInitializers() {
+	initializers = nil
+}


### PR DESCRIPTION
Closes #1180.

Add ResetInitializers() (package level): clears the registered initializers (`initializers = nil`). Idempotent. Existing OnInitialize/checkInitializers are unchanged.