### PR TITLE
feat: optionally list available commands on unknown command

### DIFF
--- a/args.go
+++ b/args.go
@@ -33,7 +33,7 @@ func legacyArgs(cmd *Command, args []string) error {
 
 	// root command with subcommands, do subcommand checking.
 	if !cmd.HasParent() && len(args) > 0 {
-		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
+		return fmt.Errorf("unknown command %q for %q%s%s", args[0], cmd.CommandPath(), cmd.findAvailableCommandsHint(), cmd.findSuggestions(args[0]))
 	}
 	return nil
 }

--- a/args_test.go
+++ b/args_test.go
@@ -576,3 +576,25 @@ func TestLegacyArgsSubcmdAcceptsArgs(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
+
+func TestUnknownCommandListsAvailable(t *testing.T) {
+	root := &Command{Use: "app"}
+	root.AddCommand(&Command{Use: "list", Run: func(cmd *Command, args []string) {}})
+	root.AddCommand(&Command{Use: "get", Run: func(cmd *Command, args []string) {}})
+	root.ListAvailableCommandsOnUnknownCommand = true
+	root.SetArgs([]string{"frobnicate"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `unknown command "frobnicate" for "app"`) {
+		t.Fatalf("base message missing: %q", msg)
+	}
+	if !strings.Contains(msg, "available commands:") {
+		t.Fatalf("available list missing: %q", msg)
+	}
+	if !strings.Contains(msg, "list") || !strings.Contains(msg, "get") {
+		t.Fatalf("command names missing: %q", msg)
+	}
+}

--- a/command.go
+++ b/command.go
@@ -257,6 +257,15 @@ type Command struct {
 	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
 	// Must be > 0.
 	SuggestionsMinimumDistance int
+
+	// ListAvailableCommandsOnUnknownCommand, when true, appends a short list of
+	// available subcommand names to "unknown command" errors so callers can
+	// recover without a second --help round-trip. See #2414.
+	ListAvailableCommandsOnUnknownCommand bool
+
+	// ListAvailableCommandsLimit caps how many names are listed when
+	// ListAvailableCommandsOnUnknownCommand is set. Zero means default (10).
+	ListAvailableCommandsLimit int
 }
 
 // Context returns underlying command context. If command was executed
@@ -794,6 +803,33 @@ func (c *Command) findSuggestions(arg string) string {
 	}
 	return sb.String()
 }
+
+// findAvailableCommandsHint returns "; available commands: a, b, ..." when
+// ListAvailableCommandsOnUnknownCommand is enabled.
+func (c *Command) findAvailableCommandsHint() string {
+	if !c.ListAvailableCommandsOnUnknownCommand {
+		return ""
+	}
+	limit := c.ListAvailableCommandsLimit
+	if limit <= 0 {
+		limit = 10
+	}
+	names := make([]string, 0, limit)
+	for _, sub := range c.Commands() {
+		if !sub.IsAvailableCommand() {
+			continue
+		}
+		names = append(names, sub.Name())
+		if len(names) >= limit {
+			break
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return "; available commands: " + strings.Join(names, ", ")
+}
+
 
 func (c *Command) findNext(next string) *Command {
 	matches := make([]*Command, 0)


### PR DESCRIPTION
## Summary

Opt-in support for listing available subcommands on unknown-command errors (issue #2414).

When `ListAvailableCommandsOnUnknownCommand` is true:

```
Error: unknown command "frobnicate" for "app"; available commands: get, list
```

- Uses `IsAvailableCommand()` (hides deprecated/hidden)
- Cap via `ListAvailableCommandsLimit` (default 10)
- Composes with existing “Did you mean this?” suggestions
- Default remains off (no behavior change)

## Test plan

- [x] `go test -run TestUnknownCommandListsAvailable`
- [x] existing unknown-command / suggestion tests