### PR TITLE
fix: preserve command-line prefixes when redrawing after bash ActiveHelp

### DIFF
--- a/bash_completionsV2.go
+++ b/bash_completionsV2.go
@@ -216,10 +216,16 @@ __%[1]s_handle_activeHelp() {
                 # by the shell when it prints the completion choices.
                 printf -- "--"
             else
-                # When there are no completion choices at all, we need
-                # to re-print the command-line since the shell will
-                # not be doing it itself.
-                __%[1]s_reprint_commandLine
+                # When there are no completion choices at all the shell will not
+                # re-print the command-line, and we cannot correctly do it
+                # ourselves: COMP_LINE does not contain prefixes such as
+                # "VAR=val prog" or "time prog", so re-printing it would drop
+                # them and desynchronize the display from readline's buffer.
+                # Instead, insert two different completions which contribute
+                # nothing to the command-line (their common prefix is empty);
+                # the shell shows them as a blank choice line and then re-draws
+                # the complete command-line itself, prefixes included.
+                COMPREPLY=('' ' ')
             fi
         elif [ $COMP_TYPE -eq 37 ] || [ $COMP_TYPE -eq 42 ]; then
             # For completion type: menu-complete/menu-complete-backward and insert-completions


### PR DESCRIPTION
Fixes #2067

## Problem

When ActiveHelp text is printed and there are no completion choices, `__prog_reprint_commandLine` re-prints the command line as `${PS1@P}${COMP_LINE[@]}`. But bash never includes command prefixes — `VAR=val prog …`, `time prog …` — in `COMP_LINE` (verified empirically on bash 4.4/5.0/5.2), so the re-printed line drops them and the display desynchronizes from readline's real buffer, exactly as reported:

```
bash-5.2$ TOKEN=12345 democli context [tab][tab]
Command help: manage contexts
bash-5.2$ democli context      ← TOKEN=12345 gone from display, cursor offset
```

A manual reprint is structurally unable to restore the prefix — no bash variable exposes it during programmable completion (`READLINE_LINE` is empty there).

## Fix

Let readline do the redraw instead, since it is the only party that knows the true buffer: when there are no completion choices, set `COMPREPLY=('' ' ')` — two *different* completions whose common prefix is empty, so nothing is inserted into the line. The shell displays them as a blank choice line and then re-draws the complete command line itself, prefixes included:

```
bash-5.2$ TOKEN=12345 democli context [tab][tab]
Command help: manage contexts

bash-5.2$ TOKEN=12345 democli context      ← correct, cursor in sync
```

This mirrors what already happens on the path where real completion choices exist (which the issue notes works correctly).

The menu-complete/insert-completions paths (`COMP_TYPE` 37/42) keep the manual reprint: inserting dummy candidates there would modify the user's line, so they retain the pre-existing limitation.

## Verification

- Reproduced the bug and verified the fix end-to-end with a demo cobra CLI using `AppendActiveHelp`, driving interactive bash under a pty: bash **4.4**, **5.0** (docker) and **5.2** (host) all redraw with the prefix intact, and subsequent typing lands at the correct position.
- `go build ./... && go test ./...` pass.