### PR TITLE
feat: DefaultHelpFunc: expose the default help function for delegation

### DIFF
--- a/command.go
+++ b/command.go
@@ -488,6 +488,14 @@ func (c *Command) HelpFunc() func(*Command, []string) {
 	if c.HasParent() {
 		return c.Parent().HelpFunc()
 	}
+	return c.DefaultHelpFunc()
+}
+
+// DefaultHelpFunc returns the default help function for c (the function that
+// prints the rendered help template to stdout). It is the implementation
+// returned by HelpFunc when no custom helpFunc is set, exposed so custom help
+// functions can delegate to it. See issue #1887.
+func (c *Command) DefaultHelpFunc() func(*Command, []string) {
 	return func(c *Command, a []string) {
 		c.mergePersistentFlags()
 		fn := c.getHelpTemplateFunc()


### PR DESCRIPTION
Closes #1887.

cobra's HelpFunc returns an inline closure (the default help renderer); the default is not separately accessible, so a custom helpFunc cannot fall back to the default rendering. Extract the inline closure into a new DefaultHelpFunc() method (returns the default help function: merges persistent flags, renders the help template to stdout). HelpFunc now returns c.DefaultHelpFunc() when no custom helpFunc is set (behavior unchanged).